### PR TITLE
feat(cad): Add model_glb_url and model_step_url to cad_component

### DIFF
--- a/src/cad/cad_component.ts
+++ b/src/cad/cad_component.ts
@@ -22,6 +22,8 @@ export const cad_component = z
     model_stl_url: z.string().optional(),
     model_3mf_url: z.string().optional(),
     model_gltf_url: z.string().optional(),
+    model_glb_url: z.string().optional(),
+    model_step_url: z.string().optional(),
     model_jscad: z.any().optional(),
   })
   .describe("Defines a component on the PCB")
@@ -44,6 +46,8 @@ export interface CadComponent {
   model_stl_url?: string
   model_3mf_url?: string
   model_gltf_url?: string
+  model_glb_url?: string
+  model_step_url?: string
   model_jscad?: any
 }
 


### PR DESCRIPTION
This change introduces support for .glb and .step 3D models by adding optional model_glb_url and model_step_url properties to cad_component.ts.    
This makes the cad_component consistent with other 3D model formats and expands its modeling capabilities.