### PR TITLE
feat: add external footprint load error

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [SourceTrace](#sourcetrace)
     - [SourceTraceNotConnectedError](#sourcetracenotconnectederror)
   - [PCB Elements](#pcb-elements)
+    - [ExternalFootprintLoadError](#externalfootprintloaderror)
     - [PcbAutoroutingError](#pcbautoroutingerror)
     - [PcbBoard](#pcbboard)
     - [PcbBreakoutPoint](#pcbbreakoutpoint)
@@ -716,6 +717,27 @@ interface SourceTraceNotConnectedError {
 ```
 
 ## PCB Elements
+
+### ExternalFootprintLoadError
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/external_footprint_load_error.ts)
+
+Defines an error that occurs when an external footprint fails to load
+
+```typescript
+/** Defines an error that occurs when an external footprint fails to load */
+interface ExternalFootprintLoadError {
+  type: "external_footprint_load_error"
+  external_footprint_load_error_id: string
+  pcb_component_id: string
+  source_component_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  footprinter_string?: string
+  error_type: "external_footprint_load_error"
+  message: string
+}
+```
 
 ### PcbAutoroutingError
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -44,6 +44,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_component,
   pcb.pcb_hole,
   pcb.pcb_missing_footprint_error,
+  pcb.external_footprint_load_error,
   pcb.pcb_manual_edit_conflict_warning,
   pcb.pcb_plated_hole,
   pcb.pcb_keepout,

--- a/src/pcb/external_footprint_load_error.ts
+++ b/src/pcb/external_footprint_load_error.ts
@@ -1,0 +1,45 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const external_footprint_load_error = z
+  .object({
+    type: z.literal("external_footprint_load_error"),
+    external_footprint_load_error_id: getZodPrefixedIdWithDefault(
+      "external_footprint_load_error",
+    ),
+    pcb_component_id: z.string(),
+    source_component_id: z.string(),
+    pcb_group_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+    footprinter_string: z.string().optional(),
+    error_type: z
+      .literal("external_footprint_load_error")
+      .default("external_footprint_load_error"),
+    message: z.string(),
+  })
+  .describe("Defines an error when an external footprint fails to load")
+
+export type ExternalFootprintLoadErrorInput = z.input<
+  typeof external_footprint_load_error
+>
+type InferredExternalFootprintLoadError = z.infer<
+  typeof external_footprint_load_error
+>
+
+export interface ExternalFootprintLoadError {
+  type: "external_footprint_load_error"
+  external_footprint_load_error_id: string
+  pcb_component_id: string
+  source_component_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  footprinter_string?: string
+  error_type: "external_footprint_load_error"
+  message: string
+}
+
+expectTypesMatch<
+  ExternalFootprintLoadError,
+  InferredExternalFootprintLoadError
+>(true)

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -32,6 +32,7 @@ export * from "./pcb_footprint_overlap_error"
 export * from "./pcb_keepout"
 export * from "./pcb_cutout"
 export * from "./pcb_missing_footprint_error"
+export * from "./external_footprint_load_error"
 export * from "./pcb_group"
 export * from "./pcb_autorouting_error"
 export * from "./pcb_manual_edit_conflict_warning"
@@ -57,6 +58,7 @@ import type { PcbVia } from "./pcb_via"
 import type { PcbBoard } from "./pcb_board"
 import type { PcbPlacementError } from "./pcb_placement_error"
 import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
+import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
 import type { PcbTraceHint } from "./pcb_trace_hint"
 import type { PcbSilkscreenLine } from "./pcb_silkscreen_line"
@@ -85,6 +87,7 @@ export type PcbCircuitElement =
   | PcbTraceError
   | PcbTraceMissingError
   | PcbMissingFootprintError
+  | ExternalFootprintLoadError
   | PcbManualEditConflictWarning
   | PcbPortNotMatchedError
   | PcbPortNotConnectedError

--- a/tests/external_footprint_load_error.test.ts
+++ b/tests/external_footprint_load_error.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { external_footprint_load_error } from "../src/pcb/external_footprint_load_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("external_footprint_load_error parses", () => {
+  const error = external_footprint_load_error.parse({
+    type: "external_footprint_load_error",
+    message: "failed to load footprint",
+    pcb_component_id: "pcb1",
+    source_component_id: "src1",
+  })
+  expect(error.external_footprint_load_error_id).toBeDefined()
+  expect(
+    error.external_footprint_load_error_id.startsWith(
+      "external_footprint_load_error",
+    ),
+  ).toBe(true)
+})
+
+test("any_circuit_element includes external_footprint_load_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "external_footprint_load_error",
+    message: "failed to load footprint",
+    pcb_component_id: "pcb1",
+    source_component_id: "src1",
+  })
+  expect(parsed.type).toBe("external_footprint_load_error")
+})


### PR DESCRIPTION
## Summary
- add external_footprint_load_error with optional footprinter_string and component metadata
- expose external_footprint_load_error through pcb and circuit unions
- document external footprint load error and add tests

## Testing
- `bun test tests/external_footprint_load_error.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bfb9b6273c832eb758e251bfe2857d