### PR TITLE
Support kohm unit in resistance schema

### DIFF
--- a/src/utils/convert-si-unit-to-number.ts
+++ b/src/utils/convert-si-unit-to-number.ts
@@ -29,6 +29,7 @@ const unitMappings: Record<
       Ω: 1,
       kΩ: 1e3,
       KΩ: 1e3,
+      kohm: 1e3,
       MΩ: 1e6,
       GΩ: 1e9,
       TΩ: 1e12,

--- a/tests/parse-and-convert-si-unit.test.ts
+++ b/tests/parse-and-convert-si-unit.test.ts
@@ -156,4 +156,11 @@ test("parseAndConvertSiUnit", () => {
     unitOfValue: null,
     value: -6,
   })
+
+  // Test kohm unit
+  expect(parseAndConvertSiUnit("20kohm")).toEqual({
+    parsedUnit: "kohm",
+    unitOfValue: "Ω",
+    value: 20000,
+  })
 })


### PR DESCRIPTION
Fixes #3

Add support for `kohm` unit in resistance parsing.

* Update `src/utils/convert-si-unit-to-number.ts` to include `kohm` in the unit mappings for resistance.
* Add a test case for `kohm` in `tests/parse-and-convert-si-unit.test.ts`.