### PR TITLE
Add board pinout flag to pcb_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,7 @@ interface PcbPort {
   x: Distance
   y: Distance
   layers: LayerRef[]
+  is_board_pinout?: boolean
 }
 ```
 

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -274,6 +274,7 @@ export interface PcbPort {
   x: Distance
   y: Distance
   layers: LayerRef[]
+  is_board_pinout?: boolean
 }
 
 export interface PcbSmtPadCircle {

--- a/src/pcb/pcb_port.ts
+++ b/src/pcb/pcb_port.ts
@@ -15,6 +15,7 @@ export const pcb_port = z
     x: distance,
     y: distance,
     layers: z.array(layer_ref),
+    is_board_pinout: z.boolean().optional(),
   })
   .describe("Defines a port on the PCB")
 
@@ -34,6 +35,7 @@ export interface PcbPort {
   x: Distance
   y: Distance
   layers: LayerRef[]
+  is_board_pinout?: boolean
 }
 
 /**

--- a/tests/pcb_port.test.ts
+++ b/tests/pcb_port.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "bun:test"
+import { pcb_port } from "../src/pcb/pcb_port"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_port parses with is_board_pinout", () => {
+  const port = pcb_port.parse({
+    type: "pcb_port",
+    source_port_id: "source_port_1",
+    pcb_component_id: "pcb_component_1",
+    x: 0,
+    y: 0,
+    layers: ["top"],
+    is_board_pinout: true,
+  })
+
+  expect(port.is_board_pinout).toBe(true)
+})
+
+test("pcb_port parses without is_board_pinout", () => {
+  const port = pcb_port.parse({
+    type: "pcb_port",
+    source_port_id: "source_port_2",
+    pcb_component_id: "pcb_component_2",
+    x: 1,
+    y: 1,
+    layers: ["bottom"],
+  })
+
+  expect(port.is_board_pinout).toBeUndefined()
+})
+
+test("any_circuit_element includes pcb_port with is_board_pinout", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_port",
+    source_port_id: "source_port_3",
+    pcb_component_id: "pcb_component_3",
+    x: 2,
+    y: 3,
+    layers: ["top"],
+    is_board_pinout: false,
+  })
+
+  expect(parsed.type).toBe("pcb_port")
+  if (parsed.type !== "pcb_port") {
+    throw new Error("expected pcb_port")
+  }
+  expect(parsed.is_board_pinout).toBe(false)
+})


### PR DESCRIPTION
## Summary
- add optional `is_board_pinout` support to the pcb_port schema and type definitions
- document the new pcb_port property in the README and PCB component overview
- cover parsing of pcb_port with the board pinout flag, including via any_circuit_element

## Testing
- bun test tests/pcb_port.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c84f8eeab8832e9f3edc0ccfe88f9f