### PR TITLE
Add intentionally not connected schematic port flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,7 @@ interface SchematicPort {
   display_pin_label?: string
   subcircuit_id?: string
   is_connected?: boolean
+  is_intentionally_not_connected?: boolean
 }
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "ts-node": "^10.9.2",
         "tsup": "^8.3.0",
         "typescript": "^5.7.2",
-        "zod": "3",
+        "zod": "^4.0.5",
       },
     },
   },
@@ -581,7 +581,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.0.5", "", {}, "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA=="],
 
     "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.103", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.3.0",
     "typescript": "^5.7.2",
-    "zod": "3"
+    "zod": "^4.0.5"
   },
   "description": "Definitions for the tscircuit intermediary JSON format",
   "files": [

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -16,6 +16,7 @@ export interface SchematicPort {
   display_pin_label?: string
   subcircuit_id?: string
   is_connected?: boolean
+  is_intentionally_not_connected?: boolean
 }
 
 export const schematic_port = z
@@ -33,6 +34,7 @@ export const schematic_port = z
     display_pin_label: z.string().optional(),
     subcircuit_id: z.string().optional(),
     is_connected: z.boolean().optional(),
+    is_intentionally_not_connected: z.boolean().optional(),
   })
   .describe("Defines a port on a schematic component")
 

--- a/tests/schematic_port.test.ts
+++ b/tests/schematic_port.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { schematic_port } from "../src/schematic/schematic_port"
+
+test("schematic_port.is_intentionally_not_connected defaults to undefined", () => {
+  const port = schematic_port.parse({
+    type: "schematic_port",
+    schematic_port_id: "sp1",
+    source_port_id: "p1",
+    center: { x: 0, y: 0 },
+  })
+  expect(port.is_intentionally_not_connected).toBeUndefined()
+})
+
+test("schematic_port.is_intentionally_not_connected can be true", () => {
+  const port = schematic_port.parse({
+    type: "schematic_port",
+    schematic_port_id: "sp2",
+    source_port_id: "p2",
+    center: { x: 1, y: 1 },
+    is_intentionally_not_connected: true,
+  })
+  expect(port.is_intentionally_not_connected).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add `is_intentionally_not_connected` flag to `SchematicPort`
- document the new field in README
- update zod to latest version
- generate docs
- test parsing of new field

## Testing
- `bun test tests/schematic_port.test.ts`
- `bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_6871ebc43858832e966e1fa655705881