### PR TITLE
feat(pcb): add pcb_copper_pour element

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -76,6 +76,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_ground_plane,
   pcb.pcb_ground_plane_region,
   pcb.pcb_thermal_spoke,
+  pcb.pcb_copper_pour,
   sch.schematic_box,
   sch.schematic_text,
   sch.schematic_line,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -38,6 +38,7 @@ export * from "./pcb_breakout_point"
 export * from "./pcb_ground_plane"
 export * from "./pcb_ground_plane_region"
 export * from "./pcb_thermal_spoke"
+export * from "./pcb_copper_pour"
 
 import type { PcbComponent } from "./pcb_component"
 import type { PcbHole } from "./pcb_hole"
@@ -69,6 +70,7 @@ import type { PcbBreakoutPoint } from "./pcb_breakout_point"
 import type { PcbGroundPlane } from "./pcb_ground_plane"
 import type { PcbGroundPlaneRegion } from "./pcb_ground_plane_region"
 import type { PcbThermalSpoke } from "./pcb_thermal_spoke"
+import type { PcbCopperPour } from "./pcb_copper_pour"
 
 export type PcbCircuitElement =
   | PcbComponent
@@ -101,3 +103,4 @@ export type PcbCircuitElement =
   | PcbGroundPlane
   | PcbGroundPlaneRegion
   | PcbThermalSpoke
+  | PcbCopperPour

--- a/src/pcb/pcb_copper_pour.ts
+++ b/src/pcb/pcb_copper_pour.ts
@@ -1,0 +1,108 @@
+import { z } from "zod"
+import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
+import { length, type Length, rotation, type Rotation } from "src/units"
+import { layer_ref, type LayerRef } from "./properties/layer_ref"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+// Common properties base for all pour shapes (internal)
+const pcb_copper_pour_base = z.object({
+  type: z.literal("pcb_copper_pour"),
+  pcb_copper_pour_id: getZodPrefixedIdWithDefault("pcb_copper_pour"),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  layer: layer_ref,
+  source_net_id: z.string().optional(),
+})
+
+// Rectangular Pour
+export const pcb_copper_pour_rect = pcb_copper_pour_base.extend({
+  shape: z.literal("rect"),
+  center: point,
+  width: length,
+  height: length,
+  rotation: rotation.optional(),
+})
+export type PcbCopperPourRectInput = z.input<typeof pcb_copper_pour_rect>
+type InferredPcbCopperPourRect = z.infer<typeof pcb_copper_pour_rect>
+/**
+ * Defines a rectangular copper pour on the PCB.
+ */
+export interface PcbCopperPourRect {
+  type: "pcb_copper_pour"
+  pcb_copper_pour_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  layer: LayerRef
+  source_net_id?: string
+  shape: "rect"
+  center: Point
+  width: Length
+  height: Length
+  rotation?: Rotation
+}
+expectTypesMatch<PcbCopperPourRect, InferredPcbCopperPourRect>(true)
+
+// Circular Pour
+export const pcb_copper_pour_circle = pcb_copper_pour_base.extend({
+  shape: z.literal("circle"),
+  center: point,
+  radius: length,
+})
+export type PcbCopperPourCircleInput = z.input<typeof pcb_copper_pour_circle>
+type InferredPcbCopperPourCircle = z.infer<typeof pcb_copper_pour_circle>
+/**
+ * Defines a circular copper pour on the PCB.
+ */
+export interface PcbCopperPourCircle {
+  type: "pcb_copper_pour"
+  pcb_copper_pour_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  layer: LayerRef
+  source_net_id?: string
+  shape: "circle"
+  center: Point
+  radius: Length
+}
+expectTypesMatch<PcbCopperPourCircle, InferredPcbCopperPourCircle>(true)
+
+// Polygon Pour
+export const pcb_copper_pour_polygon = pcb_copper_pour_base.extend({
+  shape: z.literal("polygon"),
+  points: z.array(point),
+})
+export type PcbCopperPourPolygonInput = z.input<typeof pcb_copper_pour_polygon>
+type InferredPcbCopperPourPolygon = z.infer<typeof pcb_copper_pour_polygon>
+/**
+ * Defines a polygonal copper pour on the PCB, specified by a list of points.
+ * The polygon should be closed (the last point implicitly connects to the first).
+ */
+export interface PcbCopperPourPolygon {
+  type: "pcb_copper_pour"
+  pcb_copper_pour_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  layer: LayerRef
+  source_net_id?: string
+  shape: "polygon"
+  points: Point[]
+}
+expectTypesMatch<PcbCopperPourPolygon, InferredPcbCopperPourPolygon>(true)
+
+// Union of all pour shapes
+export const pcb_copper_pour = z
+  .discriminatedUnion("shape", [
+    pcb_copper_pour_rect,
+    pcb_copper_pour_circle,
+    pcb_copper_pour_polygon,
+  ])
+  .describe("Defines a copper pour on the PCB.")
+
+export type PcbCopperPourInput = z.input<typeof pcb_copper_pour>
+export type PcbCopperPour =
+  | PcbCopperPourRect
+  | PcbCopperPourCircle
+  | PcbCopperPourPolygon
+
+type InferredPcbCopperPour = z.infer<typeof pcb_copper_pour>
+expectTypesMatch<PcbCopperPour, InferredPcbCopperPour>(true)

--- a/tests/pcb_copper_pour.test.ts
+++ b/tests/pcb_copper_pour.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { pcb_copper_pour } from "../src/pcb/pcb_copper_pour"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_copper_pour rect parses", () => {
+  const pour = pcb_copper_pour.parse({
+    type: "pcb_copper_pour",
+    shape: "rect",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+    layer: "top",
+    source_net_id: "net1",
+  })
+  expect(pour.shape).toBe("rect")
+  if (pour.shape === "rect") {
+    expect(pour.width).toBe(10)
+  }
+  expect((pour as any).pcb_copper_pour_id).toBeDefined()
+  expect(any_circuit_element.parse(pour)).toBeDefined()
+})
+
+test("pcb_copper_pour circle parses", () => {
+  const pour = pcb_copper_pour.parse({
+    type: "pcb_copper_pour",
+    shape: "circle",
+    center: { x: 0, y: 0 },
+    radius: 5,
+    layer: "top",
+    source_net_id: "net1",
+  })
+  expect(pour.shape).toBe("circle")
+  if (pour.shape === "circle") {
+    expect(pour.radius).toBe(5)
+  }
+  expect((pour as any).pcb_copper_pour_id).toBeDefined()
+  expect(any_circuit_element.parse(pour)).toBeDefined()
+})
+
+test("pcb_copper_pour polygon parses", () => {
+  const pour = pcb_copper_pour.parse({
+    type: "pcb_copper_pour",
+    shape: "polygon",
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 5, y: 10 },
+    ],
+    layer: "top",
+  })
+  expect(pour.shape).toBe("polygon")
+  if (pour.shape === "polygon") {
+    expect(pour.points.length).toBe(3)
+  }
+  expect(pour.source_net_id).toBeUndefined()
+  expect((pour as any).pcb_copper_pour_id).toBeDefined()
+  expect(any_circuit_element.parse(pour)).toBeDefined()
+})


### PR DESCRIPTION
This PR introduces the pcb_copper_pour element to the Circuit JSON specification. This element allows for defining copper pour areas on a PCB, which are essential for creating ground planes and connecting multiple components to a single net.                                                                                                     

Key changes:                                                                                                                                                                   

 • Added src/pcb/pcb_copper_pour.ts, which defines the pcb_copper_pour element with support for rect, circle, and polygon shapes.                                              
 • Included Zod schemas for parsing and corresponding TypeScript interfaces for type safety.                                                                                   
 • Added new tests in tests/pcb_copper_pour.test.ts to validate the new element.                                                                                               
 • Updated any_circuit_element and pcb/index.ts to integrate the new element into the overall specification.