### PR TITLE
Add subcircuit connectivity key to source elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ interface SourcePort {
   source_port_id: string
   source_component_id: string
   subcircuit_id?: string
+  subcircuit_connectivity_map_key?: string
 }
 ```
 

--- a/docs/SOURCE_COMPONENT_OVERVIEW.md
+++ b/docs/SOURCE_COMPONENT_OVERVIEW.md
@@ -90,6 +90,8 @@ interface SourceNet {
   is_digital_signal?: boolean
   is_analog_signal?: boolean
   trace_width?: number
+  subcircuit_id?: string
+  subcircuit_connectivity_map_key?: string
 }
 
 interface SourceSimpleDiode {
@@ -115,6 +117,8 @@ interface SourcePort {
   name: string
   source_port_id: string
   source_component_id: string
+  subcircuit_id?: string
+  subcircuit_connectivity_map_key?: string
 }
 
 interface SourceSimplePowerSource {

--- a/src/source/source_net.ts
+++ b/src/source/source_net.ts
@@ -11,6 +11,7 @@ export const source_net = z.object({
   is_analog_signal: z.boolean().optional(),
   trace_width: z.number().optional(),
   subcircuit_id: z.string().optional(),
+  subcircuit_connectivity_map_key: z.string().optional(),
 })
 
 export type SourceNet = z.infer<typeof source_net>

--- a/src/source/source_port.ts
+++ b/src/source/source_port.ts
@@ -9,6 +9,7 @@ export const source_port = z.object({
   source_port_id: z.string(),
   source_component_id: z.string(),
   subcircuit_id: z.string().optional(),
+  subcircuit_connectivity_map_key: z.string().optional(),
 })
 
 export type SourcePortInput = z.input<typeof source_port>
@@ -25,6 +26,7 @@ export interface SourcePort {
   source_port_id: string
   source_component_id: string
   subcircuit_id?: string
+  subcircuit_connectivity_map_key?: string
 }
 
 expectTypesMatch<SourcePort, InferredSourcePort>(true)


### PR DESCRIPTION
## Summary
- support `subcircuit_connectivity_map_key` on SourcePort and SourceNet
- document the new fields in `SOURCE_COMPONENT_OVERVIEW.md`
- update README example for SourcePort

## Testing
- `npm run lint:zod`
- `bun test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683dbfd6aa0c832e90efb2ef889e6b5d