### PR TITLE
Add the relation of source_group_id to source_components

### DIFF
--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -15,6 +15,7 @@ export const pcb_component = z
     width: length,
     height: length,
     subcircuit_id: z.string().optional(),
+    pcb_group_id: z.string().optional(),
   })
   .describe("Defines a component on the PCB")
 
@@ -34,6 +35,7 @@ export interface PcbComponent {
   rotation: Rotation
   width: Length
   height: Length
+  pcb_group_id?: string
 }
 
 /**

--- a/src/schematic/schematic_component.ts
+++ b/src/schematic/schematic_component.ts
@@ -55,6 +55,7 @@ export interface SchematicComponent {
   port_arrangement?: SchematicPortArrangement
   port_labels?: Record<string, string>
   symbol_display_value?: string
+  schematic_group_id?: string
 }
 
 export const schematic_component_port_arrangement_by_size = z.object({
@@ -123,6 +124,7 @@ export const schematic_component = z.object({
   port_arrangement: port_arrangement.optional(),
   port_labels: z.record(z.string()).optional(),
   symbol_display_value: z.string().optional(),
+  schematic_group_id: z.string().optional(),
 })
 
 export type SchematicComponentInput = z.input<typeof schematic_component>

--- a/src/schematic/schematic_component.ts
+++ b/src/schematic/schematic_component.ts
@@ -55,6 +55,7 @@ export interface SchematicComponent {
   port_arrangement?: SchematicPortArrangement
   port_labels?: Record<string, string>
   symbol_display_value?: string
+  subcircuit_id?: string
   schematic_group_id?: string
 }
 
@@ -124,6 +125,7 @@ export const schematic_component = z.object({
   port_arrangement: port_arrangement.optional(),
   port_labels: z.record(z.string()).optional(),
   symbol_display_value: z.string().optional(),
+  subcircuit_id: z.string().optional(),
   schematic_group_id: z.string().optional(),
 })
 

--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -15,6 +15,7 @@ export interface SourceComponentBase {
   display_value?: string
   are_pins_interchangeable?: boolean
   internally_connected_source_port_ids?: string[][]
+  source_group_id?: string
 }
 
 export const source_component_base = z.object({
@@ -29,6 +30,7 @@ export const source_component_base = z.object({
   display_value: z.string().optional(),
   are_pins_interchangeable: z.boolean().optional(),
   internally_connected_source_port_ids: z.array(z.array(z.string())).optional(),
+  source_group_id: z.string().optional(),
 })
 
 type InferredSourceComponentBase = z.infer<typeof source_component_base>


### PR DESCRIPTION
Is this relation correct? Or similarly to `subcircuit_id` we need to have a `pcb_group_id` inside `pcb_component` , which can make the connections simpler