### PR TITLE
feat: add `is_covered_with_solder_mask` option to smt pads

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -287,6 +287,7 @@ export interface PcbSmtPadCircle {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 export interface PcbSmtPadRect {
@@ -302,6 +303,7 @@ export interface PcbSmtPadRect {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 
@@ -316,6 +318,7 @@ export interface PcbSmtPadPolygon {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 

--- a/src/pcb/pcb_smtpad.ts
+++ b/src/pcb/pcb_smtpad.ts
@@ -17,6 +17,7 @@ const pcb_smtpad_circle = z.object({
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
+  is_covered_with_solder_mask: z.boolean().optional(),
 })
 
 const pcb_smtpad_rect = z.object({
@@ -34,6 +35,7 @@ const pcb_smtpad_rect = z.object({
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
+  is_covered_with_solder_mask: z.boolean().optional(),
 })
 
 const pcb_smtpad_rotated_rect = z.object({
@@ -52,6 +54,7 @@ const pcb_smtpad_rotated_rect = z.object({
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
+  is_covered_with_solder_mask: z.boolean().optional(),
 })
 
 export const pcb_smtpad_pill = z.object({
@@ -69,6 +72,7 @@ export const pcb_smtpad_pill = z.object({
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
+  is_covered_with_solder_mask: z.boolean().optional(),
 })
 const pcb_smtpad_rotated_pill = z.object({
   type: z.literal("pcb_smtpad"),
@@ -86,6 +90,7 @@ const pcb_smtpad_rotated_pill = z.object({
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
+  is_covered_with_solder_mask: z.boolean().optional(),
 })
 
 const pcb_smtpad_polygon = z.object({
@@ -99,6 +104,7 @@ const pcb_smtpad_polygon = z.object({
   port_hints: z.array(z.string()).optional(),
   pcb_component_id: z.string().optional(),
   pcb_port_id: z.string().optional(),
+  is_covered_with_solder_mask: z.boolean().optional(),
 })
 
 export const pcb_smtpad = z
@@ -136,6 +142,7 @@ export interface PcbSmtPadCircle {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 /**
@@ -156,6 +163,7 @@ export interface PcbSmtPadRect {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 /**
@@ -177,6 +185,7 @@ export interface PcbSmtPadRotatedRect {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 /**
  * Defines a pill-shaped SMT pad on the PCB (rounded rectangle).
@@ -196,6 +205,7 @@ export interface PcbSmtPadPill {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 /**
@@ -217,6 +227,7 @@ export interface PcbSmtPadRotatedPill {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 /**
@@ -233,6 +244,7 @@ export interface PcbSmtPadPolygon {
   port_hints?: string[]
   pcb_component_id?: string
   pcb_port_id?: string
+  is_covered_with_solder_mask?: boolean
 }
 
 export type PcbSmtPad =

--- a/tests/pcb_smtpad_rect.test.ts
+++ b/tests/pcb_smtpad_rect.test.ts
@@ -11,7 +11,9 @@ test("parse rect smt pad with border radius", () => {
     height: 2,
     rect_border_radius: 0.1,
     layer: "top",
+    is_covered_with_solder_mask: true,
   })
   expect(pad.shape).toBe("rect")
   expect((pad as PcbSmtPadRect).rect_border_radius).toBe(0.1)
+  expect((pad as PcbSmtPadRect).is_covered_with_solder_mask).toBe(true)
 })


### PR DESCRIPTION
## Summary
- add optional `is_covered_with_solder_mask` flag to all `pcb_smtpad` shapes
- document new solder mask coverage field for SMT pads
- test parsing an SMT pad with solder mask coverage

## Testing
- `bunx tsc --noEmit`
- `bun test tests/pcb_smtpad_rect.test.ts tests/pcb_smtpad_polygon.test.ts tests/pcb_rotated_pill_smtpad.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c7033d5eac832eb16603443cc91b50