### PR TITLE
Avoid string capacitance inputs conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Defines a simple capacitor component
 /** Defines a simple capacitor component */
 interface SourceSimpleCapacitor extends SourceComponentBase {
   ftype: "simple_capacitor"
-  capacitance: number
+  capacitance: number | string
   max_voltage_rating?: number
   display_capacitance?: string
   max_decoupling_trace_length?: number
@@ -549,7 +549,7 @@ Defines a simple resonator component
 /** Defines a simple resonator component */
 interface SourceSimpleResonator extends SourceComponentBase {
   ftype: "simple_resonator"
-  load_capacitance: number
+  load_capacitance: number | string
   equivalent_series_resistance?: number
   frequency: number
 }

--- a/docs/SOURCE_COMPONENT_OVERVIEW.md
+++ b/docs/SOURCE_COMPONENT_OVERVIEW.md
@@ -140,7 +140,7 @@ interface SourceSimpleCapacitor {
   manufacturer_part_number?: string
   supplier_part_numbers?: Partial<Record<string, string[]>>
   display_value?: string
-  capacitance: number
+  capacitance: number | string
 }
 
 interface SourceComponentBase {

--- a/src/source/source_simple_capacitor.ts
+++ b/src/source/source_simple_capacitor.ts
@@ -22,7 +22,7 @@ type InferredSourceSimpleCapacitor = z.infer<typeof source_simple_capacitor>
  */
 export interface SourceSimpleCapacitor extends SourceComponentBase {
   ftype: "simple_capacitor"
-  capacitance: number
+  capacitance: number | string
   max_voltage_rating?: number
   display_capacitance?: string
   max_decoupling_trace_length?: number

--- a/src/source/source_simple_resonator.ts
+++ b/src/source/source_simple_resonator.ts
@@ -21,7 +21,7 @@ type InferredSourceSimpleResonator = z.infer<typeof source_simple_resonator>
  */
 export interface SourceSimpleResonator extends SourceComponentBase {
   ftype: "simple_resonator"
-  load_capacitance: number
+  load_capacitance: number | string
   equivalent_series_resistance?: number
   frequency: number
 }

--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -58,13 +58,13 @@ export const resistance = z
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v).value!)
 
-export const capacitance = z
-  .string()
-  .or(z.number())
-  .transform((v) => parseAndConvertSiUnit(v).value!)
-  .transform((value) => {
-    return Number.parseFloat(value.toPrecision(12)) // Round to 12 significant digits
-  })
+export const capacitance = z.union([
+  z.string(),
+  z
+    .number()
+    .transform((v) => parseAndConvertSiUnit(v).value!)
+    .transform((value) => Number.parseFloat(value.toPrecision(12))),
+])
 
 export const inductance = z
   .string()

--- a/tests/capacitance.test.ts
+++ b/tests/capacitance.test.ts
@@ -1,45 +1,17 @@
 import { test, expect } from "bun:test"
 import { capacitance } from "src/units"
 
-test("Capacitance Precision Tests", () => {
-  const testCases = [
-    { input: "1uF", expected: 0.000001 },
-    { input: "10uF", expected: 0.00001 },
-    { input: "100uF", expected: 0.0001 },
-    { input: "1pF", expected: 1e-12 },
-    { input: "10pF", expected: 1e-11 },
-    { input: "0.001F", expected: 0.001 },
-    { input: "0.009999999999999F", expected: 0.01 },
-    { input: "0.1pF", expected: 1e-13 },
-    { input: "0.01pF", expected: 1e-14 },
-    { input: "0.001pF", expected: 1e-15 },
+test("Capacitance leaves strings untouched but rounds numbers", () => {
+  const stringInputs = ["1uF", "0.009999999999999F"]
+  for (const input of stringInputs) {
+    expect(capacitance.parse(input)).toBe(input)
+  }
+
+  const numberCases = [
+    { input: 0.001, expected: 0.001 },
+    { input: 0.009999999999999, expected: 0.01 },
   ]
-
-  const results = testCases.map((testCase) => ({
-    ...testCase,
-    actual: capacitance.parse(testCase.input),
-  }))
-
-  expect(
-    `${"Input".padEnd(20)} ${"Actual".padEnd(16)} ${"Expected".padEnd(16)}\n${results
-      .map(
-        (r) =>
-          `${r.input.padEnd(20)} ${r.actual.toString().padEnd(16)} ${r.expected.toString().padEnd(16)}`,
-      )
-      .join("\n")}`,
-  ).toMatchInlineSnapshot(`
-"Input                Actual           Expected        
-1uF                  0.000001         0.000001        
-10uF                 0.00001          0.00001         
-100uF                0.0001           0.0001          
-1pF                  1e-12            1e-12           
-10pF                 1e-11            1e-11           
-0.001F               0.001            0.001           
-0.009999999999999F   0.01             0.01            
-0.1pF                1e-13            1e-13           
-0.01pF               1e-14            1e-14           
-0.001pF              1e-15            1e-15           "
-`)
-
-  expect(results.every((r) => r.actual === r.expected)).toBeTrue()
+  for (const { input, expected } of numberCases) {
+    expect(capacitance.parse(input)).toBe(expected)
+  }
 })


### PR DESCRIPTION
## Summary
- avoid SI unit conversion for capacitance string inputs, but still normalize numeric inputs
- support string or numeric capacitance in simple capacitor and resonator component types
- revise documentation and tests for new capacitance handling

## Testing
- `npm run format`
- `npm run lint:zod`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a8a6fccdc8832c909ddd1e867bd404