### PR TITLE
feat: add error type for components outside board boundaries

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -78,6 +78,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_ground_plane_region,
   pcb.pcb_thermal_spoke,
   pcb.pcb_copper_pour,
+  pcb.pcb_component_outside_board_error,
   sch.schematic_box,
   sch.schematic_text,
   sch.schematic_line,
@@ -148,6 +149,7 @@ expectStringUnionsMatch<
   | "pcb_port_not_matched_error DOES NOT HAVE AN pcb_port_not_matched_error_id PROPERTY"
   | "pcb_autorouting_error DOES NOT HAVE AN pcb_autorouting_error_id PROPERTY"
   | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
+  | "pcb_component_outside_board_error DOES NOT HAVE AN pcb_component_outside_board_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"
   | "schematic_box DOES NOT HAVE AN schematic_box_id PROPERTY"
   | "schematic_line DOES NOT HAVE AN schematic_line_id PROPERTY"

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -149,7 +149,6 @@ expectStringUnionsMatch<
   | "pcb_port_not_matched_error DOES NOT HAVE AN pcb_port_not_matched_error_id PROPERTY"
   | "pcb_autorouting_error DOES NOT HAVE AN pcb_autorouting_error_id PROPERTY"
   | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
-  | "pcb_component_outside_board_error DOES NOT HAVE AN pcb_component_outside_board_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"
   | "schematic_box DOES NOT HAVE AN schematic_box_id PROPERTY"
   | "schematic_line DOES NOT HAVE AN schematic_line_id PROPERTY"

--- a/src/common/CircuitJsonError.ts
+++ b/src/common/CircuitJsonError.ts
@@ -5,6 +5,7 @@ import type {
   PcbAutoroutingError,
   PcbFootprintOverlapError,
   PcbMissingFootprintError,
+  PcbComponentOutsideBoardError,
 } from "src/pcb"
 import type { SchematicError } from "src/schematic"
 
@@ -15,4 +16,5 @@ export type CircuitJsonError =
   | PcbAutoroutingError
   | PcbFootprintOverlapError
   | PcbMissingFootprintError
+  | PcbComponentOutsideBoardError
   | SchematicError

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -41,6 +41,7 @@ export * from "./pcb_ground_plane"
 export * from "./pcb_ground_plane_region"
 export * from "./pcb_thermal_spoke"
 export * from "./pcb_copper_pour"
+export * from "./pcb_component_outside_board_error"
 
 import type { PcbComponent } from "./pcb_component"
 import type { PcbHole } from "./pcb_hole"
@@ -74,6 +75,7 @@ import type { PcbGroundPlane } from "./pcb_ground_plane"
 import type { PcbGroundPlaneRegion } from "./pcb_ground_plane_region"
 import type { PcbThermalSpoke } from "./pcb_thermal_spoke"
 import type { PcbCopperPour } from "./pcb_copper_pour"
+import type { PcbComponentOutsideBoardError } from "./pcb_component_outside_board_error"
 
 export type PcbCircuitElement =
   | PcbComponent
@@ -108,3 +110,4 @@ export type PcbCircuitElement =
   | PcbGroundPlaneRegion
   | PcbThermalSpoke
   | PcbCopperPour
+  | PcbComponentOutsideBoardError

--- a/src/pcb/pcb_component_outside_board_error.ts
+++ b/src/pcb/pcb_component_outside_board_error.ts
@@ -1,0 +1,71 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { point, type Point } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_component_outside_board_error = z
+  .object({
+    type: z.literal("pcb_component_outside_board_error"),
+    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    error_type: z
+      .literal("pcb_component_outside_board_error")
+      .default("pcb_component_outside_board_error"),
+    message: z.string(),
+    pcb_component_id: z.string(),
+    pcb_board_id: z.string(),
+    component_center: point,
+    component_bounds: z.object({
+      min_x: z.number(),
+      max_x: z.number(),
+      min_y: z.number(),
+      max_y: z.number(),
+    }),
+    board_bounds: z.object({
+      min_x: z.number(),
+      max_x: z.number(),
+      min_y: z.number(),
+      max_y: z.number(),
+    }),
+    subcircuit_id: z.string().optional(),
+    source_component_id: z.string().optional(),
+  })
+  .describe(
+    "Error emitted when a PCB component is placed outside the board boundaries",
+  )
+
+export type PcbComponentOutsideBoardErrorInput = z.input<
+  typeof pcb_component_outside_board_error
+>
+type InferredPcbComponentOutsideBoardError = z.infer<
+  typeof pcb_component_outside_board_error
+>
+
+/** Error emitted when a PCB component is placed outside the board boundaries */
+export interface PcbComponentOutsideBoardError {
+  type: "pcb_component_outside_board_error"
+  pcb_error_id: string
+  error_type: "pcb_component_outside_board_error"
+  message: string
+  pcb_component_id: string
+  pcb_board_id: string
+  component_center: Point
+  component_bounds: {
+    min_x: number
+    max_x: number
+    min_y: number
+    max_y: number
+  }
+  board_bounds: {
+    min_x: number
+    max_x: number
+    min_y: number
+    max_y: number
+  }
+  subcircuit_id?: string
+  source_component_id?: string
+}
+
+expectTypesMatch<
+  PcbComponentOutsideBoardError,
+  InferredPcbComponentOutsideBoardError
+>(true)

--- a/src/pcb/pcb_component_outside_board_error.ts
+++ b/src/pcb/pcb_component_outside_board_error.ts
@@ -6,7 +6,9 @@ import { expectTypesMatch } from "src/utils/expect-types-match"
 export const pcb_component_outside_board_error = z
   .object({
     type: z.literal("pcb_component_outside_board_error"),
-    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    pcb_component_outside_board_error_id: getZodPrefixedIdWithDefault(
+      "pcb_component_outside_board_error",
+    ),
     error_type: z
       .literal("pcb_component_outside_board_error")
       .default("pcb_component_outside_board_error"),
@@ -15,12 +17,6 @@ export const pcb_component_outside_board_error = z
     pcb_board_id: z.string(),
     component_center: point,
     component_bounds: z.object({
-      min_x: z.number(),
-      max_x: z.number(),
-      min_y: z.number(),
-      max_y: z.number(),
-    }),
-    board_bounds: z.object({
       min_x: z.number(),
       max_x: z.number(),
       min_y: z.number(),
@@ -43,19 +39,13 @@ type InferredPcbComponentOutsideBoardError = z.infer<
 /** Error emitted when a PCB component is placed outside the board boundaries */
 export interface PcbComponentOutsideBoardError {
   type: "pcb_component_outside_board_error"
-  pcb_error_id: string
+  pcb_component_outside_board_error_id: string
   error_type: "pcb_component_outside_board_error"
   message: string
   pcb_component_id: string
   pcb_board_id: string
   component_center: Point
   component_bounds: {
-    min_x: number
-    max_x: number
-    min_y: number
-    max_y: number
-  }
-  board_bounds: {
     min_x: number
     max_x: number
     min_y: number

--- a/tests/pcb_component_outside_board_error.test.ts
+++ b/tests/pcb_component_outside_board_error.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test"
+import { pcb_component_outside_board_error } from "src/pcb/pcb_component_outside_board_error"
+import { any_circuit_element } from "src/any_circuit_element"
+
+test("pcb_component_outside_board_error parses", () => {
+  const errorData = {
+    type: "pcb_component_outside_board_error",
+    pcb_error_id: "error_1",
+    message:
+      "Component R1 (pcb_component_1) is placed outside board boundaries at (15, 20)",
+    pcb_component_id: "pcb_component_1",
+    pcb_board_id: "pcb_board_1",
+    component_center: { x: 15, y: 20 },
+    component_bounds: {
+      min_x: 10,
+      max_x: 20,
+      min_y: 15,
+      max_y: 25,
+    },
+    board_bounds: {
+      min_x: 0,
+      max_x: 10,
+      min_y: 0,
+      max_y: 10,
+    },
+    source_component_id: "source_component_1",
+  }
+
+  const parsed = pcb_component_outside_board_error.parse(errorData)
+
+  expect(parsed.type).toBe("pcb_component_outside_board_error")
+  expect(parsed.error_type).toBe("pcb_component_outside_board_error")
+  expect(parsed.message).toContain("Component R1")
+  expect(parsed.pcb_component_id).toBe("pcb_component_1")
+  expect(parsed.pcb_board_id).toBe("pcb_board_1")
+  expect(parsed.component_center.x).toBe(15)
+  expect(parsed.component_center.y).toBe(20)
+  expect(parsed.component_bounds.min_x).toBe(10)
+  expect(parsed.component_bounds.max_x).toBe(20)
+  expect(parsed.board_bounds.min_x).toBe(0)
+  expect(parsed.board_bounds.max_x).toBe(10)
+})
+
+test("any_circuit_element includes pcb_component_outside_board_error", () => {
+  const errorData = {
+    type: "pcb_component_outside_board_error",
+    pcb_error_id: "error_1",
+    message: "Component outside board",
+    pcb_component_id: "pcb_component_1",
+    pcb_board_id: "pcb_board_1",
+    component_center: { x: 15, y: 20 },
+    component_bounds: {
+      min_x: 10,
+      max_x: 20,
+      min_y: 15,
+      max_y: 25,
+    },
+    board_bounds: {
+      min_x: 0,
+      max_x: 10,
+      min_y: 0,
+      max_y: 10,
+    },
+  }
+
+  expect(() => any_circuit_element.parse(errorData)).not.toThrow()
+})

--- a/tests/pcb_component_outside_board_error.test.ts
+++ b/tests/pcb_component_outside_board_error.test.ts
@@ -5,7 +5,7 @@ import { any_circuit_element } from "src/any_circuit_element"
 test("pcb_component_outside_board_error parses", () => {
   const errorData = {
     type: "pcb_component_outside_board_error",
-    pcb_error_id: "error_1",
+    pcb_component_outside_board_error_id: "error_1",
     message:
       "Component R1 (pcb_component_1) is placed outside board boundaries at (15, 20)",
     pcb_component_id: "pcb_component_1",
@@ -16,12 +16,6 @@ test("pcb_component_outside_board_error parses", () => {
       max_x: 20,
       min_y: 15,
       max_y: 25,
-    },
-    board_bounds: {
-      min_x: 0,
-      max_x: 10,
-      min_y: 0,
-      max_y: 10,
     },
     source_component_id: "source_component_1",
   }
@@ -37,14 +31,12 @@ test("pcb_component_outside_board_error parses", () => {
   expect(parsed.component_center.y).toBe(20)
   expect(parsed.component_bounds.min_x).toBe(10)
   expect(parsed.component_bounds.max_x).toBe(20)
-  expect(parsed.board_bounds.min_x).toBe(0)
-  expect(parsed.board_bounds.max_x).toBe(10)
 })
 
 test("any_circuit_element includes pcb_component_outside_board_error", () => {
   const errorData = {
     type: "pcb_component_outside_board_error",
-    pcb_error_id: "error_1",
+    pcb_component_outside_board_error_id: "error_1",
     message: "Component outside board",
     pcb_component_id: "pcb_component_1",
     pcb_board_id: "pcb_board_1",
@@ -54,12 +46,6 @@ test("any_circuit_element includes pcb_component_outside_board_error", () => {
       max_x: 20,
       min_y: 15,
       max_y: 25,
-    },
-    board_bounds: {
-      min_x: 0,
-      max_x: 10,
-      min_y: 0,
-      max_y: 10,
     },
   }
 


### PR DESCRIPTION
Add PcbComponentOutsideBoardError to detect when PCB components are placed
outside the board's physical boundaries, with detailed positioning data
for debugging and automated correction.

this is first step for https://github.com/tscircuit/core/issues/1323