### PR TITLE
feat: optional source trace id for schematic traces

### DIFF
--- a/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
+++ b/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
@@ -12,7 +12,8 @@ can also import.
 interface SchematicTrace {
   type: "schematic_trace"
   schematic_trace_id: string
-  source_trace_id: string
+  source_trace_id?: string
+  subcircuit_connectivity_map_key?: string // will be required in future
   edges: Array<{
     from: {
       x: number

--- a/src/schematic/schematic_trace.ts
+++ b/src/schematic/schematic_trace.ts
@@ -19,19 +19,21 @@ export interface SchematicTraceEdge {
 export interface SchematicTrace {
   type: "schematic_trace"
   schematic_trace_id: string
-  source_trace_id: string
+  source_trace_id?: string
   junctions: {
     x: number
     y: number
   }[]
   edges: SchematicTraceEdge[]
   subcircuit_id?: string
+  /** Optional for now, but will be required in a future release */
+  subcircuit_connectivity_map_key?: string
 }
 
 export const schematic_trace = z.object({
   type: z.literal("schematic_trace"),
   schematic_trace_id: z.string(),
-  source_trace_id: z.string(),
+  source_trace_id: z.string().optional(),
   junctions: z.array(
     z.object({
       x: z.number(),
@@ -54,6 +56,8 @@ export const schematic_trace = z.object({
     }),
   ),
   subcircuit_id: z.string().optional(),
+  // TODO: make required in a future release
+  subcircuit_connectivity_map_key: z.string().optional(),
 })
 
 export type SchematicTraceInput = z.input<typeof schematic_trace>

--- a/tests/schematic_trace_optional_fields.test.ts
+++ b/tests/schematic_trace_optional_fields.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { schematic_trace } from "../src/schematic/schematic_trace"
+
+test("schematic_trace.source_trace_id is optional", () => {
+  const trace = schematic_trace.parse({
+    type: "schematic_trace",
+    schematic_trace_id: "trace1",
+    junctions: [{ x: 0, y: 0 }],
+    edges: [
+      {
+        from: { x: 0, y: 0 },
+        to: { x: 1, y: 0 },
+      },
+    ],
+  })
+  expect(trace.source_trace_id).toBeUndefined()
+})
+
+test("schematic_trace.subcircuit_connectivity_map_key is optional", () => {
+  const trace = schematic_trace.parse({
+    type: "schematic_trace",
+    schematic_trace_id: "trace2",
+    subcircuit_connectivity_map_key: "sub1",
+    junctions: [{ x: 0, y: 0 }],
+    edges: [
+      {
+        from: { x: 0, y: 0 },
+        to: { x: 1, y: 0 },
+      },
+    ],
+  })
+  expect(trace.subcircuit_connectivity_map_key).toBe("sub1")
+})


### PR DESCRIPTION
## Summary
- make `schematic_trace.source_trace_id` optional
- add optional `schematic_trace.subcircuit_connectivity_map_key`
- document new optional fields and cover with tests

## Testing
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68b9bbb38fbc832ea4bf2af00b4a6024