### PR TITLE
Add pcb_breakout_point element

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -361,6 +361,17 @@ export interface PcbTrace {
   route: Array<PcbTraceRoutePoint>
 }
 
+export interface PcbBreakoutPoint {
+  type: "pcb_breakout_point"
+  pcb_breakout_point_id: string
+  pcb_group_id: string
+  subcircuit_id?: string
+  source_trace_id?: string
+  source_net_id?: string
+  x: Distance
+  y: Distance
+}
+
 export interface PcbBoard {
   type: "pcb_board"
   pcb_board_id: string

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -63,6 +63,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_fabrication_note_path,
   pcb.pcb_fabrication_note_text,
   pcb.pcb_autorouting_error,
+  pcb.pcb_breakout_point,
   pcb.pcb_cutout,
   sch.schematic_box,
   sch.schematic_text,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -31,6 +31,7 @@ export * from "./pcb_missing_footprint_error"
 export * from "./pcb_group"
 export * from "./pcb_autorouting_error"
 export * from "./pcb_manual_edit_conflict_warning"
+export * from "./pcb_breakout_point"
 
 import type { PcbComponent } from "./pcb_component"
 import type { PcbHole } from "./pcb_hole"
@@ -55,6 +56,7 @@ import type { PcbSilkscreenRect } from "./pcb_silkscreen_rect"
 import type { PcbSilkscreenCircle } from "./pcb_silkscreen_circle"
 import type { PcbAutoroutingError } from "./pcb_autorouting_error"
 import type { PcbCutout } from "./pcb_cutout"
+import type { PcbBreakoutPoint } from "./pcb_breakout_point"
 
 export type PcbCircuitElement =
   | PcbComponent
@@ -80,3 +82,4 @@ export type PcbCircuitElement =
   | PcbSilkscreenCircle
   | PcbAutoroutingError
   | PcbCutout
+  | PcbBreakoutPoint

--- a/src/pcb/pcb_breakout_point.ts
+++ b/src/pcb/pcb_breakout_point.ts
@@ -1,0 +1,38 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { distance, type Distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_breakout_point = z
+  .object({
+    type: z.literal("pcb_breakout_point"),
+    pcb_breakout_point_id: getZodPrefixedIdWithDefault("pcb_breakout_point"),
+    pcb_group_id: z.string(),
+    subcircuit_id: z.string().optional(),
+    source_trace_id: z.string().optional(),
+    source_net_id: z.string().optional(),
+    x: distance,
+    y: distance,
+  })
+  .describe(
+    "Defines a routing target within a pcb_group for a source_trace or source_net",
+  )
+
+export type PcbBreakoutPointInput = z.input<typeof pcb_breakout_point>
+type InferredPcbBreakoutPoint = z.infer<typeof pcb_breakout_point>
+
+/**
+ * Defines a routing target within a pcb_group for a source_trace or source_net
+ */
+export interface PcbBreakoutPoint {
+  type: "pcb_breakout_point"
+  pcb_breakout_point_id: string
+  pcb_group_id: string
+  subcircuit_id?: string
+  source_trace_id?: string
+  source_net_id?: string
+  x: Distance
+  y: Distance
+}
+
+expectTypesMatch<PcbBreakoutPoint, InferredPcbBreakoutPoint>(true)


### PR DESCRIPTION
## Summary
- introduce `pcb_breakout_point` element for routing targets
- export new element from pcb index and add to union types
- document `PcbBreakoutPoint` in PCB component overview

## Testing
- `bun test`
- `npm run lint:zod`


------
https://chatgpt.com/codex/tasks/task_b_68451cb14d68832ea25c40504745247d