### PR TITLE
change from `pcb_error_id` to `pcb_port_not_connected_error_id`

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -40,7 +40,7 @@ export interface PcbPortNotMatchedError {
 
 export interface PcbPortNotConnectedError {
   type: "pcb_port_not_connected_error"
-  pcb_error_id: string
+  pcb_port_not_connected_error_id: string
   error_type: "pcb_port_not_connected_error"
   message: string
   pcb_port_ids: string[]

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -141,7 +141,6 @@ expectStringUnionsMatch<
   // THIS IS FOR LEGACY REASONS, DO NOT ADD MORE EXCEPTIONS
   | "source_project_metadata DOES NOT HAVE AN source_project_metadata_id PROPERTY"
   | "pcb_port_not_matched_error DOES NOT HAVE AN pcb_port_not_matched_error_id PROPERTY"
-  | "pcb_port_not_connected_error DOES NOT HAVE AN pcb_port_not_connected_error_id PROPERTY"
   | "pcb_autorouting_error DOES NOT HAVE AN pcb_autorouting_error_id PROPERTY"
   | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"

--- a/src/pcb/pcb_port_not_connected_error.ts
+++ b/src/pcb/pcb_port_not_connected_error.ts
@@ -5,7 +5,9 @@ import { expectTypesMatch } from "src/utils/expect-types-match"
 export const pcb_port_not_connected_error = z
   .object({
     type: z.literal("pcb_port_not_connected_error"),
-    pcb_error_id: getZodPrefixedIdWithDefault("pcb_port_not_connected_error"),
+    pcb_port_not_connected_error_id: getZodPrefixedIdWithDefault(
+      "pcb_port_not_connected_error",
+    ),
     error_type: z
       .literal("pcb_port_not_connected_error")
       .default("pcb_port_not_connected_error"),
@@ -28,7 +30,7 @@ type InferredPcbPortNotConnectedError = z.infer<
  */
 export interface PcbPortNotConnectedError {
   type: "pcb_port_not_connected_error"
-  pcb_error_id: string
+  pcb_port_not_connected_error_id: string
   error_type: "pcb_port_not_connected_error"
   message: string
   pcb_port_ids: string[]

--- a/tests/pcb_port_not_connected_error.test.ts
+++ b/tests/pcb_port_not_connected_error.test.ts
@@ -9,10 +9,12 @@ test("pcb_port_not_connected_error parses", () => {
     pcb_port_ids: [],
     pcb_component_ids: [],
   })
-  expect(error.pcb_error_id).toBeDefined()
-  expect(error.pcb_error_id.startsWith("pcb_port_not_connected_error")).toBe(
-    true,
-  )
+  expect(error.pcb_port_not_connected_error_id).toBeDefined()
+  expect(
+    error.pcb_port_not_connected_error_id.startsWith(
+      "pcb_port_not_connected_error",
+    ),
+  ).toBe(true)
 })
 
 test("any_circuit_element includes pcb_port_not_connected_error", () => {


### PR DESCRIPTION
It's bit confusing cause some of the error objects are using just `pcb_error_id`. But this seems to be verbose and follow the standard