### PR TITLE
Add source port field to PcbBreakoutPoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ interface PcbBreakoutPoint {
   pcb_group_id: string
   subcircuit_id?: string
   source_trace_id?: string
+  source_port_id?: string
   source_net_id?: string
   x: Distance
   y: Distance

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -367,6 +367,7 @@ export interface PcbBreakoutPoint {
   pcb_group_id: string
   subcircuit_id?: string
   source_trace_id?: string
+  source_port_id?: string
   source_net_id?: string
   x: Distance
   y: Distance

--- a/src/pcb/pcb_breakout_point.ts
+++ b/src/pcb/pcb_breakout_point.ts
@@ -10,6 +10,7 @@ export const pcb_breakout_point = z
     pcb_group_id: z.string(),
     subcircuit_id: z.string().optional(),
     source_trace_id: z.string().optional(),
+    source_port_id: z.string().optional(),
     source_net_id: z.string().optional(),
     x: distance,
     y: distance,
@@ -30,6 +31,7 @@ export interface PcbBreakoutPoint {
   pcb_group_id: string
   subcircuit_id?: string
   source_trace_id?: string
+  source_port_id?: string
   source_net_id?: string
   x: Distance
   y: Distance


### PR DESCRIPTION
## Summary
- add optional `source_port_id` property to `PcbBreakoutPoint` schema and interface
- document new property in PCB component overview and README

## Testing
- `npm run generate-docs`
- `npm run format`
- `npm run lint:zod`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6845cef6d1f4832eafd7102ef1ed0df2