### PR TITLE
feat: add layout_mode to pcb_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ interface PcbGroup {
   pcb_component_ids: string[]
   name?: string
   description?: string
+  layout_mode?: string
   autorouter_configuration?: {
     trace_clearance: Length
   }

--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -16,6 +16,7 @@ export const pcb_group = z
     pcb_component_ids: z.array(z.string()),
     name: z.string().optional(),
     description: z.string().optional(),
+    layout_mode: z.string().optional(),
     autorouter_configuration: z
       .object({
         trace_clearance: length,
@@ -43,6 +44,7 @@ export interface PcbGroup {
   pcb_component_ids: string[]
   name?: string
   description?: string
+  layout_mode?: string
   autorouter_configuration?: {
     trace_clearance: Length
   }

--- a/tests/pcb_group_autorouter.test.ts
+++ b/tests/pcb_group_autorouter.test.ts
@@ -27,3 +27,26 @@ test("pcb_group.autorouter_used_string is optional", () => {
   })
   expect(group.autorouter_used_string).toBeUndefined()
 })
+
+test("pcb_group.layout_mode is optional string", () => {
+  const group = pcb_group.parse({
+    type: "pcb_group",
+    source_group_id: "g1",
+    width: 10,
+    height: 10,
+    center: { x: 0, y: 0 },
+    pcb_component_ids: [],
+    layout_mode: "manual",
+  })
+  expect(group.layout_mode).toBe("manual")
+
+  const withoutLayoutMode = pcb_group.parse({
+    type: "pcb_group",
+    source_group_id: "g1",
+    width: 10,
+    height: 10,
+    center: { x: 0, y: 0 },
+    pcb_component_ids: [],
+  })
+  expect(withoutLayoutMode.layout_mode).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- allow pcb_group to specify an optional `layout_mode`
- document new field in README
- cover optional layout_mode with dedicated tests

## Testing
- `bun test tests/pcb_group_autorouter.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_688d9715504c832e9e1f5726e84bd335