### PR TITLE
Fix README generator deprecation filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbTrace](#pcbtrace)
     - [PcbTraceError](#pcbtraceerror)
     - [PcbTraceHint](#pcbtracehint)
+    - [PcbVia](#pcbvia)
   - [Schematic Elements](#schematic-elements)
     - [SchematicBox](#schematicbox)
     - [SchematicComponent](#schematiccomponent)
@@ -217,8 +218,7 @@ interface SourceComponentBase {
 
 ```typescript
 /** Error emitted when a component fails to be constructed.
- * Contains details about the failure and prevents the component from being rendered. */
-interface SourceFailedToCreateComponentError {
+ * Contains details about the failure and prevents the component from being rendered. */interface SourceFailedToCreateComponentError {
   type: "source_failed_to_create_component_error"
   source_failed_to_create_component_error_id: string
   error_type: "source_failed_to_create_component_error"
@@ -254,8 +254,7 @@ interface SourceGroup {
 The source code is missing a property
 
 ```typescript
-/** The source code is missing a property */
-interface SourceMissingPropertyError {
+/** The source code is missing a property */ interface SourceMissingPropertyError {
   type: "source_missing_property_error"
   source_missing_property_error_id: string
   source_component_id: string
@@ -292,8 +291,7 @@ interface SourceNet {
 Defines a ground plane in the source domain
 
 ```typescript
-/** Defines a ground plane in the source domain */
-interface SourcePcbGroundPlane {
+/** Defines a ground plane in the source domain */ interface SourcePcbGroundPlane {
   type: "source_pcb_ground_plane"
   source_pcb_ground_plane_id: string
   source_group_id: string
@@ -309,8 +307,7 @@ interface SourcePcbGroundPlane {
 Defines a source port that can be connected to other components
 
 ```typescript
-/** Defines a source port that can be connected to other components */
-interface SourcePort {
+/** Defines a source port that can be connected to other components */ interface SourcePort {
   type: "source_port"
   pin_number?: number
   port_hints?: string[]
@@ -343,8 +340,8 @@ interface SourceProjectMetadata {
 Defines a simple battery component
 
 ```typescript
-/** Defines a simple battery component */
-interface SourceSimpleBattery extends SourceComponentBase {
+/** Defines a simple battery component */ interface SourceSimpleBattery
+  extends SourceComponentBase {
   ftype: "simple_battery"
   capacity: number
 }
@@ -357,8 +354,8 @@ interface SourceSimpleBattery extends SourceComponentBase {
 Defines a simple capacitor component
 
 ```typescript
-/** Defines a simple capacitor component */
-interface SourceSimpleCapacitor extends SourceComponentBase {
+/** Defines a simple capacitor component */ interface SourceSimpleCapacitor
+  extends SourceComponentBase {
   ftype: "simple_capacitor"
   capacitance: number
   max_voltage_rating?: number
@@ -374,8 +371,8 @@ interface SourceSimpleCapacitor extends SourceComponentBase {
 Defines a simple integrated circuit component
 
 ```typescript
-/** Defines a simple integrated circuit component */
-interface SourceSimpleChip extends SourceComponentBase {
+/** Defines a simple integrated circuit component */ interface SourceSimpleChip
+  extends SourceComponentBase {
   ftype: "simple_chip"
 }
 ```
@@ -387,8 +384,8 @@ interface SourceSimpleChip extends SourceComponentBase {
 Defines a simple crystal oscillator component
 
 ```typescript
-/** Defines a simple crystal oscillator component */
-interface SourceSimpleCrystal extends SourceComponentBase {
+/** Defines a simple crystal oscillator component */ interface SourceSimpleCrystal
+  extends SourceComponentBase {
   ftype: "simple_crystal"
   frequency: number
   load_capacitance?: number
@@ -402,8 +399,8 @@ interface SourceSimpleCrystal extends SourceComponentBase {
 Defines a simple diode component
 
 ```typescript
-/** Defines a simple diode component */
-interface SourceSimpleDiode extends SourceComponentBase {
+/** Defines a simple diode component */ interface SourceSimpleDiode
+  extends SourceComponentBase {
   ftype: "simple_diode"
 }
 ```
@@ -427,8 +424,8 @@ interface SourceSimpleFuse extends SourceComponentBase {
 Defines a simple ground component
 
 ```typescript
-/** Defines a simple ground component */
-interface SourceSimpleGround extends SourceComponentBase {
+/** Defines a simple ground component */ interface SourceSimpleGround
+  extends SourceComponentBase {
   ftype: "simple_ground"
 }
 ```
@@ -440,8 +437,8 @@ interface SourceSimpleGround extends SourceComponentBase {
 Defines a simple inductor component
 
 ```typescript
-/** Defines a simple inductor component */
-interface SourceSimpleInductor extends SourceComponentBase {
+/** Defines a simple inductor component */ interface SourceSimpleInductor
+  extends SourceComponentBase {
   ftype: "simple_inductor"
   inductance: number
   max_current_rating?: number
@@ -455,8 +452,8 @@ interface SourceSimpleInductor extends SourceComponentBase {
 Defines a simple led component
 
 ```typescript
-/** Defines a simple led component */
-interface SourceSimpleLed extends Omit<SourceSimpleDiode, "ftype"> {
+/** Defines a simple led component */ interface SourceSimpleLed
+  extends Omit<SourceSimpleDiode, "ftype"> {
   ftype: "simple_led"
   color?: string
   wavelength?: string
@@ -470,9 +467,8 @@ interface SourceSimpleLed extends Omit<SourceSimpleDiode, "ftype"> {
 ```typescript
 /** Defines a simple mosfet component
  * This is a three-pin semiconductor device (source, gate, drain)
- * Pin configuration is handled by the schematic port system */
-
-interface SourceSimpleMosfet extends SourceComponentBase {
+ * Pin configuration is handled by the schematic port system */ interface SourceSimpleMosfet
+  extends SourceComponentBase {
   ftype: "simple_mosfet"
   channel_type: "n" | "p"
   mosfet_mode: "enhancement" | "depletion"
@@ -486,8 +482,8 @@ interface SourceSimpleMosfet extends SourceComponentBase {
 Defines a simple power source component
 
 ```typescript
-/** Defines a simple power source component */
-interface SourceSimplePowerSource extends SourceComponentBase {
+/** Defines a simple power source component */ interface SourceSimplePowerSource
+  extends SourceComponentBase {
   ftype: "simple_power_source"
   voltage: number
 }
@@ -500,8 +496,8 @@ interface SourceSimplePowerSource extends SourceComponentBase {
 Defines a simple push button component
 
 ```typescript
-/** Defines a simple push button component */
-interface SourceSimplePushButton extends SourceComponentBase {
+/** Defines a simple push button component */ interface SourceSimplePushButton
+  extends SourceComponentBase {
   ftype: "simple_push_button"
 }
 ```
@@ -513,8 +509,8 @@ interface SourceSimplePushButton extends SourceComponentBase {
 Defines a simple resistor component
 
 ```typescript
-/** Defines a simple resistor component */
-interface SourceSimpleResistor extends SourceComponentBase {
+/** Defines a simple resistor component */ interface SourceSimpleResistor
+  extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
   display_resistance?: string
@@ -528,8 +524,8 @@ interface SourceSimpleResistor extends SourceComponentBase {
 Defines a simple resonator component
 
 ```typescript
-/** Defines a simple resonator component */
-interface SourceSimpleResonator extends SourceComponentBase {
+/** Defines a simple resonator component */ interface SourceSimpleResonator
+  extends SourceComponentBase {
   ftype: "simple_resonator"
   load_capacitance: number
   equivalent_series_resistance?: number
@@ -544,8 +540,8 @@ interface SourceSimpleResonator extends SourceComponentBase {
 Defines a simple switch component
 
 ```typescript
-/** Defines a simple switch component */
-interface SourceSimpleSwitch extends SourceComponentBase {
+/** Defines a simple switch component */ interface SourceSimpleSwitch
+  extends SourceComponentBase {
   ftype: "simple_switch"
 }
 ```
@@ -557,8 +553,8 @@ interface SourceSimpleSwitch extends SourceComponentBase {
 ```typescript
 /** Defines a simple test point component
  * Can be surface-mount or through-hole.
- * Pad shape and dimensions configurable for different use cases. */
-interface SourceSimpleTestPoint extends SourceComponentBase {
+ * Pad shape and dimensions configurable for different use cases. */ interface SourceSimpleTestPoint
+  extends SourceComponentBase {
   ftype: "simple_test_point"
   footprint_variant?: "pad" | "through_hole"
   pad_shape?: "rect" | "circle"
@@ -576,9 +572,8 @@ interface SourceSimpleTestPoint extends SourceComponentBase {
 ```typescript
 /** Defines a simple transistor component
  * This is a three-pin semiconductor device (emitter, base, collector)
- * Pin configuration is handled by the schematic port system */
-
-interface SourceSimpleTransistor extends SourceComponentBase {
+ * Pin configuration is handled by the schematic port system */ interface SourceSimpleTransistor
+  extends SourceComponentBase {
   ftype: "simple_transistor"
   transistor_type: "npn" | "pnp"
 }
@@ -624,8 +619,7 @@ interface PcbAutoroutingErrorInterface {
 Defines the board outline of the PCB
 
 ```typescript
-/** Defines the board outline of the PCB */
-interface PcbBoard {
+/** Defines the board outline of the PCB */ interface PcbBoard {
   type: "pcb_board"
   pcb_board_id: string
   is_subcircuit?: boolean
@@ -647,8 +641,7 @@ interface PcbBoard {
 Defines a routing target within a pcb_group for a source_trace or source_net
 
 ```typescript
-/** Defines a routing target within a pcb_group for a source_trace or source_net */
-interface PcbBreakoutPoint {
+/** Defines a routing target within a pcb_group for a source_trace or source_net */ interface PcbBreakoutPoint {
   type: "pcb_breakout_point"
   pcb_breakout_point_id: string
   pcb_group_id: string
@@ -668,8 +661,7 @@ interface PcbBreakoutPoint {
 Defines a component on the PCB
 
 ```typescript
-/** Defines a component on the PCB */
-interface PcbComponent {
+/** Defines a component on the PCB */ interface PcbComponent {
   type: "pcb_component"
   pcb_component_id: string
   source_component_id: string
@@ -690,8 +682,7 @@ interface PcbComponent {
 Defines a rectangular cutout on the PCB.
 
 ```typescript
-/** Defines a rectangular cutout on the PCB. */
-interface PcbCutoutRect {
+/** Defines a rectangular cutout on the PCB. */ interface PcbCutoutRect {
   type: "pcb_cutout"
   pcb_cutout_id: string
   pcb_group_id?: string
@@ -711,8 +702,7 @@ interface PcbCutoutRect {
 Defines a fabrication path on the PCB for fabricators or assemblers
 
 ```typescript
-/** Defines a fabrication path on the PCB for fabricators or assemblers */
-interface PcbFabricationNotePath {
+/** Defines a fabrication path on the PCB for fabricators or assemblers */ interface PcbFabricationNotePath {
   type: "pcb_fabrication_note_path"
   pcb_fabrication_note_path_id: string
   pcb_component_id: string
@@ -731,8 +721,7 @@ interface PcbFabricationNotePath {
 Defines a fabrication note in text on the PCB, useful for leaving notes for assemblers or fabricators
 
 ```typescript
-/** Defines a fabrication note in text on the PCB, useful for leaving notes for assemblers or fabricators */
-interface PcbFabricationNoteText {
+/** Defines a fabrication note in text on the PCB, useful for leaving notes for assemblers or fabricators */ interface PcbFabricationNoteText {
   type: "pcb_fabrication_note_text"
   pcb_fabrication_note_text_id: string
   subcircuit_id?: string
@@ -760,8 +749,7 @@ interface PcbFabricationNoteText {
 Defines a ground plane on the PCB
 
 ```typescript
-/** Defines a ground plane on the PCB */
-interface PcbGroundPlane {
+/** Defines a ground plane on the PCB */ interface PcbGroundPlane {
   type: "pcb_ground_plane"
   pcb_ground_plane_id: string
   source_pcb_ground_plane_id: string
@@ -778,8 +766,7 @@ interface PcbGroundPlane {
 Defines a polygon region of a ground plane
 
 ```typescript
-/** Defines a polygon region of a ground plane */
-interface PcbGroundPlaneRegion {
+/** Defines a polygon region of a ground plane */ interface PcbGroundPlaneRegion {
   type: "pcb_ground_plane_region"
   pcb_ground_plane_region_id: string
   pcb_ground_plane_id: string
@@ -797,8 +784,7 @@ interface PcbGroundPlaneRegion {
 Defines a group of components on the PCB
 
 ```typescript
-/** Defines a group of components on the PCB */
-interface PcbGroup {
+/** Defines a group of components on the PCB */ interface PcbGroup {
   type: "pcb_group"
   pcb_group_id: string
   source_group_id: string
@@ -820,8 +806,7 @@ interface PcbGroup {
 Defines a circular or square hole on the PCB
 
 ```typescript
-/** Defines a circular or square hole on the PCB */
-interface PcbHoleCircleOrSquare {
+/** Defines a circular or square hole on the PCB */ interface PcbHoleCircleOrSquare {
   type: "pcb_hole"
   pcb_hole_id: string
   pcb_group_id?: string
@@ -840,8 +825,7 @@ interface PcbHoleCircleOrSquare {
 Warning emitted when a component has both manual placement (via manualEdits) and explicit pcbX/pcbY coordinates
 
 ```typescript
-/** Warning emitted when a component has both manual placement (via manualEdits) and explicit pcbX/pcbY coordinates */
-interface PcbManualEditConflictWarning {
+/** Warning emitted when a component has both manual placement (via manualEdits) and explicit pcbX/pcbY coordinates */ interface PcbManualEditConflictWarning {
   type: "pcb_manual_edit_conflict_warning"
   pcb_manual_edit_conflict_warning_id: string
   warning_type: "pcb_manual_edit_conflict_warning"
@@ -860,8 +844,7 @@ interface PcbManualEditConflictWarning {
 Defines a placement error on the PCB
 
 ```typescript
-/** Defines a placement error on the PCB */
-interface PcbMissingFootprintError {
+/** Defines a placement error on the PCB */ interface PcbMissingFootprintError {
   type: "pcb_missing_footprint_error"
   pcb_missing_footprint_error_id: string
   pcb_group_id?: string
@@ -879,8 +862,7 @@ interface PcbMissingFootprintError {
 Defines a placement error on the PCB
 
 ```typescript
-/** Defines a placement error on the PCB */
-interface PcbPlacementError {
+/** Defines a placement error on the PCB */ interface PcbPlacementError {
   type: "pcb_placement_error"
   pcb_placement_error_id: string
   error_type: "pcb_placement_error"
@@ -895,8 +877,7 @@ interface PcbPlacementError {
 Defines a circular plated hole on the PCB
 
 ```typescript
-/** Defines a circular plated hole on the PCB */
-interface PcbPlatedHoleCircle {
+/** Defines a circular plated hole on the PCB */ interface PcbPlatedHoleCircle {
   type: "pcb_plated_hole"
   shape: "circle"
   pcb_group_id?: string
@@ -912,7 +893,7 @@ interface PcbPlatedHoleCircle {
   pcb_plated_hole_id: string
 }
 
-interface PcbHolePillWithRectPad {
+/** Defines an oval or pill-shaped plated hole on the PCB */ interface PcbHolePillWithRectPad {
   type: "pcb_plated_hole"
   shape: "pill_hole_with_rect_pad"
   pcb_group_id?: string
@@ -932,7 +913,7 @@ interface PcbHolePillWithRectPad {
   pcb_plated_hole_id: string
 }
 
-interface PcbHoleCircularWithRectPad {
+/** Defines an oval or pill-shaped plated hole on the PCB */ interface PcbHoleCircularWithRectPad {
   type: "pcb_plated_hole"
   shape: "circular_hole_with_rect_pad"
   pcb_group_id?: string
@@ -959,8 +940,7 @@ interface PcbHoleCircularWithRectPad {
 Defines a port on the PCB
 
 ```typescript
-/** Defines a port on the PCB */
-interface PcbPort {
+/** Defines a port on the PCB */ interface PcbPort {
   type: "pcb_port"
   pcb_port_id: string
   pcb_group_id?: string
@@ -980,8 +960,7 @@ interface PcbPort {
 Defines a trace error on the PCB where a port is not matched
 
 ```typescript
-/** Defines a trace error on the PCB where a port is not matched */
-interface PcbPortNotMatchedError {
+/** Defines a trace error on the PCB where a port is not matched */ interface PcbPortNotMatchedError {
   type: "pcb_port_not_matched_error"
   pcb_error_id: string
   error_type: "pcb_port_not_matched_error"
@@ -997,8 +976,7 @@ interface PcbPortNotMatchedError {
 Defines a silkscreen circle on the PCB
 
 ```typescript
-/** Defines a silkscreen circle on the PCB */
-interface PcbSilkscreenCircle {
+/** Defines a silkscreen circle on the PCB */ interface PcbSilkscreenCircle {
   type: "pcb_silkscreen_circle"
   pcb_silkscreen_circle_id: string
   pcb_component_id: string
@@ -1018,8 +996,7 @@ interface PcbSilkscreenCircle {
 Defines a silkscreen line on the PCB
 
 ```typescript
-/** Defines a silkscreen line on the PCB */
-interface PcbSilkscreenLine {
+/** Defines a silkscreen line on the PCB */ interface PcbSilkscreenLine {
   type: "pcb_silkscreen_line"
   pcb_silkscreen_line_id: string
   pcb_component_id: string
@@ -1041,8 +1018,7 @@ interface PcbSilkscreenLine {
 Defines a silkscreen oval on the PCB
 
 ```typescript
-/** Defines a silkscreen oval on the PCB */
-interface PcbSilkscreenOval {
+/** Defines a silkscreen oval on the PCB */ interface PcbSilkscreenOval {
   type: "pcb_silkscreen_oval"
   pcb_silkscreen_oval_id: string
   pcb_component_id: string
@@ -1062,8 +1038,7 @@ interface PcbSilkscreenOval {
 Defines a silkscreen path on the PCB
 
 ```typescript
-/** Defines a silkscreen path on the PCB */
-interface PcbSilkscreenPath {
+/** Defines a silkscreen path on the PCB */ interface PcbSilkscreenPath {
   type: "pcb_silkscreen_path"
   pcb_silkscreen_path_id: string
   pcb_component_id: string
@@ -1082,8 +1057,7 @@ interface PcbSilkscreenPath {
 Defines a silkscreen pill on the PCB
 
 ```typescript
-/** Defines a silkscreen pill on the PCB */
-interface PcbSilkscreenPill {
+/** Defines a silkscreen pill on the PCB */ interface PcbSilkscreenPill {
   type: "pcb_silkscreen_pill"
   pcb_silkscreen_pill_id: string
   pcb_component_id: string
@@ -1103,8 +1077,7 @@ interface PcbSilkscreenPill {
 Defines a silkscreen rect on the PCB
 
 ```typescript
-/** Defines a silkscreen rect on the PCB */
-interface PcbSilkscreenRect {
+/** Defines a silkscreen rect on the PCB */ interface PcbSilkscreenRect {
   type: "pcb_silkscreen_rect"
   pcb_silkscreen_rect_id: string
   pcb_component_id: string
@@ -1128,8 +1101,7 @@ interface PcbSilkscreenRect {
 Defines silkscreen text on the PCB
 
 ```typescript
-/** Defines silkscreen text on the PCB */
-interface PcbSilkscreenText {
+/** Defines silkscreen text on the PCB */ interface PcbSilkscreenText {
   type: "pcb_silkscreen_text"
   pcb_silkscreen_text_id: string
   pcb_group_id?: string
@@ -1153,8 +1125,7 @@ interface PcbSilkscreenText {
 Defines solderpaste on the PCB
 
 ```typescript
-/** Defines solderpaste on the PCB */
-interface PcbSolderPasteCircle {
+/** Defines solderpaste on the PCB */ interface PcbSolderPasteCircle {
   type: "pcb_solder_paste"
   shape: "circle"
   pcb_solder_paste_id: string
@@ -1176,8 +1147,7 @@ interface PcbSolderPasteCircle {
 Defines text on the PCB
 
 ```typescript
-/** Defines text on the PCB */
-interface PcbText {
+/** Defines text on the PCB */ interface PcbText {
   type: "pcb_text"
   pcb_text_id: string
   pcb_group_id?: string
@@ -1200,8 +1170,7 @@ interface PcbText {
 Pattern for connecting a ground plane to a plated hole
 
 ```typescript
-/** Pattern for connecting a ground plane to a plated hole */
-interface PcbThermalSpoke {
+/** Pattern for connecting a ground plane to a plated hole */ interface PcbThermalSpoke {
   type: "pcb_thermal_spoke"
   pcb_thermal_spoke_id: string
   pcb_ground_plane_id: string
@@ -1237,8 +1206,7 @@ interface PcbTraceRoutePointWire {
 Defines a trace error on the PCB
 
 ```typescript
-/** Defines a trace error on the PCB */
-interface PcbTraceError {
+/** Defines a trace error on the PCB */ interface PcbTraceError {
   type: "pcb_trace_error"
   pcb_trace_error_id: string
   error_type: "pcb_trace_error"
@@ -1258,13 +1226,37 @@ interface PcbTraceError {
 A hint that can be used during generation of a PCB trace.
 
 ```typescript
-/** A hint that can be used during generation of a PCB trace. */
-interface PcbTraceHint {
+/** A hint that can be used during generation of a PCB trace. */ interface PcbTraceHint {
   type: "pcb_trace_hint"
   pcb_trace_hint_id: string
   pcb_port_id: string
   pcb_component_id: string
   route: RouteHintPoint[]
+}
+```
+
+### PcbVia
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_via.ts)
+
+Defines a via on the PCB
+
+```typescript
+/** Defines a via on the PCB */ interface PcbVia {
+  type: "pcb_via"
+  pcb_via_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  x: Distance
+  y: Distance
+  outer_diameter: Distance
+  hole_diameter: Distance
+  /** @deprecated */
+  from_layer?: LayerRef
+  /** @deprecated */
+  to_layer?: LayerRef
+  layers: LayerRef[]
+  pcb_trace_id?: string
 }
 ```
 
@@ -1338,8 +1330,7 @@ interface SchematicError {
 Defines a group of components on the schematic
 
 ```typescript
-/** Defines a group of components on the schematic */
-interface SchematicGroup {
+/** Defines a group of components on the schematic */ interface SchematicGroup {
   type: "schematic_group"
   schematic_group_id: string
   source_group_id: string
@@ -1376,8 +1367,7 @@ interface SchematicLayoutError {
 ```typescript
 /** Defines a line on the schematic, this can be used for adding arbitrary lines
  * to a schematic, but don't use it for drawing traces, schematic boxes or where
- * other schematic elements are more appropriate. */
-interface SchematicLine {
+ * other schematic elements are more appropriate. */ interface SchematicLine {
   type: "schematic_line"
   schematic_component_id: string
   x1: number
@@ -1394,8 +1384,7 @@ interface SchematicLine {
 Warning emitted when a component has both manual placement (via manualEdits) and explicit schX/schY coordinates
 
 ```typescript
-/** Warning emitted when a component has both manual placement (via manualEdits) and explicit schX/schY coordinates */
-interface SchematicManualEditConflictWarning {
+/** Warning emitted when a component has both manual placement (via manualEdits) and explicit schX/schY coordinates */ interface SchematicManualEditConflictWarning {
   type: "schematic_manual_edit_conflict_warning"
   schematic_manual_edit_conflict_warning_id: string
   warning_type: "schematic_manual_edit_conflict_warning"

--- a/scripts/generate-readme-docs.ts
+++ b/scripts/generate-readme-docs.ts
@@ -36,14 +36,31 @@ async function generateDocs() {
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
       .join("")
 
-    const exportBlocks =
-      content.match(
-        /\/\*\*[\s\S]*?\*\/\s*export\s+(interface|type)\s+[A-Z][^=]*?(?:{[\s\S]*?}|=[^;]*?;)|export\s+(interface|type)\s+[A-Z][^=]*?(?:{[\s\S]*?}|=[^;]*?;)/gm,
-      ) ?? []
+    const exportBlocks: string[] = []
+    const exportRegex =
+      /export\s+(interface|type)\s+[A-Z][^=]*?(?:{[\s\S]*?}|=[^;]*?;)/gm
+    for (const match of content.matchAll(exportRegex)) {
+      const start = match.index ?? 0
+      const before = content.slice(0, start)
+      const comments = before.match(/\/\*\*[\s\S]*?\*\//g)
+      const comment = comments ? comments[comments.length - 1] : ""
+      exportBlocks.push(comment + match[0])
+    }
 
     const cleanBlocks = exportBlocks
       .filter((block) => {
-        const isDeprecated = block.includes("@deprecated")
+        const interfaceIndex = block.indexOf("export interface")
+        const typeIndex = block.indexOf("export type")
+        const exportIndex =
+          interfaceIndex !== -1
+            ? interfaceIndex
+            : typeIndex !== -1
+              ? typeIndex
+              : 0
+        const beforeExport = block.slice(0, exportIndex)
+        const comments = beforeExport.match(/\/\*\*[\s\S]*?\*\/\s*/g)
+        const comment = comments ? comments[comments.length - 1] : ""
+        const isDeprecated = comment.includes("@deprecated")
         const isZodRelated =
           block.includes("z.") ||
           block.includes("Inferred") ||

--- a/scripts/generate-readme-docs.ts
+++ b/scripts/generate-readme-docs.ts
@@ -43,7 +43,8 @@ async function generateDocs() {
       const start = match.index ?? 0
       const before = content.slice(0, start)
       const comments = before.match(/\/\*\*[\s\S]*?\*\//g)
-      const comment = comments ? comments[comments.length - 1] : ""
+      const comment =
+        comments && comments.length > 0 ? comments[comments.length - 1]! : ""
       exportBlocks.push(comment + match[0])
     }
 
@@ -59,7 +60,8 @@ async function generateDocs() {
               : 0
         const beforeExport = block.slice(0, exportIndex)
         const comments = beforeExport.match(/\/\*\*[\s\S]*?\*\/\s*/g)
-        const comment = comments ? comments[comments.length - 1] : ""
+        const comment =
+          comments && comments.length > 0 ? comments[comments.length - 1]! : ""
         const isDeprecated = comment.includes("@deprecated")
         const isZodRelated =
           block.includes("z.") ||

--- a/tests/generate-readme-filter.test.ts
+++ b/tests/generate-readme-filter.test.ts
@@ -9,7 +9,8 @@ function parseExportBlocks(content: string): string[] {
     const start = match.index ?? 0
     const before = content.slice(0, start)
     const comments = before.match(/\/\*\*[\s\S]*?\*\//g)
-    const comment = comments ? comments[comments.length - 1] : ""
+    const comment =
+      comments && comments.length > 0 ? comments[comments.length - 1]! : ""
     blocks.push(comment + match[0])
   }
   return blocks
@@ -22,7 +23,8 @@ function filterBlocks(blocks: string[]): string[] {
     const exportIndex = interfaceIndex !== -1 ? interfaceIndex : typeIndex
     const beforeExport = block.slice(0, exportIndex)
     const comments = beforeExport.match(/\/\*\*[\s\S]*?\*\/\s*/g)
-    const comment = comments ? comments[comments.length - 1] : ""
+    const comment =
+      comments && comments.length > 0 ? comments[comments.length - 1]! : ""
     const isDeprecated = comment.includes("@deprecated")
     const isZodRelated =
       block.includes("z.") ||

--- a/tests/generate-readme-filter.test.ts
+++ b/tests/generate-readme-filter.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "bun:test"
+import fs from "node:fs"
+
+function parseExportBlocks(content: string): string[] {
+  const blocks: string[] = []
+  const regex =
+    /export\s+(interface|type)\s+[A-Z][^=]*?(?:{[\s\S]*?}|=[^;]*?;)/gm
+  for (const match of content.matchAll(regex)) {
+    const start = match.index ?? 0
+    const before = content.slice(0, start)
+    const comments = before.match(/\/\*\*[\s\S]*?\*\//g)
+    const comment = comments ? comments[comments.length - 1] : ""
+    blocks.push(comment + match[0])
+  }
+  return blocks
+}
+
+function filterBlocks(blocks: string[]): string[] {
+  return blocks.filter((block) => {
+    const interfaceIndex = block.indexOf("export interface")
+    const typeIndex = block.indexOf("export type")
+    const exportIndex = interfaceIndex !== -1 ? interfaceIndex : typeIndex
+    const beforeExport = block.slice(0, exportIndex)
+    const comments = beforeExport.match(/\/\*\*[\s\S]*?\*\/\s*/g)
+    const comment = comments ? comments[comments.length - 1] : ""
+    const isDeprecated = comment.includes("@deprecated")
+    const isZodRelated =
+      block.includes("z.") ||
+      block.includes("Inferred") ||
+      block.includes("Input") ||
+      block.includes(".parse(")
+    return !isDeprecated && !isZodRelated
+  })
+}
+
+test("PcbVia interface is retained by docs generator filter", () => {
+  const content = fs.readFileSync("src/pcb/pcb_via.ts", "utf8")
+  const exportBlocks = parseExportBlocks(content)
+  const clean = filterBlocks(exportBlocks)
+  expect(clean.some((b) => b.includes("interface PcbVia"))).toBeTrue()
+})


### PR DESCRIPTION
## Summary
- ignore deprecated properties when generating README docs
- ensure PcbVia interface appears
- add regression test for README generator

## Testing
- `bun test tests/generate-readme-filter.test.ts`
- `bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_684f06726f80832e917ccb6f26ae4170