### PR TITLE
feat: add optional model unit scale for CAD components

### DIFF
--- a/src/cad/cad_component.ts
+++ b/src/cad/cad_component.ts
@@ -25,6 +25,7 @@ export const cad_component = z
     model_glb_url: z.string().optional(),
     model_step_url: z.string().optional(),
     model_wrl_url: z.string().optional(),
+    model_unit_to_mm_scale_factor: z.number().optional(),
     model_jscad: z.any().optional(),
   })
   .describe("Defines a component on the PCB")
@@ -50,6 +51,7 @@ export interface CadComponent {
   model_glb_url?: string
   model_step_url?: string
   model_wrl_url?: string
+  model_unit_to_mm_scale_factor?: number
   model_jscad?: any
 }
 

--- a/tests/cad_component_model_unit_to_mm_scale_factor_optional.test.ts
+++ b/tests/cad_component_model_unit_to_mm_scale_factor_optional.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { cad_component } from "../src/cad/cad_component"
+
+test("cad_component.model_unit_to_mm_scale_factor is optional", () => {
+  const component = cad_component.parse({
+    type: "cad_component",
+    cad_component_id: "cad1",
+    pcb_component_id: "pcb1",
+    source_component_id: "src1",
+    position: { x: 0, y: 0, z: 0 },
+  })
+  expect(component.model_unit_to_mm_scale_factor).toBeUndefined()
+})
+
+test("cad_component.model_unit_to_mm_scale_factor parses number", () => {
+  const component = cad_component.parse({
+    type: "cad_component",
+    cad_component_id: "cad2",
+    pcb_component_id: "pcb2",
+    source_component_id: "src2",
+    position: { x: 0, y: 0, z: 0 },
+    model_unit_to_mm_scale_factor: 25.4,
+  })
+  expect(component.model_unit_to_mm_scale_factor).toBe(25.4)
+})


### PR DESCRIPTION
## Summary
- add optional `model_unit_to_mm_scale_factor` to CAD component schema
- test optional numeric field on CAD component

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c102d5f904832eaaa4b5c2ab930a2a