### PR TITLE
feat: add hole offset to circular plated holes with rectangular pads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,8 @@ interface PcbHoleCircularWithRectPad {
   hole_diameter: number
   rect_pad_width: number
   rect_pad_height: number
+  hole_x: Distance
+  hole_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -163,7 +163,9 @@ export interface PcbHoleCircularWithRectPad {
   pad_shape: "rect"
   hole_diameter: number
   rect_pad_width: number
-  rect_pad_height: number 
+  rect_pad_height: number
+  hole_x: Distance
+  hole_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/src/pcb/pcb_plated_hole.ts
+++ b/src/pcb/pcb_plated_hole.ts
@@ -88,6 +88,8 @@ const pcb_circular_hole_with_rect_pad = z.object({
   hole_diameter: z.number(),
   rect_pad_width: z.number(),
   rect_pad_height: z.number(),
+  hole_x: distance,
+  hole_y: distance,
   x: distance,
   y: distance,
   layers: z.array(layer_ref),
@@ -188,6 +190,8 @@ export interface PcbHoleCircularWithRectPad {
   hole_diameter: number
   rect_pad_width: number
   rect_pad_height: number
+  hole_x: Distance
+  hole_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]


### PR DESCRIPTION
## Summary
- allow circular plated holes to specify hole_x and hole_y offsets
- document hole_x and hole_y for circular hole with rect pad

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68c15fcef5f88327b9c30a22c2d6629b