### PR TITLE
Add hole offsets to rectangular pad plated holes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,8 @@ interface PcbHolePillWithRectPad {
   rect_pad_width: number
   rect_pad_height: number
   rect_border_radius?: number
+  hole_offset_x: Distance
+  hole_offset_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]
@@ -1137,6 +1139,8 @@ interface PcbHoleRotatedPillWithRectPad {
   rect_pad_height: number
   rect_border_radius?: number
   rect_ccw_rotation: Rotation
+  hole_offset_x: Distance
+  hole_offset_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -176,7 +176,56 @@ export interface PcbHoleCircularWithRectPad {
   pcb_plated_hole_id: string
 }
 
-export type PcbPlatedHole = PcbPlatedHoleCircle | PcbPlatedHoleOval | PcbHoleCircularWithRectPad
+export interface PcbHolePillWithRectPad {
+  type: "pcb_plated_hole"
+  shape: "pill_hole_with_rect_pad"
+  hole_shape: "pill"
+  pad_shape: "rect"
+  hole_width: number
+  hole_height: number
+  rect_pad_width: number
+  rect_pad_height: number
+  rect_border_radius?: number
+  hole_offset_x: Distance
+  hole_offset_y: Distance
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
+export interface PcbHoleRotatedPillWithRectPad {
+  type: "pcb_plated_hole"
+  shape: "rotated_pill_hole_with_rect_pad"
+  hole_shape: "rotated_pill"
+  pad_shape: "rect"
+  hole_width: number
+  hole_height: number
+  hole_ccw_rotation: Rotation
+  rect_pad_width: number
+  rect_pad_height: number
+  rect_border_radius?: number
+  rect_ccw_rotation: Rotation
+  hole_offset_x: Distance
+  hole_offset_y: Distance
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
+export type PcbPlatedHole =
+  | PcbPlatedHoleCircle
+  | PcbPlatedHoleOval
+  | PcbHoleCircularWithRectPad
+  | PcbHolePillWithRectPad
+  | PcbHoleRotatedPillWithRectPad
 
 export interface PcbFabricationNoteText {
   type: "pcb_fabrication_note_text"

--- a/src/pcb/pcb_plated_hole.ts
+++ b/src/pcb/pcb_plated_hole.ts
@@ -113,6 +113,8 @@ const pcb_pill_hole_with_rect_pad = z.object({
   rect_pad_width: z.number(),
   rect_pad_height: z.number(),
   rect_border_radius: z.number().optional(),
+  hole_offset_x: distance.default(0),
+  hole_offset_y: distance.default(0),
   x: distance,
   y: distance,
   layers: z.array(layer_ref),
@@ -135,6 +137,8 @@ const pcb_rotated_pill_hole_with_rect_pad = z.object({
   rect_pad_height: z.number(),
   rect_border_radius: z.number().optional(),
   rect_ccw_rotation: rotation,
+  hole_offset_x: distance.default(0),
+  hole_offset_y: distance.default(0),
   x: distance,
   y: distance,
   layers: z.array(layer_ref),
@@ -155,6 +159,8 @@ export interface PcbHolePillWithRectPad {
   rect_pad_width: number
   rect_pad_height: number
   rect_border_radius?: number
+  hole_offset_x: Distance
+  hole_offset_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]
@@ -178,6 +184,8 @@ export interface PcbHoleRotatedPillWithRectPad {
   rect_pad_height: number
   rect_border_radius?: number
   rect_ccw_rotation: Rotation
+  hole_offset_x: Distance
+  hole_offset_y: Distance
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/tests/pcb_pill_hole_with_rect_pad.test.ts
+++ b/tests/pcb_pill_hole_with_rect_pad.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import {
+  pcb_plated_hole,
+  type PcbHolePillWithRectPad,
+} from "../src/pcb/pcb_plated_hole"
+
+test("parse pill hole with rect pad defaults hole offset to 0", () => {
+  const hole = pcb_plated_hole.parse({
+    type: "pcb_plated_hole",
+    shape: "pill_hole_with_rect_pad",
+    hole_shape: "pill",
+    pad_shape: "rect",
+    hole_width: 1,
+    hole_height: 2,
+    rect_pad_width: 3,
+    rect_pad_height: 4,
+    x: 0,
+    y: 0,
+    layers: ["top"],
+  }) as PcbHolePillWithRectPad
+
+  expect(hole.hole_offset_x).toBe(0)
+  expect(hole.hole_offset_y).toBe(0)
+})
+
+test("parse pill hole with rect pad and offsets", () => {
+  const hole = pcb_plated_hole.parse({
+    type: "pcb_plated_hole",
+    shape: "pill_hole_with_rect_pad",
+    hole_shape: "pill",
+    pad_shape: "rect",
+    hole_width: 1,
+    hole_height: 2,
+    rect_pad_width: 3,
+    rect_pad_height: 4,
+    hole_offset_x: 0.5,
+    hole_offset_y: -0.25,
+    x: 0,
+    y: 0,
+    layers: ["top"],
+  }) as PcbHolePillWithRectPad
+
+  expect(hole.hole_offset_x).toBe(0.5)
+  expect(hole.hole_offset_y).toBe(-0.25)
+})

--- a/tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
+++ b/tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
@@ -24,4 +24,30 @@ test("parse rotated pill hole with rect pad", () => {
   expect(hole.shape).toBe("rotated_pill_hole_with_rect_pad")
   expect((hole as PcbHoleRotatedPillWithRectPad).hole_ccw_rotation).toBe(45)
   expect((hole as PcbHoleRotatedPillWithRectPad).rect_border_radius).toBe(0.1)
+  expect((hole as PcbHoleRotatedPillWithRectPad).hole_offset_x).toBe(0)
+  expect((hole as PcbHoleRotatedPillWithRectPad).hole_offset_y).toBe(0)
+})
+
+test("parse rotated pill hole with rect pad and offsets", () => {
+  const hole = pcb_plated_hole.parse({
+    type: "pcb_plated_hole",
+    shape: "rotated_pill_hole_with_rect_pad",
+    hole_shape: "rotated_pill",
+    pad_shape: "rect",
+    hole_width: 1,
+    hole_height: 2,
+    hole_ccw_rotation: 45,
+    rect_pad_width: 3,
+    rect_pad_height: 4,
+    rect_border_radius: 0.1,
+    rect_ccw_rotation: 45,
+    hole_offset_x: 0.2,
+    hole_offset_y: -0.3,
+    x: 0,
+    y: 0,
+    layers: ["top"],
+  }) as PcbHoleRotatedPillWithRectPad
+
+  expect(hole.hole_offset_x).toBe(0.2)
+  expect(hole.hole_offset_y).toBe(-0.3)
 })


### PR DESCRIPTION
## Summary
- add `hole_offset_x`/`hole_offset_y` support to pill and rotated pill plated holes with rectangular pads
- document the new offset fields alongside the plated hole type definitions
- extend test coverage to verify default and custom offsets for these plated holes

## Testing
- bun test tests/pcb_rotated_pill_hole_with_rect_pad.test.ts
- bun test tests/pcb_pill_hole_with_rect_pad.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c8a3db0854833097164b53f22ef104