### PR TITLE
Add subcircuit_id to circuit elements

### DIFF
--- a/src/cad/cad_component.ts
+++ b/src/cad/cad_component.ts
@@ -14,6 +14,7 @@ export const cad_component = z
     rotation: point3.optional(),
     size: point3.optional(),
     layer: layer_ref.optional(),
+    subcircuit_id: z.string().optional(),
 
     // These are all ways to generate/load the 3d model
     footprinter_string: z.string().optional(),
@@ -36,6 +37,7 @@ export interface CadComponent {
   rotation?: Point3
   size?: Point3
   layer?: LayerRef
+  subcircuit_id?: string
   footprinter_string?: string
   model_obj_url?: string
   model_stl_url?: string

--- a/src/pcb/pcb_autorouting_error.ts
+++ b/src/pcb/pcb_autorouting_error.ts
@@ -10,6 +10,7 @@ export const pcb_autorouting_error = z
       .literal("pcb_autorouting_error")
       .default("pcb_autorouting_error"),
     message: z.string(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("The autorouting has failed to route a portion of the board")
 
@@ -21,6 +22,7 @@ export interface PcbAutoroutingErrorInterface {
   pcb_error_id: string
   error_type: "pcb_autorouting_error"
   message: string
+  subcircuit_id?: string
 }
 
 export type PcbAutoroutingError = PcbAutoroutingErrorInterface

--- a/src/pcb/pcb_placement_error.ts
+++ b/src/pcb/pcb_placement_error.ts
@@ -8,6 +8,7 @@ export const pcb_placement_error = z
     pcb_placement_error_id: getZodPrefixedIdWithDefault("pcb_placement_error"),
     error_type: z.literal("pcb_placement_error").default("pcb_placement_error"),
     message: z.string(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Defines a placement error on the PCB")
 
@@ -22,6 +23,7 @@ export interface PcbPlacementError {
   pcb_placement_error_id: string
   error_type: "pcb_placement_error"
   message: string
+  subcircuit_id?: string
 }
 
 /**

--- a/src/pcb/pcb_port_not_matched_error.ts
+++ b/src/pcb/pcb_port_not_matched_error.ts
@@ -11,6 +11,7 @@ export const pcb_port_not_matched_error = z
       .default("pcb_port_not_matched_error"),
     message: z.string(),
     pcb_component_ids: z.array(z.string()),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Defines a trace error on the PCB where a port is not matched")
 
@@ -28,6 +29,7 @@ export interface PcbPortNotMatchedError {
   error_type: "pcb_port_not_matched_error"
   message: string
   pcb_component_ids: string[]
+  subcircuit_id?: string
 }
 
 /**

--- a/src/pcb/pcb_thermal_spoke.ts
+++ b/src/pcb/pcb_thermal_spoke.ts
@@ -14,6 +14,7 @@ export const pcb_thermal_spoke = z
     spoke_inner_diameter: distance,
     spoke_outer_diameter: distance,
     pcb_plated_hole_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Pattern for connecting a ground plane to a plated hole")
 
@@ -33,6 +34,7 @@ export interface PcbThermalSpoke {
   spoke_inner_diameter: Distance
   spoke_outer_diameter: Distance
   pcb_plated_hole_id?: string
+  subcircuit_id?: string
 }
 
 expectTypesMatch<PcbThermalSpoke, InferredPcbThermalSpoke>(true)

--- a/src/pcb/pcb_trace_error.ts
+++ b/src/pcb/pcb_trace_error.ts
@@ -13,6 +13,7 @@ export const pcb_trace_error = z
     source_trace_id: z.string(),
     pcb_component_ids: z.array(z.string()),
     pcb_port_ids: z.array(z.string()),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Defines a trace error on the PCB")
 
@@ -32,6 +33,7 @@ export interface PcbTraceError {
   source_trace_id: string
   pcb_component_ids: string[]
   pcb_port_ids: string[]
+  subcircuit_id?: string
 }
 
 /**

--- a/src/pcb/pcb_trace_hint.ts
+++ b/src/pcb/pcb_trace_hint.ts
@@ -12,6 +12,7 @@ export interface PcbTraceHint {
   pcb_port_id: string
   pcb_component_id: string
   route: RouteHintPoint[]
+  subcircuit_id?: string
 }
 
 export const pcb_trace_hint = z
@@ -21,6 +22,7 @@ export const pcb_trace_hint = z
     pcb_port_id: z.string(),
     pcb_component_id: z.string(),
     route: z.array(route_hint_point),
+    subcircuit_id: z.string().optional(),
   })
   .describe("A hint that can be used during generation of a PCB trace")
 

--- a/src/schematic/schematic_box.ts
+++ b/src/schematic/schematic_box.ts
@@ -10,6 +10,7 @@ export interface SchematicBox {
   is_dashed: boolean
   x: number
   y: number
+  subcircuit_id?: string
 }
 
 export const schematic_box = z
@@ -21,6 +22,7 @@ export const schematic_box = z
     is_dashed: z.boolean().default(false),
     x: distance,
     y: distance,
+    subcircuit_id: z.string().optional(),
   })
   .describe("Draws a box on the schematic")
 

--- a/src/schematic/schematic_debug_object.ts
+++ b/src/schematic/schematic_debug_object.ts
@@ -6,6 +6,7 @@ import { expectTypesMatch } from "src/utils/expect-types-match"
 export const schematic_debug_object_base = z.object({
   type: z.literal("schematic_debug_object"),
   label: z.string().optional(),
+  subcircuit_id: z.string().optional(),
 })
 
 export const schematic_debug_rect = schematic_debug_object_base.extend({
@@ -38,6 +39,7 @@ export interface SchematicDebugRect {
   shape: "rect"
   center: Point
   size: Size
+  subcircuit_id?: string
 }
 
 export interface SchematicDebugLine {
@@ -46,6 +48,7 @@ export interface SchematicDebugLine {
   shape: "line"
   start: Point
   end: Point
+  subcircuit_id?: string
 }
 
 export interface SchematicDebugPoint {
@@ -53,6 +56,7 @@ export interface SchematicDebugPoint {
   label?: string
   shape: "point"
   center: Point
+  subcircuit_id?: string
 }
 
 export type SchematicDebugObject =

--- a/src/schematic/schematic_error.ts
+++ b/src/schematic/schematic_error.ts
@@ -6,6 +6,7 @@ export interface SchematicError {
   schematic_error_id: string
   error_type: "schematic_port_not_found"
   message: string
+  subcircuit_id?: string
 }
 
 export const schematic_error = z
@@ -17,6 +18,7 @@ export const schematic_error = z
       .literal("schematic_port_not_found")
       .default("schematic_port_not_found"),
     message: z.string(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Defines a schematic error on the schematic")
 

--- a/src/schematic/schematic_layout_error.ts
+++ b/src/schematic/schematic_layout_error.ts
@@ -14,6 +14,7 @@ export const schematic_layout_error = z
     message: z.string(),
     source_group_id: z.string(),
     schematic_group_id: z.string(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Error emitted when schematic layout fails for a group")
 
@@ -27,6 +28,7 @@ export interface SchematicLayoutError {
   message: string
   source_group_id: string
   schematic_group_id: string
+  subcircuit_id?: string
 }
 
 expectTypesMatch<SchematicLayoutError, InferredSchematicLayoutError>(true)

--- a/src/schematic/schematic_line.ts
+++ b/src/schematic/schematic_line.ts
@@ -14,6 +14,7 @@ export interface SchematicLine {
   x2: number
   y1: number
   y2: number
+  subcircuit_id?: string
 }
 
 export const schematic_line = z.object({
@@ -23,6 +24,7 @@ export const schematic_line = z.object({
   x2: distance,
   y1: distance,
   y2: distance,
+  subcircuit_id: z.string().optional(),
 })
 
 export type SchematicLineInput = z.input<typeof schematic_line>

--- a/src/schematic/schematic_net_label.ts
+++ b/src/schematic/schematic_net_label.ts
@@ -14,6 +14,7 @@ export interface SchematicNetLabel {
   anchor_side: "top" | "bottom" | "left" | "right"
   text: string
   symbol_name?: string | undefined
+  subcircuit_id?: string
 }
 
 export const schematic_net_label = z.object({
@@ -27,6 +28,7 @@ export const schematic_net_label = z.object({
   anchor_side: z.enum(["top", "bottom", "left", "right"]),
   text: z.string(),
   symbol_name: z.string().optional(),
+  subcircuit_id: z.string().optional(),
 })
 
 export type SchematicNetLabelInput = z.input<typeof schematic_net_label>

--- a/src/schematic/schematic_path.ts
+++ b/src/schematic/schematic_path.ts
@@ -8,6 +8,7 @@ export interface SchematicPath {
   fill_color?: "red" | "blue"
   is_filled?: boolean
   points: Point[]
+  subcircuit_id?: string
 }
 
 export const schematic_path = z.object({
@@ -16,6 +17,7 @@ export const schematic_path = z.object({
   fill_color: z.enum(["red", "blue"]).optional(),
   is_filled: z.boolean().optional(),
   points: z.array(point),
+  subcircuit_id: z.string().optional(),
 })
 
 export type SchematicPathInput = z.input<typeof schematic_path>

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -14,6 +14,7 @@ export interface SchematicPort {
   true_ccw_index?: number
   pin_number?: number
   display_pin_label?: string
+  subcircuit_id?: string
 }
 
 export const schematic_port = z
@@ -29,6 +30,7 @@ export const schematic_port = z
     true_ccw_index: z.number().optional(),
     pin_number: z.number().optional(),
     display_pin_label: z.string().optional(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Defines a port on a schematic component")
 

--- a/src/schematic/schematic_text.ts
+++ b/src/schematic/schematic_text.ts
@@ -19,6 +19,7 @@ export interface SchematicText {
   rotation: number
   anchor: NinePointAnchor | FivePointAnchor
   color: string
+  subcircuit_id?: string
 }
 
 export const schematic_text = z.object({
@@ -36,6 +37,7 @@ export const schematic_text = z.object({
     .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
     .default("center"),
   color: z.string().default("#000000"),
+  subcircuit_id: z.string().optional(),
 })
 
 export type SchematicTextInput = z.input<typeof schematic_text>

--- a/src/schematic/schematic_trace.ts
+++ b/src/schematic/schematic_trace.ts
@@ -25,6 +25,7 @@ export interface SchematicTrace {
     y: number
   }[]
   edges: SchematicTraceEdge[]
+  subcircuit_id?: string
 }
 
 export const schematic_trace = z.object({
@@ -52,6 +53,7 @@ export const schematic_trace = z.object({
       to_schematic_port_id: z.string().optional(),
     }),
   ),
+  subcircuit_id: z.string().optional(),
 })
 
 export type SchematicTraceInput = z.input<typeof schematic_trace>

--- a/src/schematic/schematic_voltage_probe.ts
+++ b/src/schematic/schematic_voltage_probe.ts
@@ -9,6 +9,7 @@ export interface SchematicVoltageProbe {
   position: Point
   schematic_trace_id: string
   voltage?: number
+  subcircuit_id?: string
 }
 
 export const schematic_voltage_probe = z
@@ -18,6 +19,7 @@ export const schematic_voltage_probe = z
     position: point,
     schematic_trace_id: z.string(),
     voltage: voltage.optional(),
+    subcircuit_id: z.string().optional(),
   })
   .describe("Defines a voltage probe measurement point on a schematic trace")
 

--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -16,6 +16,7 @@ export interface SourceComponentBase {
   are_pins_interchangeable?: boolean
   internally_connected_source_port_ids?: string[][]
   source_group_id?: string
+  subcircuit_id?: string
 }
 
 export const source_component_base = z.object({
@@ -31,6 +32,7 @@ export const source_component_base = z.object({
   are_pins_interchangeable: z.boolean().optional(),
   internally_connected_source_port_ids: z.array(z.array(z.string())).optional(),
   source_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
 })
 
 type InferredSourceComponentBase = z.infer<typeof source_component_base>

--- a/src/source/source_missing_property_error.ts
+++ b/src/source/source_missing_property_error.ts
@@ -10,6 +10,7 @@ export const source_missing_property_error = z
     ),
     source_component_id: z.string(),
     property_name: z.string(),
+    subcircuit_id: z.string().optional(),
     error_type: z
       .literal("source_missing_property_error")
       .default("source_missing_property_error"),
@@ -32,6 +33,7 @@ export interface SourceMissingPropertyError {
   source_missing_property_error_id: string
   source_component_id: string
   property_name: string
+  subcircuit_id?: string
   error_type: "source_missing_property_error"
   message: string
 }

--- a/src/source/source_project_metadata.ts
+++ b/src/source/source_project_metadata.ts
@@ -7,6 +7,7 @@ export interface SourceProjectMetadata {
   software_used_string?: string
   project_url?: string
   created_at?: string // ISO8601 timestamp
+  subcircuit_id?: string
 }
 
 export const source_project_metadata = z.object({
@@ -15,6 +16,7 @@ export const source_project_metadata = z.object({
   software_used_string: z.string().optional(),
   project_url: z.string().optional(),
   created_at: z.string().datetime().optional(),
+  subcircuit_id: z.string().optional(),
 })
 
 export type InferredProjectMetadata = z.infer<typeof source_project_metadata>


### PR DESCRIPTION
## Summary
- include `subcircuit_id` in `SourceComponentBase`
- add optional `subcircuit_id` across schematic, PCB and CAD element schemas

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684f55d9a54c832eb8b5e583d670bbbc