### PR TITLE
Add pcb footprint overlap error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
 ## Table of Contents
 
 <!-- toc:start -->
-
 - [Circuit JSON Specification `circuit-json`](#circuit-json-specification-circuit-json)
-
   - [Things You Can Do With Circuit JSON](#things-you-can-do-with-circuit-json)
   - [Typescript Usage](#typescript-usage)
 
@@ -80,6 +78,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbCutout](#pcbcutout)
     - [PcbFabricationNotePath](#pcbfabricationnotepath)
     - [PcbFabricationNoteText](#pcbfabricationnotetext)
+    - [PcbFootprintOverlapError](#pcbfootprintoverlaperror)
     - [PcbGroundPlane](#pcbgroundplane)
     - [PcbGroundPlaneRegion](#pcbgroundplaneregion)
     - [PcbGroup](#pcbgroup)
@@ -194,7 +193,6 @@ There are 3 main element prefixes:
 - `schematic_` - e.g. `schematic_component`. Anything required to render the Schematic
 
 <!-- circuit-json-docs:start -->
-
 ## Source Components
 
 ### SourceComponentBase
@@ -233,13 +231,13 @@ interface SourceFailedToCreateComponentError {
   subcircuit_id?: string
   parent_source_component_id?: string
   pcb_center?: {
-    x?: number
-    y?: number
-  }
+  x?: number
+  y?: number
+}
   schematic_center?: {
-    x?: number
-    y?: number
-  }
+  x?: number
+  y?: number
+}
 }
 ```
 
@@ -754,13 +752,27 @@ interface PcbFabricationNoteText {
   text: string
   layer: VisibleLayer
   anchor_position: Point
-  anchor_alignment:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right"
+  anchor_alignment: | "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right"
   color?: string
+}
+```
+
+### PcbFootprintOverlapError
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_footprint_overlap_error.ts)
+
+Error emitted when a pcb footprint overlaps with another element
+
+```typescript
+/** Error emitted when a pcb footprint overlaps with another element */interface PcbFootprintOverlapError {
+  type: "pcb_footprint_overlap_error"
+  pcb_error_id: string
+  error_type: "pcb_footprint_overlap_error"
+  message: string
+  pcb_smtpad_ids?: string[]
+  pcb_plated_hole_ids?: string[]
+  pcb_hole_ids?: string[]
+  pcb_keepout_ids?: string[]
 }
 ```
 
@@ -822,8 +834,8 @@ interface PcbGroup {
   name?: string
   description?: string
   autorouter_configuration?: {
-    trace_clearance: Length
-  }
+  trace_clearance: Length
+}
   autorouter_used_string?: string
 }
 ```
@@ -1363,13 +1375,13 @@ interface SchematicComponent {
   schematic_component_id: string
   pin_spacing?: number
   pin_styles?: Record<
-    string,
-    {
-      left_margin?: number
-      right_margin?: number
-      top_margin?: number
-      bottom_margin?: number
-    }
+  string,
+  {
+  left_margin?: number
+  right_margin?: number
+  top_margin?: number
+  bottom_margin?: number
+}
   >
   box_width?: number
   symbol_name?: string
@@ -1392,14 +1404,12 @@ interface SchematicPortArrangementBySides {
   right_side?: { pins: number[]; direction?: "top-to-bottom" | "bottom-to-top" }
   top_side?: { pins: number[]; direction?: "left-to-right" | "right-to-left" }
   bottom_side?: {
-    pins: number[]
-    direction?: "left-to-right" | "right-to-left"
-  }
+  pins: number[]
+  direction?: "left-to-right" | "right-to-left"
+}
 }
 
-type SchematicPortArrangement =
-  | SchematicPortArrangementBySize
-  | SchematicPortArrangementBySides
+type SchematicPortArrangement = | SchematicPortArrangementBySize | SchematicPortArrangementBySides
 ```
 
 ### SchematicDebugObject
@@ -1407,10 +1417,7 @@ type SchematicPortArrangement =
 [Source](https://github.com/tscircuit/circuit-json/blob/main/src/schematic/schematic_debug_object.ts)
 
 ```typescript
-type SchematicDebugObject =
-  | SchematicDebugRect
-  | SchematicDebugLine
-  | SchematicDebugPoint
+type SchematicDebugObject = | SchematicDebugRect | SchematicDebugLine | SchematicDebugPoint
 
 interface SchematicDebugRect {
   type: "schematic_debug_object"
@@ -1548,8 +1555,8 @@ interface SchematicNetLabel {
   text: string
   symbol_name?: string | undefined
   /** When true the net label can be repositioned. When false the label's
-   * position is fixed by the element it is attached to. */
-
+  * position is fixed by the element it is attached to. */
+  
   is_movable?: boolean
   subcircuit_id?: string
 }
@@ -1653,9 +1660,9 @@ interface SchematicText {
   text: string
   font_size: number
   position: {
-    x: number
-    y: number
-  }
+  x: number
+  y: number
+}
   rotation: number
   anchor: NinePointAnchor | FivePointAnchor
   color: string
@@ -1670,13 +1677,13 @@ interface SchematicText {
 ```typescript
 interface SchematicTraceEdge {
   from: {
-    x: number
-    y: number
-  }
+  x: number
+  y: number
+}
   to: {
-    x: number
-    y: number
-  }
+  x: number
+  y: number
+}
   is_crossing?: boolean
   from_schematic_port_id?: string
   to_schematic_port_id?: string

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -63,6 +63,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_fabrication_note_path,
   pcb.pcb_fabrication_note_text,
   pcb.pcb_autorouting_error,
+  pcb.pcb_footprint_overlap_error,
   pcb.pcb_breakout_point,
   pcb.pcb_cutout,
   pcb.pcb_ground_plane,
@@ -136,6 +137,7 @@ expectStringUnionsMatch<
   | "source_project_metadata DOES NOT HAVE AN source_project_metadata_id PROPERTY"
   | "pcb_port_not_matched_error DOES NOT HAVE AN pcb_port_not_matched_error_id PROPERTY"
   | "pcb_autorouting_error DOES NOT HAVE AN pcb_autorouting_error_id PROPERTY"
+  | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"
   | "schematic_box DOES NOT HAVE AN schematic_box_id PROPERTY"
   | "schematic_line DOES NOT HAVE AN schematic_line_id PROPERTY"

--- a/src/common/CircuitJsonError.ts
+++ b/src/common/CircuitJsonError.ts
@@ -3,6 +3,7 @@ import type {
   PcbPlacementError,
   PcbPortNotMatchedError,
   PcbAutoroutingError,
+  PcbFootprintOverlapError,
   PcbMissingFootprintError,
 } from "src/pcb"
 import type { SchematicError } from "src/schematic"
@@ -12,5 +13,6 @@ export type CircuitJsonError =
   | PcbPlacementError
   | PcbPortNotMatchedError
   | PcbAutoroutingError
+  | PcbFootprintOverlapError
   | PcbMissingFootprintError
   | SchematicError

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -25,6 +25,7 @@ export * from "./pcb_silkscreen_circle"
 export * from "./pcb_silkscreen_oval"
 export * from "./pcb_fabrication_note_text"
 export * from "./pcb_fabrication_note_path"
+export * from "./pcb_footprint_overlap_error"
 export * from "./pcb_keepout"
 export * from "./pcb_cutout"
 export * from "./pcb_missing_footprint_error"
@@ -58,6 +59,7 @@ import type { PcbSilkscreenText } from "./pcb_silkscreen_text"
 import type { PcbSilkscreenRect } from "./pcb_silkscreen_rect"
 import type { PcbSilkscreenCircle } from "./pcb_silkscreen_circle"
 import type { PcbAutoroutingError } from "./pcb_autorouting_error"
+import type { PcbFootprintOverlapError } from "./pcb_footprint_overlap_error"
 import type { PcbCutout } from "./pcb_cutout"
 import type { PcbBreakoutPoint } from "./pcb_breakout_point"
 import type { PcbGroundPlane } from "./pcb_ground_plane"
@@ -87,6 +89,7 @@ export type PcbCircuitElement =
   | PcbSilkscreenRect
   | PcbSilkscreenCircle
   | PcbAutoroutingError
+  | PcbFootprintOverlapError
   | PcbCutout
   | PcbBreakoutPoint
   | PcbGroundPlane

--- a/src/pcb/pcb_footprint_overlap_error.ts
+++ b/src/pcb/pcb_footprint_overlap_error.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_footprint_overlap_error = z
+  .object({
+    type: z.literal("pcb_footprint_overlap_error"),
+    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    error_type: z
+      .literal("pcb_footprint_overlap_error")
+      .default("pcb_footprint_overlap_error"),
+    message: z.string(),
+    pcb_smtpad_ids: z.array(z.string()).optional(),
+    pcb_plated_hole_ids: z.array(z.string()).optional(),
+    pcb_hole_ids: z.array(z.string()).optional(),
+    pcb_keepout_ids: z.array(z.string()).optional(),
+  })
+  .describe("Error emitted when a pcb footprint overlaps with another element")
+
+export type PcbFootprintOverlapErrorInput = z.input<
+  typeof pcb_footprint_overlap_error
+>
+type InferredPcbFootprintOverlapError = z.infer<
+  typeof pcb_footprint_overlap_error
+>
+
+/** Error emitted when a pcb footprint overlaps with another element */
+export interface PcbFootprintOverlapError {
+  type: "pcb_footprint_overlap_error"
+  pcb_error_id: string
+  error_type: "pcb_footprint_overlap_error"
+  message: string
+  pcb_smtpad_ids?: string[]
+  pcb_plated_hole_ids?: string[]
+  pcb_hole_ids?: string[]
+  pcb_keepout_ids?: string[]
+}
+
+expectTypesMatch<PcbFootprintOverlapError, InferredPcbFootprintOverlapError>(
+  true,
+)


### PR DESCRIPTION
## Summary
- add `pcb_footprint_overlap_error` with schema and interface
- export and re-export new PCB element
- include the type in `AnyCircuitElement` and `CircuitJsonError`
- regenerate README docs

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68768b3cc400832eb9a5cc3270bf074d