### PR TITLE
Add warning_type property for warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ Warning emitted when a component has both manual placement (via manualEdits) and
 interface PcbManualEditConflictWarning {
   type: "pcb_manual_edit_conflict_warning"
   pcb_manual_edit_conflict_warning_id: string
+  warning_type: "pcb_manual_edit_conflict_warning"
   message: string
   pcb_component_id: string
   pcb_group_id?: string
@@ -1280,6 +1281,7 @@ Warning emitted when a component has both manual placement (via manualEdits) and
 interface SchematicManualEditConflictWarning {
   type: "schematic_manual_edit_conflict_warning"
   schematic_manual_edit_conflict_warning_id: string
+  warning_type: "schematic_manual_edit_conflict_warning"
   message: string
   schematic_component_id: string
   schematic_group_id?: string

--- a/src/pcb/pcb_manual_edit_conflict_warning.ts
+++ b/src/pcb/pcb_manual_edit_conflict_warning.ts
@@ -8,6 +8,9 @@ export const pcb_manual_edit_conflict_warning = z
     pcb_manual_edit_conflict_warning_id: getZodPrefixedIdWithDefault(
       "pcb_manual_edit_conflict_warning",
     ),
+    warning_type: z
+      .literal("pcb_manual_edit_conflict_warning")
+      .default("pcb_manual_edit_conflict_warning"),
     message: z.string(),
     pcb_component_id: z.string(),
     pcb_group_id: z.string().optional(),
@@ -31,6 +34,7 @@ type InferredPcbManualEditConflictWarning = z.infer<
 export interface PcbManualEditConflictWarning {
   type: "pcb_manual_edit_conflict_warning"
   pcb_manual_edit_conflict_warning_id: string
+  warning_type: "pcb_manual_edit_conflict_warning"
   message: string
   pcb_component_id: string
   pcb_group_id?: string

--- a/src/schematic/schematic_manual_edit_conflict_warning.ts
+++ b/src/schematic/schematic_manual_edit_conflict_warning.ts
@@ -8,6 +8,9 @@ export const schematic_manual_edit_conflict_warning = z
     schematic_manual_edit_conflict_warning_id: getZodPrefixedIdWithDefault(
       "schematic_manual_edit_conflict_warning",
     ),
+    warning_type: z
+      .literal("schematic_manual_edit_conflict_warning")
+      .default("schematic_manual_edit_conflict_warning"),
     message: z.string(),
     schematic_component_id: z.string(),
     schematic_group_id: z.string().optional(),
@@ -31,6 +34,7 @@ type InferredSchematicManualEditConflictWarning = z.infer<
 export interface SchematicManualEditConflictWarning {
   type: "schematic_manual_edit_conflict_warning"
   schematic_manual_edit_conflict_warning_id: string
+  warning_type: "schematic_manual_edit_conflict_warning"
   message: string
   schematic_component_id: string
   schematic_group_id?: string


### PR DESCRIPTION
## Summary
- include `warning_type` literal in PCB and schematic manual edit warnings
- document `warning_type` in README

## Testing
- `npm run format`
- `npm run lint:zod`


------
https://chatgpt.com/codex/tasks/task_b_68485bf0a8a0832eb9dd45259cba9318