### PR TITLE
Refactor smtpads to use z.discriminatedUnion for type safety

### DIFF
--- a/src/pcb/pcb_smtpad.ts
+++ b/src/pcb/pcb_smtpad.ts
@@ -83,7 +83,7 @@ const pcb_smtpad_polygon = z.object({
 })
 
 export const pcb_smtpad = z
-  .union([
+  .discriminatedUnion("shape", [
     pcb_smtpad_circle,
     pcb_smtpad_rect,
     pcb_smtpad_rotated_rect,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/85f5ee23-463d-4302-a6be-84b70ee3dc91)
