### PR TITLE
feat: add pcb trace missing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbTrace](#pcbtrace)
     - [PcbTraceError](#pcbtraceerror)
     - [PcbTraceHint](#pcbtracehint)
+    - [PcbTraceMissingError](#pcbtracemissingerror)
     - [PcbVia](#pcbvia)
   - [Schematic Elements](#schematic-elements)
     - [SchematicBox](#schematicbox)
@@ -1369,6 +1370,27 @@ interface PcbTraceHint {
   pcb_port_id: string
   pcb_component_id: string
   route: RouteHintPoint[]
+  subcircuit_id?: string
+}
+```
+
+### PcbTraceMissingError
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_trace_missing_error.ts)
+
+Defines an error when a source trace has no corresponding PCB trace
+
+```typescript
+/** Defines an error when a source trace has no corresponding PCB trace */
+interface PcbTraceMissingError {
+  type: "pcb_trace_missing_error"
+  pcb_trace_missing_error_id: string
+  error_type: "pcb_trace_missing_error"
+  message: string
+  center?: Point
+  source_trace_id: string
+  pcb_component_ids: string[]
+  pcb_port_ids: string[]
   subcircuit_id?: string
 }
 ```

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -95,6 +95,17 @@ export interface PcbTraceError {
   pcb_port_ids: string[]
 }
 
+export interface PcbTraceMissingError {
+  type: "pcb_trace_missing_error"
+  pcb_trace_missing_error_id: string
+  error_type: "pcb_trace_missing_error"
+  message: string
+  center?: Point
+  source_trace_id: string
+  pcb_component_ids: string[]
+  pcb_port_ids: string[]
+}
+
 export interface PcbSilkscreenPill {
   type: "pcb_silkscreen_pill"
   pcb_silkscreen_pill_id: string

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -60,6 +60,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_silkscreen_circle,
   pcb.pcb_silkscreen_oval,
   pcb.pcb_trace_error,
+  pcb.pcb_trace_missing_error,
   pcb.pcb_placement_error,
   pcb.pcb_port_not_matched_error,
   pcb.pcb_fabrication_note_path,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -12,6 +12,7 @@ export * from "./pcb_solder_paste"
 export * from "./pcb_text"
 export * from "./pcb_trace"
 export * from "./pcb_trace_error"
+export * from "./pcb_trace_missing_error"
 export * from "./pcb_port_not_matched_error"
 export * from "./pcb_via"
 export * from "./pcb_board"
@@ -46,6 +47,7 @@ import type { PcbSolderPaste } from "./pcb_solder_paste"
 import type { PcbText } from "./pcb_text"
 import type { PcbTrace } from "./pcb_trace"
 import type { PcbTraceError } from "./pcb_trace_error"
+import type { PcbTraceMissingError } from "./pcb_trace_missing_error"
 import type { PcbPortNotMatchedError } from "./pcb_port_not_matched_error"
 import type { PcbVia } from "./pcb_via"
 import type { PcbBoard } from "./pcb_board"
@@ -76,6 +78,7 @@ export type PcbCircuitElement =
   | PcbText
   | PcbTrace
   | PcbTraceError
+  | PcbTraceMissingError
   | PcbMissingFootprintError
   | PcbManualEditConflictWarning
   | PcbPortNotMatchedError

--- a/src/pcb/pcb_trace_missing_error.ts
+++ b/src/pcb/pcb_trace_missing_error.ts
@@ -1,0 +1,48 @@
+import { z } from "zod"
+import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_trace_missing_error = z
+  .object({
+    type: z.literal("pcb_trace_missing_error"),
+    pcb_trace_missing_error_id: getZodPrefixedIdWithDefault(
+      "pcb_trace_missing_error",
+    ),
+    error_type: z
+      .literal("pcb_trace_missing_error")
+      .default("pcb_trace_missing_error"),
+    message: z.string(),
+    center: point.optional(),
+    source_trace_id: z.string(),
+    pcb_component_ids: z.array(z.string()),
+    pcb_port_ids: z.array(z.string()),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Defines an error when a source trace has no corresponding PCB trace",
+  )
+
+export type PcbTraceMissingErrorInput = z.input<typeof pcb_trace_missing_error>
+type InferredPcbTraceMissingError = z.infer<typeof pcb_trace_missing_error>
+
+/**
+ * Defines an error when a source trace has no corresponding PCB trace
+ */
+export interface PcbTraceMissingError {
+  type: "pcb_trace_missing_error"
+  pcb_trace_missing_error_id: string
+  error_type: "pcb_trace_missing_error"
+  message: string
+  center?: Point
+  source_trace_id: string
+  pcb_component_ids: string[]
+  pcb_port_ids: string[]
+  subcircuit_id?: string
+}
+
+/**
+ * @deprecated use PcbTraceMissingError
+ */
+export type PCBTraceMissingError = PcbTraceMissingError
+
+expectTypesMatch<PcbTraceMissingError, InferredPcbTraceMissingError>(true)

--- a/tests/pcb_trace_missing_error.test.ts
+++ b/tests/pcb_trace_missing_error.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { pcb_trace_missing_error } from "../src/pcb/pcb_trace_missing_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_trace_missing_error parses", () => {
+  const error = pcb_trace_missing_error.parse({
+    type: "pcb_trace_missing_error",
+    message: "trace missing",
+    source_trace_id: "st1",
+    pcb_component_ids: [],
+    pcb_port_ids: [],
+  })
+  expect(error.pcb_trace_missing_error_id).toBeDefined()
+  expect(
+    error.pcb_trace_missing_error_id.startsWith("pcb_trace_missing_error"),
+  ).toBe(true)
+})
+
+test("any_circuit_element includes pcb_trace_missing_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_trace_missing_error",
+    message: "trace missing",
+    source_trace_id: "st1",
+    pcb_component_ids: [],
+    pcb_port_ids: [],
+  })
+  expect(parsed.type).toBe("pcb_trace_missing_error")
+})


### PR DESCRIPTION
## Summary
- add `pcb_trace_missing_error` type for missing PCB trace mapping
- document `PcbTraceMissingError` and export from PCB modules
- test parsing and union inclusion of new error

## Testing
- `bun test tests/pcb_trace_missing_error.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_689abeb53f60832e97d2d6f58ce45515