### PR TITLE
feat(pcb): Replace circular copper pour with BRep shape

### DIFF
--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -1,3 +1,4 @@
+export * from "./properties/brep"
 export * from "./properties/layer_ref"
 export * from "./properties/pcb_route_hints"
 export * from "./properties/supplier_name"

--- a/src/pcb/pcb_copper_pour.ts
+++ b/src/pcb/pcb_copper_pour.ts
@@ -3,6 +3,7 @@ import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
 import { length, type Length, rotation, type Rotation } from "src/units"
 import { layer_ref, type LayerRef } from "./properties/layer_ref"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { brep_shape, type BRepShape } from "./properties/brep"
 
 // Common properties base for all pour shapes (internal)
 const pcb_copper_pour_base = z.object({
@@ -42,29 +43,27 @@ export interface PcbCopperPourRect {
 }
 expectTypesMatch<PcbCopperPourRect, InferredPcbCopperPourRect>(true)
 
-// Circular Pour
-export const pcb_copper_pour_circle = pcb_copper_pour_base.extend({
-  shape: z.literal("circle"),
-  center: point,
-  radius: length,
+// BRep Pour
+export const pcb_copper_pour_brep = pcb_copper_pour_base.extend({
+  shape: z.literal("brep"),
+  brep_shape: brep_shape,
 })
-export type PcbCopperPourCircleInput = z.input<typeof pcb_copper_pour_circle>
-type InferredPcbCopperPourCircle = z.infer<typeof pcb_copper_pour_circle>
+export type PcbCopperPourBRepInput = z.input<typeof pcb_copper_pour_brep>
+type InferredPcbCopperPourBRep = z.infer<typeof pcb_copper_pour_brep>
 /**
- * Defines a circular copper pour on the PCB.
+ * Defines a BRep copper pour on the PCB.
  */
-export interface PcbCopperPourCircle {
+export interface PcbCopperPourBRep {
   type: "pcb_copper_pour"
   pcb_copper_pour_id: string
   pcb_group_id?: string
   subcircuit_id?: string
   layer: LayerRef
   source_net_id?: string
-  shape: "circle"
-  center: Point
-  radius: Length
+  shape: "brep"
+  brep_shape: BRepShape
 }
-expectTypesMatch<PcbCopperPourCircle, InferredPcbCopperPourCircle>(true)
+expectTypesMatch<PcbCopperPourBRep, InferredPcbCopperPourBRep>(true)
 
 // Polygon Pour
 export const pcb_copper_pour_polygon = pcb_copper_pour_base.extend({
@@ -93,7 +92,7 @@ expectTypesMatch<PcbCopperPourPolygon, InferredPcbCopperPourPolygon>(true)
 export const pcb_copper_pour = z
   .discriminatedUnion("shape", [
     pcb_copper_pour_rect,
-    pcb_copper_pour_circle,
+    pcb_copper_pour_brep,
     pcb_copper_pour_polygon,
   ])
   .describe("Defines a copper pour on the PCB.")
@@ -101,7 +100,7 @@ export const pcb_copper_pour = z
 export type PcbCopperPourInput = z.input<typeof pcb_copper_pour>
 export type PcbCopperPour =
   | PcbCopperPourRect
-  | PcbCopperPourCircle
+  | PcbCopperPourBRep
   | PcbCopperPourPolygon
 
 type InferredPcbCopperPour = z.infer<typeof pcb_copper_pour>

--- a/src/pcb/properties/brep.ts
+++ b/src/pcb/properties/brep.ts
@@ -28,7 +28,7 @@ expectTypesMatch<Ring, InferredRing>(true)
 
 export const brep_shape = z.object({
   outer_ring: ring,
-  inner_rings: z.array(ring),
+  inner_rings: z.array(ring).default([]),
 })
 
 /**

--- a/src/pcb/properties/brep.ts
+++ b/src/pcb/properties/brep.ts
@@ -17,23 +17,32 @@ type InferredPointWithBulge = z.infer<typeof point_with_bulge>
 expectTypesMatch<PointWithBulge, InferredPointWithBulge>(true)
 
 export const ring = z.object({
-  cwVertices: z.array(point_with_bulge),
+  vertices: z.array(point_with_bulge),
 })
 
 export interface Ring {
-  cwVertices: PointWithBulge[]
+  vertices: PointWithBulge[]
 }
 type InferredRing = z.infer<typeof ring>
 expectTypesMatch<Ring, InferredRing>(true)
 
 export const brep_shape = z.object({
-  outerRing: ring,
-  innerRings: z.array(ring),
+  outer_ring: ring,
+  inner_rings: z.array(ring),
 })
 
+/**
+ * B-rep shape defined by an outer ring and inner rings (holes).
+ */
 export interface BRepShape {
-  outerRing: Ring
-  innerRings: Ring[]
+  /**
+   * The outer boundary of the shape. Vertices must be in clockwise order.
+   */
+  outer_ring: Ring
+  /**
+   * Inner boundaries (holes). Vertices must be in counter-clockwise order.
+   */
+  inner_rings: Ring[]
 }
 type InferredBRepShape = z.infer<typeof brep_shape>
 expectTypesMatch<BRepShape, InferredBRepShape>(true)

--- a/src/pcb/properties/brep.ts
+++ b/src/pcb/properties/brep.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { distance } from "src/units"
+import { distance, type Distance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export const point_with_bulge = z.object({
@@ -9,8 +9,8 @@ export const point_with_bulge = z.object({
 })
 
 export interface PointWithBulge {
-  x: number
-  y: number
+  x: Distance
+  y: Distance
   bulge?: number
 }
 type InferredPointWithBulge = z.infer<typeof point_with_bulge>

--- a/src/pcb/properties/brep.ts
+++ b/src/pcb/properties/brep.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+import { distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const point_with_bulge = z.object({
+  x: distance,
+  y: distance,
+  bulge: z.number().optional(),
+})
+
+export interface PointWithBulge {
+  x: number
+  y: number
+  bulge?: number
+}
+type InferredPointWithBulge = z.infer<typeof point_with_bulge>
+expectTypesMatch<PointWithBulge, InferredPointWithBulge>(true)
+
+export const ring = z.object({
+  cwVertices: z.array(point_with_bulge),
+})
+
+export interface Ring {
+  cwVertices: PointWithBulge[]
+}
+type InferredRing = z.infer<typeof ring>
+expectTypesMatch<Ring, InferredRing>(true)
+
+export const brep_shape = z.object({
+  outerRing: ring,
+  innerRings: z.array(ring),
+})
+
+export interface BRepShape {
+  outerRing: Ring
+  innerRings: Ring[]
+}
+type InferredBRepShape = z.infer<typeof brep_shape>
+expectTypesMatch<BRepShape, InferredBRepShape>(true)

--- a/tests/pcb_copper_pour.test.ts
+++ b/tests/pcb_copper_pour.test.ts
@@ -20,18 +20,25 @@ test("pcb_copper_pour rect parses", () => {
   expect(any_circuit_element.parse(pour)).toBeDefined()
 })
 
-test("pcb_copper_pour circle parses", () => {
+test("pcb_copper_pour brep parses", () => {
   const pour = pcb_copper_pour.parse({
     type: "pcb_copper_pour",
-    shape: "circle",
-    center: { x: 0, y: 0 },
-    radius: 5,
+    shape: "brep",
+    brep_shape: {
+      outerRing: {
+        cwVertices: [
+          { x: 0, y: 0, bulge: 1 },
+          { x: 1, y: 1 },
+        ],
+      },
+      innerRings: [],
+    },
     layer: "top",
     source_net_id: "net1",
   })
-  expect(pour.shape).toBe("circle")
-  if (pour.shape === "circle") {
-    expect(pour.radius).toBe(5)
+  expect(pour.shape).toBe("brep")
+  if (pour.shape === "brep") {
+    expect(pour.brep_shape.outerRing.cwVertices.length).toBe(2)
   }
   expect((pour as any).pcb_copper_pour_id).toBeDefined()
   expect(any_circuit_element.parse(pour)).toBeDefined()

--- a/tests/pcb_copper_pour.test.ts
+++ b/tests/pcb_copper_pour.test.ts
@@ -25,20 +25,20 @@ test("pcb_copper_pour brep parses", () => {
     type: "pcb_copper_pour",
     shape: "brep",
     brep_shape: {
-      outerRing: {
-        cwVertices: [
+      outer_ring: {
+        vertices: [
           { x: 0, y: 0, bulge: 1 },
           { x: 1, y: 1 },
         ],
       },
-      innerRings: [],
+      inner_rings: [],
     },
     layer: "top",
     source_net_id: "net1",
   })
   expect(pour.shape).toBe("brep")
   if (pour.shape === "brep") {
-    expect(pour.brep_shape.outerRing.cwVertices.length).toBe(2)
+    expect(pour.brep_shape.outer_ring.vertices.length).toBe(2)
   }
   expect((pour as any).pcb_copper_pour_id).toBeDefined()
   expect(any_circuit_element.parse(pour)).toBeDefined()

--- a/tests/pcb_copper_pour.test.ts
+++ b/tests/pcb_copper_pour.test.ts
@@ -31,7 +31,6 @@ test("pcb_copper_pour brep parses", () => {
           { x: 1, y: 1 },
         ],
       },
-      inner_rings: [],
     },
     layer: "top",
     source_net_id: "net1",
@@ -39,6 +38,7 @@ test("pcb_copper_pour brep parses", () => {
   expect(pour.shape).toBe("brep")
   if (pour.shape === "brep") {
     expect(pour.brep_shape.outer_ring.vertices.length).toBe(2)
+    expect(pour.brep_shape.inner_rings).toEqual([])
   }
   expect((pour as any).pcb_copper_pour_id).toBeDefined()
   expect(any_circuit_element.parse(pour)).toBeDefined()


### PR DESCRIPTION
This pull request modifies the pcb_copper_pour element by replacing the circle shape option with a more flexible brep (Boundary        
Representation) shape. This allows for defining more complex copper pour geometries, including those with arcs.                        

The changes include:                                                                                                                   

 • Removing PcbCopperPourCircle.                                                                                                       
 • Adding PcbCopperPourBRep and its supporting types (BRepShape, Ring, PointWithBulge).                                                
 • Updating the tests to reflect the removal of the circle shape and the addition of the BRep shape.