### PR TITLE
Add rotated pill hole and pad types

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,6 +971,28 @@ interface PcbHolePillWithRectPad {
   pcb_plated_hole_id: string
 }
 
+interface PcbHoleRotatedPillWithRectPad {
+  type: "pcb_plated_hole"
+  shape: "rotated_pill_hole_with_rect_pad"
+  pcb_group_id?: string
+  subcircuit_id?: string
+  hole_shape: "rotated_pill"
+  pad_shape: "rect"
+  hole_width: number
+  hole_height: number
+  hole_ccw_rotation: Rotation
+  rect_pad_width: number
+  rect_pad_height: number
+  rect_ccw_rotation: Rotation
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
 interface PcbHoleCircularWithRectPad {
   type: "pcb_plated_hole"
   shape: "circular_hole_with_rect_pad"

--- a/src/pcb/pcb_plated_hole.ts
+++ b/src/pcb/pcb_plated_hole.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { distance, type Distance } from "src/units"
+import { distance, type Distance, rotation, type Rotation } from "src/units"
 import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
@@ -115,6 +115,27 @@ const pcb_pill_hole_with_rect_pad = z.object({
   pcb_port_id: z.string().optional(),
   pcb_plated_hole_id: getZodPrefixedIdWithDefault("pcb_plated_hole"),
 })
+const pcb_rotated_pill_hole_with_rect_pad = z.object({
+  type: z.literal("pcb_plated_hole"),
+  shape: z.literal("rotated_pill_hole_with_rect_pad"),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  hole_shape: z.literal("rotated_pill"),
+  pad_shape: z.literal("rect"),
+  hole_width: z.number(),
+  hole_height: z.number(),
+  hole_ccw_rotation: rotation,
+  rect_pad_width: z.number(),
+  rect_pad_height: z.number(),
+  rect_ccw_rotation: rotation,
+  x: distance,
+  y: distance,
+  layers: z.array(layer_ref),
+  port_hints: z.array(z.string()).optional(),
+  pcb_component_id: z.string().optional(),
+  pcb_port_id: z.string().optional(),
+  pcb_plated_hole_id: getZodPrefixedIdWithDefault("pcb_plated_hole"),
+})
 export interface PcbHolePillWithRectPad {
   type: "pcb_plated_hole"
   shape: "pill_hole_with_rect_pad"
@@ -126,6 +147,28 @@ export interface PcbHolePillWithRectPad {
   hole_height: number
   rect_pad_width: number
   rect_pad_height: number
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
+export interface PcbHoleRotatedPillWithRectPad {
+  type: "pcb_plated_hole"
+  shape: "rotated_pill_hole_with_rect_pad"
+  pcb_group_id?: string
+  subcircuit_id?: string
+  hole_shape: "rotated_pill"
+  pad_shape: "rect"
+  hole_width: number
+  hole_height: number
+  hole_ccw_rotation: Rotation
+  rect_pad_width: number
+  rect_pad_height: number
+  rect_ccw_rotation: Rotation
   x: Distance
   y: Distance
   layers: LayerRef[]
@@ -159,12 +202,14 @@ export const pcb_plated_hole = z.union([
   pcb_plated_hole_oval,
   pcb_circular_hole_with_rect_pad,
   pcb_pill_hole_with_rect_pad,
+  pcb_rotated_pill_hole_with_rect_pad,
 ])
 export type PcbPlatedHole =
   | PcbPlatedHoleCircle
   | PcbPlatedHoleOval
   | PcbHoleCircularWithRectPad
   | PcbHolePillWithRectPad
+  | PcbHoleRotatedPillWithRectPad
 
 expectTypesMatch<PcbPlatedHoleCircle, z.infer<typeof pcb_plated_hole_circle>>(
   true,
@@ -177,6 +222,10 @@ expectTypesMatch<
 expectTypesMatch<
   PcbHolePillWithRectPad,
   z.infer<typeof pcb_pill_hole_with_rect_pad>
+>(true)
+expectTypesMatch<
+  PcbHoleRotatedPillWithRectPad,
+  z.infer<typeof pcb_rotated_pill_hole_with_rect_pad>
 >(true)
 /**
  * @deprecated use PcbPlatedHole

--- a/src/pcb/pcb_smtpad.ts
+++ b/src/pcb/pcb_smtpad.ts
@@ -68,6 +68,23 @@ export const pcb_smtpad_pill = z.object({
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
 })
+const pcb_smtpad_rotated_pill = z.object({
+  type: z.literal("pcb_smtpad"),
+  shape: z.literal("rotated_pill"),
+  pcb_smtpad_id: getZodPrefixedIdWithDefault("pcb_smtpad"),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  x: distance,
+  y: distance,
+  width: z.number(),
+  height: z.number(),
+  radius: z.number(),
+  ccw_rotation: rotation,
+  layer: layer_ref,
+  port_hints: z.array(z.string()).optional(),
+  pcb_component_id: z.string().optional(),
+  pcb_port_id: z.string().optional(),
+})
 
 const pcb_smtpad_polygon = z.object({
   type: z.literal("pcb_smtpad"),
@@ -87,6 +104,7 @@ export const pcb_smtpad = z
     pcb_smtpad_circle,
     pcb_smtpad_rect,
     pcb_smtpad_rotated_rect,
+    pcb_smtpad_rotated_pill,
     pcb_smtpad_pill,
     pcb_smtpad_polygon,
   ])
@@ -96,6 +114,7 @@ export type PCBSMTPadInput = z.input<typeof pcb_smtpad>
 type PCBSMTPadCircle = z.infer<typeof pcb_smtpad_circle>
 type PCBSMTPadRect = z.infer<typeof pcb_smtpad_rect>
 type PCBSMTPadRotatedRect = z.infer<typeof pcb_smtpad_rotated_rect>
+type PCBSMTPadRotatedPill = z.infer<typeof pcb_smtpad_rotated_pill>
 type PCBSMTPadPill = z.infer<typeof pcb_smtpad_pill>
 type PCBSMTPadPolygon = z.infer<typeof pcb_smtpad_polygon>
 
@@ -176,6 +195,27 @@ export interface PcbSmtPadPill {
 }
 
 /**
+ * Defines a rotated pill-shaped SMT pad on the PCB
+ */
+export interface PcbSmtPadRotatedPill {
+  type: "pcb_smtpad"
+  shape: "rotated_pill"
+  pcb_smtpad_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  x: Distance
+  y: Distance
+  width: number
+  height: number
+  radius: number
+  ccw_rotation: Rotation
+  layer: LayerRef
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+}
+
+/**
  * Defines a polygonal SMT pad on the PCB
  */
 export interface PcbSmtPadPolygon {
@@ -195,6 +235,7 @@ export type PcbSmtPad =
   | PcbSmtPadCircle
   | PcbSmtPadRect
   | PcbSmtPadRotatedRect
+  | PcbSmtPadRotatedPill
   | PcbSmtPadPill
   | PcbSmtPadPolygon
 
@@ -206,5 +247,6 @@ export type PCBSMTPad = PcbSmtPad
 expectTypesMatch<PcbSmtPadCircle, PCBSMTPadCircle>(true)
 expectTypesMatch<PcbSmtPadRect, PCBSMTPadRect>(true)
 expectTypesMatch<PcbSmtPadRotatedRect, PCBSMTPadRotatedRect>(true)
+expectTypesMatch<PcbSmtPadRotatedPill, PCBSMTPadRotatedPill>(true)
 expectTypesMatch<PcbSmtPadPill, PCBSMTPadPill>(true)
 expectTypesMatch<PcbSmtPadPolygon, PCBSMTPadPolygon>(true)

--- a/tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
+++ b/tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import {
+  pcb_plated_hole,
+  type PcbHoleRotatedPillWithRectPad,
+} from "../src/pcb/pcb_plated_hole"
+
+test("parse rotated pill hole with rect pad", () => {
+  const hole = pcb_plated_hole.parse({
+    type: "pcb_plated_hole",
+    shape: "rotated_pill_hole_with_rect_pad",
+    hole_shape: "rotated_pill",
+    pad_shape: "rect",
+    hole_width: 1,
+    hole_height: 2,
+    hole_ccw_rotation: 45,
+    rect_pad_width: 3,
+    rect_pad_height: 4,
+    rect_ccw_rotation: 45,
+    x: 0,
+    y: 0,
+    layers: ["top"],
+  })
+  expect(hole.shape).toBe("rotated_pill_hole_with_rect_pad")
+  expect((hole as PcbHoleRotatedPillWithRectPad).hole_ccw_rotation).toBe(45)
+})

--- a/tests/pcb_rotated_pill_smtpad.test.ts
+++ b/tests/pcb_rotated_pill_smtpad.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { pcb_smtpad, type PcbSmtPadRotatedPill } from "../src/pcb/pcb_smtpad"
+
+test("parse rotated pill smt pad", () => {
+  const pad = pcb_smtpad.parse({
+    type: "pcb_smtpad",
+    shape: "rotated_pill",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 2,
+    radius: 0.5,
+    ccw_rotation: 90,
+    layer: "top",
+  })
+  expect(pad.shape).toBe("rotated_pill")
+  expect((pad as PcbSmtPadRotatedPill).ccw_rotation).toBe(90)
+})


### PR DESCRIPTION
## Summary
- introduce `rotated_pill_hole_with_rect_pad` for plated holes
- support `rotated_pill` SMT pads
- document the new interface in README
- test that rotated pill shapes parse correctly

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6885c8d7e560832e9b494c7d8a170d18