### PR TITLE
Add autorouter fields to pcb_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
 ## Table of Contents
 
 <!-- toc:start -->
-
 - [Circuit JSON Specification `circuit-json`](#circuit-json-specification-circuit-json)
-
   - [Things You Can Do With Circuit JSON](#things-you-can-do-with-circuit-json)
   - [Typescript Usage](#typescript-usage)
 
@@ -192,7 +190,6 @@ There are 3 main element prefixes:
 - `schematic_` - e.g. `schematic_component`. Anything required to render the Schematic
 
 <!-- circuit-json-docs:start -->
-
 ## Source Components
 
 ### SourceComponentBase
@@ -231,13 +228,13 @@ interface SourceFailedToCreateComponentError {
   subcircuit_id?: string
   parent_source_component_id?: string
   pcb_center?: {
-    x?: number
-    y?: number
-  }
+  x?: number
+  y?: number
+}
   schematic_center?: {
-    x?: number
-    y?: number
-  }
+  x?: number
+  y?: number
+}
 }
 ```
 
@@ -752,12 +749,7 @@ interface PcbFabricationNoteText {
   text: string
   layer: VisibleLayer
   anchor_position: Point
-  anchor_alignment:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right"
+  anchor_alignment: | "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right"
   color?: string
 }
 ```
@@ -819,6 +811,10 @@ interface PcbGroup {
   pcb_component_ids: string[]
   name?: string
   description?: string
+  autorouter_configuration?: {
+  trace_clearance: Length
+}
+  autorouter_used_string?: string
 }
 ```
 
@@ -1357,13 +1353,13 @@ interface SchematicComponent {
   schematic_component_id: string
   pin_spacing?: number
   pin_styles?: Record<
-    string,
-    {
-      left_margin?: number
-      right_margin?: number
-      top_margin?: number
-      bottom_margin?: number
-    }
+  string,
+  {
+  left_margin?: number
+  right_margin?: number
+  top_margin?: number
+  bottom_margin?: number
+}
   >
   box_width?: number
   symbol_name?: string
@@ -1386,14 +1382,12 @@ interface SchematicPortArrangementBySides {
   right_side?: { pins: number[]; direction?: "top-to-bottom" | "bottom-to-top" }
   top_side?: { pins: number[]; direction?: "left-to-right" | "right-to-left" }
   bottom_side?: {
-    pins: number[]
-    direction?: "left-to-right" | "right-to-left"
-  }
+  pins: number[]
+  direction?: "left-to-right" | "right-to-left"
+}
 }
 
-type SchematicPortArrangement =
-  | SchematicPortArrangementBySize
-  | SchematicPortArrangementBySides
+type SchematicPortArrangement = | SchematicPortArrangementBySize | SchematicPortArrangementBySides
 ```
 
 ### SchematicDebugObject
@@ -1401,10 +1395,7 @@ type SchematicPortArrangement =
 [Source](https://github.com/tscircuit/circuit-json/blob/main/src/schematic/schematic_debug_object.ts)
 
 ```typescript
-type SchematicDebugObject =
-  | SchematicDebugRect
-  | SchematicDebugLine
-  | SchematicDebugPoint
+type SchematicDebugObject = | SchematicDebugRect | SchematicDebugLine | SchematicDebugPoint
 
 interface SchematicDebugRect {
   type: "schematic_debug_object"
@@ -1542,8 +1533,8 @@ interface SchematicNetLabel {
   text: string
   symbol_name?: string | undefined
   /** When true the net label can be repositioned. When false the label's
-   * position is fixed by the element it is attached to. */
-
+  * position is fixed by the element it is attached to. */
+  
   is_movable?: boolean
   subcircuit_id?: string
 }
@@ -1598,9 +1589,9 @@ interface SchematicText {
   text: string
   font_size: number
   position: {
-    x: number
-    y: number
-  }
+  x: number
+  y: number
+}
   rotation: number
   anchor: NinePointAnchor | FivePointAnchor
   color: string
@@ -1615,13 +1606,13 @@ interface SchematicText {
 ```typescript
 interface SchematicTraceEdge {
   from: {
-    x: number
-    y: number
-  }
+  x: number
+  y: number
+}
   to: {
-    x: number
-    y: number
-  }
+  x: number
+  y: number
+}
   is_crossing?: boolean
   from_schematic_port_id?: string
   to_schematic_port_id?: string

--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -16,6 +16,12 @@ export const pcb_group = z
     pcb_component_ids: z.array(z.string()),
     name: z.string().optional(),
     description: z.string().optional(),
+    autorouter_configuration: z
+      .object({
+        trace_clearance: length,
+      })
+      .optional(),
+    autorouter_used_string: z.string().optional(),
   })
   .describe("Defines a group of components on the PCB")
 
@@ -37,6 +43,10 @@ export interface PcbGroup {
   pcb_component_ids: string[]
   name?: string
   description?: string
+  autorouter_configuration?: {
+    trace_clearance: Length
+  }
+  autorouter_used_string?: string
 }
 
 expectTypesMatch<PcbGroup, InferredPcbGroup>(true)

--- a/tests/pcb_group_autorouter.test.ts
+++ b/tests/pcb_group_autorouter.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { pcb_group } from "../src/pcb/pcb_group"
+
+// Test autorouter_configuration optional and shape
+
+test("pcb_group.autorouter_configuration.trace_clearance parses", () => {
+  const group = pcb_group.parse({
+    type: "pcb_group",
+    source_group_id: "g1",
+    width: 10,
+    height: 10,
+    center: { x: 0, y: 0 },
+    pcb_component_ids: [],
+    autorouter_configuration: { trace_clearance: 0.2 },
+  })
+  expect(group.autorouter_configuration?.trace_clearance).toBe(0.2)
+})
+
+test("pcb_group.autorouter_used_string is optional", () => {
+  const group = pcb_group.parse({
+    type: "pcb_group",
+    source_group_id: "g1",
+    width: 10,
+    height: 10,
+    center: { x: 0, y: 0 },
+    pcb_component_ids: [],
+  })
+  expect(group.autorouter_used_string).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add optional autorouter fields in pcb_group schema and interface
- document these fields in README
- test pcb_group autorouter options

## Testing
- `bun test tests/pcb_group_autorouter.test.ts`
- `bun test tests/generate-readme-filter.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68680ce430b8832e8af330e860c51858