### PR TITLE
Add pcb net definition and rats nest color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbHole](#pcbhole)
     - [PcbManualEditConflictWarning](#pcbmanualeditconflictwarning)
     - [PcbMissingFootprintError](#pcbmissingfootprinterror)
+    - [PcbNet](#pcbnet)
     - [PcbPlacementError](#pcbplacementerror)
     - [PcbPlatedHole](#pcbplatedhole)
     - [PcbPort](#pcbport)
@@ -1061,6 +1062,22 @@ interface PcbMissingFootprintError {
   error_type: "pcb_missing_footprint_error"
   source_component_id: string
   message: string
+}
+```
+
+### PcbNet
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_net.ts)
+
+Defines a net on the PCB
+
+```typescript
+/** Defines a net on the PCB */
+interface PcbNet {
+  type: "pcb_net"
+  pcb_net_id: string
+  source_net_id?: string
+  rats_nest_color?: string
 }
 ```
 

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -434,11 +434,22 @@ export interface PcbTrace {
   type: "pcb_trace"
   source_trace_id?: string
   pcb_component_id?: string
+  pcb_group_id?: string
+  subcircuit_id?: string
   pcb_trace_id: string
   route_order_index?: number
   route_thickness_mode?: "constant" | "interpolated"
   should_round_corners?: boolean
+  trace_length?: number
+  rats_nest_color?: string
   route: Array<PcbTraceRoutePoint>
+}
+
+export interface PcbNet {
+  type: "pcb_net"
+  pcb_net_id: string
+  source_net_id?: string
+  rats_nest_color?: string
 }
 
 export interface PcbBreakoutPoint {

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -50,6 +50,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_plated_hole,
   pcb.pcb_keepout,
   pcb.pcb_port,
+  pcb.pcb_net,
   pcb.pcb_text,
   pcb.pcb_trace,
   pcb.pcb_via,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -16,6 +16,7 @@ export * from "./pcb_trace_error"
 export * from "./pcb_trace_missing_error"
 export * from "./pcb_port_not_matched_error"
 export * from "./pcb_port_not_connected_error"
+export * from "./pcb_net"
 export * from "./pcb_via"
 export * from "./pcb_board"
 export * from "./pcb_placement_error"
@@ -57,6 +58,7 @@ import type { PcbTraceMissingError } from "./pcb_trace_missing_error"
 import type { PcbPortNotMatchedError } from "./pcb_port_not_matched_error"
 import type { PcbPortNotConnectedError } from "./pcb_port_not_connected_error"
 import type { PcbVia } from "./pcb_via"
+import type { PcbNet } from "./pcb_net"
 import type { PcbBoard } from "./pcb_board"
 import type { PcbPlacementError } from "./pcb_placement_error"
 import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
@@ -97,6 +99,7 @@ export type PcbCircuitElement =
   | PcbPortNotMatchedError
   | PcbPortNotConnectedError
   | PcbVia
+  | PcbNet
   | PcbBoard
   | PcbPlacementError
   | PcbTraceHint

--- a/src/pcb/pcb_net.ts
+++ b/src/pcb/pcb_net.ts
@@ -1,0 +1,27 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_net = z
+  .object({
+    type: z.literal("pcb_net"),
+    pcb_net_id: getZodPrefixedIdWithDefault("pcb_net"),
+    source_net_id: z.string().optional(),
+    rats_nest_color: z.string().optional(),
+  })
+  .describe("Defines a net on the PCB")
+
+export type PcbNetInput = z.input<typeof pcb_net>
+type InferredPcbNet = z.infer<typeof pcb_net>
+
+/**
+ * Defines a net on the PCB
+ */
+export interface PcbNet {
+  type: "pcb_net"
+  pcb_net_id: string
+  source_net_id?: string
+  rats_nest_color?: string
+}
+
+expectTypesMatch<PcbNet, InferredPcbNet>(true)

--- a/src/pcb/pcb_trace.ts
+++ b/src/pcb/pcb_trace.ts
@@ -45,6 +45,7 @@ export const pcb_trace = z
     route_order_index: z.number().optional(),
     should_round_corners: z.boolean().optional(),
     trace_length: z.number().optional(),
+    rats_nest_color: z.string().optional(),
     route: z.array(pcb_trace_route_point),
   })
   .describe("Defines a trace on the PCB")
@@ -94,6 +95,7 @@ export interface PcbTrace {
   route_thickness_mode?: "constant" | "interpolated"
   should_round_corners?: boolean
   trace_length?: number
+  rats_nest_color?: string
   route: Array<PcbTraceRoutePoint>
 }
 

--- a/tests/pcb_net.test.ts
+++ b/tests/pcb_net.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { pcb_net } from "../src/pcb/pcb_net"
+
+test("pcb_net optional fields default to undefined", () => {
+  const net = pcb_net.parse({
+    type: "pcb_net",
+  })
+
+  expect(net.pcb_net_id).toBeDefined()
+  expect(net.pcb_net_id.startsWith("pcb_net")).toBe(true)
+  expect(net.source_net_id).toBeUndefined()
+  expect(net.rats_nest_color).toBeUndefined()
+})
+
+test("pcb_net optional fields can be provided", () => {
+  const net = pcb_net.parse({
+    type: "pcb_net",
+    pcb_net_id: "pcb_net_123",
+    source_net_id: "source_net_1",
+    rats_nest_color: "#ffaa00",
+  })
+
+  expect(net.pcb_net_id).toBe("pcb_net_123")
+  expect(net.source_net_id).toBe("source_net_1")
+  expect(net.rats_nest_color).toBe("#ffaa00")
+})

--- a/tests/pcb_trace_rats_nest_color.test.ts
+++ b/tests/pcb_trace_rats_nest_color.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { pcb_trace } from "../src/pcb/pcb_trace"
+
+test("pcb_trace.rats_nest_color defaults to undefined", () => {
+  const trace = pcb_trace.parse({
+    type: "pcb_trace",
+    route: [
+      {
+        route_type: "wire",
+        x: 0,
+        y: 0,
+        width: 0.2,
+        layer: "top",
+      },
+    ],
+  })
+
+  expect(trace.rats_nest_color).toBeUndefined()
+})
+
+test("pcb_trace.rats_nest_color can be specified", () => {
+  const trace = pcb_trace.parse({
+    type: "pcb_trace",
+    rats_nest_color: "#00ffcc",
+    route: [
+      {
+        route_type: "wire",
+        x: 1,
+        y: 1,
+        width: 0.3,
+        layer: "bottom",
+      },
+    ],
+  })
+
+  expect(trace.rats_nest_color).toBe("#00ffcc")
+})


### PR DESCRIPTION
## Summary
- add optional rats_nest_color to pcb_trace definitions and docs
- introduce pcb_net type with optional source_net_id and rats_nest_color and wire it into exports
- document new type and add targeted parsing tests

## Testing
- bun test tests/pcb_net.test.ts
- bun test tests/pcb_trace_rats_nest_color.test.ts
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68ca39452294832ebd5b98d77473dcb5