### PR TITLE
Add default error_type values for all errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ interface SourceComponentBase {
 interface SourceFailedToCreateComponentError {
   type: "source_failed_to_create_component_error"
   source_failed_to_create_component_error_id: string
+  error_type: "source_failed_to_create_component_error"
   message: string
   component_name?: string
   subcircuit_id?: string
@@ -544,6 +545,7 @@ interface SourceTrace {
 interface PcbAutoroutingErrorInterface {
   type: "pcb_autorouting_error"
   pcb_error_id: string
+  error_type: "pcb_autorouting_error"
   message: string
 }
 ```
@@ -755,6 +757,7 @@ Defines a placement error on the PCB
 interface PcbPlacementError {
   type: "pcb_placement_error"
   pcb_placement_error_id: string
+  error_type: "pcb_placement_error"
   message: string
 }
 ```
@@ -855,6 +858,7 @@ Defines a trace error on the PCB where a port is not matched
 interface PcbPortNotMatchedError {
   type: "pcb_port_not_matched_error"
   pcb_error_id: string
+  error_type: "pcb_port_not_matched_error"
   message: string
   pcb_component_ids: string[]
 }
@@ -1211,6 +1215,7 @@ interface SchematicGroup {
 interface SchematicLayoutError {
   type: "schematic_layout_error"
   schematic_layout_error_id: string
+  error_type: "schematic_layout_error"
   message: string
   source_group_id: string
   schematic_group_id: string

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -33,6 +33,7 @@ export interface PcbComponent {
 export interface PcbPortNotMatchedError {
   type: "pcb_port_not_matched_error"
   pcb_error_id: string
+  error_type: "pcb_port_not_matched_error"
   message: string
   pcb_component_ids: string[]
 }
@@ -237,6 +238,7 @@ export interface PcbSilkscreenOval {
 export interface PcbPlacementError {
   type: "pcb_placement_error"
   pcb_placement_error_id: string
+  error_type: "pcb_placement_error"
   message: string
 }
 

--- a/src/pcb/pcb_autorouting_error.ts
+++ b/src/pcb/pcb_autorouting_error.ts
@@ -6,6 +6,9 @@ export const pcb_autorouting_error = z
   .object({
     type: z.literal("pcb_autorouting_error"),
     pcb_error_id: getZodPrefixedIdWithDefault("pcb_autorouting_error"),
+    error_type: z
+      .literal("pcb_autorouting_error")
+      .default("pcb_autorouting_error"),
     message: z.string(),
   })
   .describe("The autorouting has failed to route a portion of the board")
@@ -16,6 +19,7 @@ type PcbInferredAutoroutingError = z.infer<typeof pcb_autorouting_error>
 export interface PcbAutoroutingErrorInterface {
   type: "pcb_autorouting_error"
   pcb_error_id: string
+  error_type: "pcb_autorouting_error"
   message: string
 }
 

--- a/src/pcb/pcb_missing_footprint_error.ts
+++ b/src/pcb/pcb_missing_footprint_error.ts
@@ -10,7 +10,9 @@ export const pcb_missing_footprint_error = z
     ),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
-    error_type: z.literal("pcb_missing_footprint_error"),
+    error_type: z
+      .literal("pcb_missing_footprint_error")
+      .default("pcb_missing_footprint_error"),
     source_component_id: z.string(),
     message: z.string(),
   })

--- a/src/pcb/pcb_placement_error.ts
+++ b/src/pcb/pcb_placement_error.ts
@@ -6,6 +6,7 @@ export const pcb_placement_error = z
   .object({
     type: z.literal("pcb_placement_error"),
     pcb_placement_error_id: getZodPrefixedIdWithDefault("pcb_placement_error"),
+    error_type: z.literal("pcb_placement_error").default("pcb_placement_error"),
     message: z.string(),
   })
   .describe("Defines a placement error on the PCB")
@@ -19,6 +20,7 @@ type InferredPcbPlacementError = z.infer<typeof pcb_placement_error>
 export interface PcbPlacementError {
   type: "pcb_placement_error"
   pcb_placement_error_id: string
+  error_type: "pcb_placement_error"
   message: string
 }
 

--- a/src/pcb/pcb_port_not_matched_error.ts
+++ b/src/pcb/pcb_port_not_matched_error.ts
@@ -6,6 +6,9 @@ export const pcb_port_not_matched_error = z
   .object({
     type: z.literal("pcb_port_not_matched_error"),
     pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    error_type: z
+      .literal("pcb_port_not_matched_error")
+      .default("pcb_port_not_matched_error"),
     message: z.string(),
     pcb_component_ids: z.array(z.string()),
   })
@@ -22,6 +25,7 @@ type InferredPcbPortNotMatchedError = z.infer<typeof pcb_port_not_matched_error>
 export interface PcbPortNotMatchedError {
   type: "pcb_port_not_matched_error"
   pcb_error_id: string
+  error_type: "pcb_port_not_matched_error"
   message: string
   pcb_component_ids: string[]
 }

--- a/src/pcb/pcb_trace_error.ts
+++ b/src/pcb/pcb_trace_error.ts
@@ -6,7 +6,7 @@ export const pcb_trace_error = z
   .object({
     type: z.literal("pcb_trace_error"),
     pcb_trace_error_id: getZodPrefixedIdWithDefault("pcb_trace_error"),
-    error_type: z.literal("pcb_trace_error"),
+    error_type: z.literal("pcb_trace_error").default("pcb_trace_error"),
     message: z.string(),
     center: point.optional(),
     pcb_trace_id: z.string(),

--- a/src/schematic/schematic_error.ts
+++ b/src/schematic/schematic_error.ts
@@ -13,7 +13,9 @@ export const schematic_error = z
     type: z.literal("schematic_error"),
     schematic_error_id: z.string(),
     // eventually each error type should be broken out into a dir of files
-    error_type: z.literal("schematic_port_not_found"),
+    error_type: z
+      .literal("schematic_port_not_found")
+      .default("schematic_port_not_found"),
     message: z.string(),
   })
   .describe("Defines a schematic error on the schematic")

--- a/src/schematic/schematic_layout_error.ts
+++ b/src/schematic/schematic_layout_error.ts
@@ -8,6 +8,9 @@ export const schematic_layout_error = z
     schematic_layout_error_id: getZodPrefixedIdWithDefault(
       "schematic_layout_error",
     ),
+    error_type: z
+      .literal("schematic_layout_error")
+      .default("schematic_layout_error"),
     message: z.string(),
     source_group_id: z.string(),
     schematic_group_id: z.string(),
@@ -20,6 +23,7 @@ type InferredSchematicLayoutError = z.infer<typeof schematic_layout_error>
 export interface SchematicLayoutError {
   type: "schematic_layout_error"
   schematic_layout_error_id: string
+  error_type: "schematic_layout_error"
   message: string
   source_group_id: string
   schematic_group_id: string

--- a/src/source/source_failed_to_create_component_error.ts
+++ b/src/source/source_failed_to_create_component_error.ts
@@ -8,6 +8,9 @@ export const source_failed_to_create_component_error = z
     source_failed_to_create_component_error_id: getZodPrefixedIdWithDefault(
       "source_failed_to_create_component_error",
     ),
+    error_type: z
+      .literal("source_failed_to_create_component_error")
+      .default("source_failed_to_create_component_error"),
     component_name: z.string().optional(),
     subcircuit_id: z.string().optional(),
     parent_source_component_id: z.string().optional(),
@@ -41,6 +44,7 @@ type InferredSourceFailedToCreateComponentError = z.infer<
 export interface SourceFailedToCreateComponentError {
   type: "source_failed_to_create_component_error"
   source_failed_to_create_component_error_id: string
+  error_type: "source_failed_to_create_component_error"
   message: string
   component_name?: string
   subcircuit_id?: string

--- a/src/source/source_missing_property_error.ts
+++ b/src/source/source_missing_property_error.ts
@@ -10,7 +10,9 @@ export const source_missing_property_error = z
     ),
     source_component_id: z.string(),
     property_name: z.string(),
-    error_type: z.literal("source_missing_property_error"),
+    error_type: z
+      .literal("source_missing_property_error")
+      .default("source_missing_property_error"),
     message: z.string(),
   })
   .describe("The source code is missing a property")


### PR DESCRIPTION
## Summary
- allow omitting `error_type` when creating any error object by setting default literals

## Testing
- `bun run generate-docs`
- `bun run format`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_683de87dec48832eb1b0914621986a93