### PR TITLE
feat: add is_positive_voltage_source to source_net

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ interface SourceNet {
   is_ground?: boolean
   is_digital_signal?: boolean
   is_analog_signal?: boolean
+  is_positive_voltage_source?: boolean
   trace_width?: number
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string

--- a/docs/SOURCE_COMPONENT_OVERVIEW.md
+++ b/docs/SOURCE_COMPONENT_OVERVIEW.md
@@ -89,6 +89,7 @@ interface SourceNet {
   is_ground?: boolean
   is_digital_signal?: boolean
   is_analog_signal?: boolean
+  is_positive_voltage_source?: boolean
   trace_width?: number
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string

--- a/src/source/source_net.ts
+++ b/src/source/source_net.ts
@@ -10,6 +10,7 @@ export const source_net = z.object({
   is_ground: z.boolean().optional(),
   is_digital_signal: z.boolean().optional(),
   is_analog_signal: z.boolean().optional(),
+  is_positive_voltage_source: z.boolean().optional(),
   trace_width: z.number().optional(),
   subcircuit_id: z.string().optional(),
   subcircuit_connectivity_map_key: z.string().optional(),
@@ -27,6 +28,7 @@ export interface SourceNet {
   is_ground?: boolean
   is_digital_signal?: boolean
   is_analog_signal?: boolean
+  is_positive_voltage_source?: boolean
   trace_width?: number
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string

--- a/tests/source_net.test.ts
+++ b/tests/source_net.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { source_net } from "../src/source/source_net"
+
+test("source_net.is_positive_voltage_source defaults to undefined", () => {
+  const net = source_net.parse({
+    type: "source_net",
+    source_net_id: "net1",
+    name: "VCC",
+    member_source_group_ids: [],
+  })
+  expect(net.is_positive_voltage_source).toBeUndefined()
+})
+
+test("source_net.is_positive_voltage_source can be true", () => {
+  const net = source_net.parse({
+    type: "source_net",
+    source_net_id: "net1",
+    name: "VCC",
+    member_source_group_ids: [],
+    is_positive_voltage_source: true,
+  })
+  expect(net.is_positive_voltage_source).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add is_positive_voltage_source boolean flag to SourceNet schema and interface
- document is_positive_voltage_source on SourceNet in README and component overview docs
- test SourceNet parsing for is_positive_voltage_source

## Testing
- `bun test tests/source_net.test.ts`
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68ba568a4424832e835b23d17ce509f0