### PR TITLE
Exported schematic warning from any_circuit_element

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -69,6 +69,7 @@ export const any_circuit_element = z.union([
   sch.schematic_net_label,
   sch.schematic_debug_object,
   sch.schematic_voltage_probe,
+  sch.schematic_manual_edit_conflict_warning,
   cad.cad_component,
 ])
 


### PR DESCRIPTION
related to https://github.com/tscircuit/tscircuit.com/issues/866

@seveibar had forgot to export it from any_circuit_element. Was fixing core then it showed me the error that it is not exported from 'CircuitJsonUtilsObject' and then went to circuit-json-utils and was trying to export it then it showed me that it is not exported from circuit-json.

Hope am doing it correct?