### PR TITLE
feat: add rect border radius to plated holes and smtpads

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -164,6 +164,7 @@ export interface PcbHoleCircularWithRectPad {
   hole_diameter: number
   rect_pad_width: number
   rect_pad_height: number
+  rect_border_radius?: number
   hole_offset_x: Distance
   hole_offset_y: Distance
   x: Distance
@@ -296,6 +297,7 @@ export interface PcbSmtPadRect {
   y: Distance
   width: number
   height: number
+  rect_border_radius?: number
   layer: LayerRef
   port_hints?: string[]
   pcb_component_id?: string

--- a/src/pcb/pcb_plated_hole.ts
+++ b/src/pcb/pcb_plated_hole.ts
@@ -88,6 +88,7 @@ const pcb_circular_hole_with_rect_pad = z.object({
   hole_diameter: z.number(),
   rect_pad_width: z.number(),
   rect_pad_height: z.number(),
+  rect_border_radius: z.number().optional(),
   hole_offset_x: distance.default(0),
   hole_offset_y: distance.default(0),
   x: distance,
@@ -109,6 +110,7 @@ const pcb_pill_hole_with_rect_pad = z.object({
   hole_height: z.number(),
   rect_pad_width: z.number(),
   rect_pad_height: z.number(),
+  rect_border_radius: z.number().optional(),
   x: distance,
   y: distance,
   layers: z.array(layer_ref),
@@ -129,6 +131,7 @@ const pcb_rotated_pill_hole_with_rect_pad = z.object({
   hole_ccw_rotation: rotation,
   rect_pad_width: z.number(),
   rect_pad_height: z.number(),
+  rect_border_radius: z.number().optional(),
   rect_ccw_rotation: rotation,
   x: distance,
   y: distance,
@@ -149,6 +152,7 @@ export interface PcbHolePillWithRectPad {
   hole_height: number
   rect_pad_width: number
   rect_pad_height: number
+  rect_border_radius?: number
   x: Distance
   y: Distance
   layers: LayerRef[]
@@ -170,6 +174,7 @@ export interface PcbHoleRotatedPillWithRectPad {
   hole_ccw_rotation: Rotation
   rect_pad_width: number
   rect_pad_height: number
+  rect_border_radius?: number
   rect_ccw_rotation: Rotation
   x: Distance
   y: Distance
@@ -190,6 +195,7 @@ export interface PcbHoleCircularWithRectPad {
   hole_diameter: number
   rect_pad_width: number
   rect_pad_height: number
+  rect_border_radius?: number
   hole_offset_x: Distance
   hole_offset_y: Distance
   x: Distance

--- a/src/pcb/pcb_smtpad.ts
+++ b/src/pcb/pcb_smtpad.ts
@@ -29,6 +29,7 @@ const pcb_smtpad_rect = z.object({
   y: distance,
   width: z.number(),
   height: z.number(),
+  rect_border_radius: z.number().optional(),
   layer: layer_ref,
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
@@ -45,6 +46,7 @@ const pcb_smtpad_rotated_rect = z.object({
   y: distance,
   width: z.number(),
   height: z.number(),
+  rect_border_radius: z.number().optional(),
   ccw_rotation: rotation,
   layer: layer_ref,
   port_hints: z.array(z.string()).optional(),
@@ -149,6 +151,7 @@ export interface PcbSmtPadRect {
   y: Distance
   width: number
   height: number
+  rect_border_radius?: number
   layer: LayerRef
   port_hints?: string[]
   pcb_component_id?: string
@@ -168,6 +171,7 @@ export interface PcbSmtPadRotatedRect {
   y: Distance
   width: number
   height: number
+  rect_border_radius?: number
   ccw_rotation: Rotation
   layer: LayerRef
   port_hints?: string[]

--- a/tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
+++ b/tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
@@ -15,6 +15,7 @@ test("parse rotated pill hole with rect pad", () => {
     hole_ccw_rotation: 45,
     rect_pad_width: 3,
     rect_pad_height: 4,
+    rect_border_radius: 0.1,
     rect_ccw_rotation: 45,
     x: 0,
     y: 0,
@@ -22,4 +23,5 @@ test("parse rotated pill hole with rect pad", () => {
   })
   expect(hole.shape).toBe("rotated_pill_hole_with_rect_pad")
   expect((hole as PcbHoleRotatedPillWithRectPad).hole_ccw_rotation).toBe(45)
+  expect((hole as PcbHoleRotatedPillWithRectPad).rect_border_radius).toBe(0.1)
 })

--- a/tests/pcb_smtpad_rect.test.ts
+++ b/tests/pcb_smtpad_rect.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { pcb_smtpad, type PcbSmtPadRect } from "../src/pcb/pcb_smtpad"
+
+test("parse rect smt pad with border radius", () => {
+  const pad = pcb_smtpad.parse({
+    type: "pcb_smtpad",
+    shape: "rect",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 2,
+    rect_border_radius: 0.1,
+    layer: "top",
+  })
+  expect(pad.shape).toBe("rect")
+  expect((pad as PcbSmtPadRect).rect_border_radius).toBe(0.1)
+})


### PR DESCRIPTION
## Summary
- add optional `rect_border_radius` to plated hole types using rectangular pads
- support `rect_border_radius` on rectangular and rotated SMT pads
- document new `rect_border_radius` option
- test rectangular pad border radius parsing

## Testing
- `bunx tsc --noEmit`
- `bun test tests/pcb_rotated_pill_hole_with_rect_pad.test.ts tests/pcb_smtpad_rect.test.ts`
- `bun scripts/generate-pcb-component-overview.ts` *(fails: Could not resolve authentication method)*

------
https://chatgpt.com/codex/tasks/task_b_68c446b41c0c832eadbb2a44e7d65620