### PR TITLE
Add default is_box_with_pins flag to schematic component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1698,6 +1698,7 @@ interface SchematicComponent {
   schematic_group_id?: string
   is_schematic_group?: boolean
   source_group_id?: string
+  is_box_with_pins: boolean
 }
 
 interface SchematicPortArrangementBySize {

--- a/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
+++ b/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
@@ -103,6 +103,7 @@ interface SchematicComponent {
         }
       }
   port_labels?: Record<string, string>
+  is_box_with_pins: boolean
 }
 
 interface SchematicDebugRect {

--- a/src/schematic/schematic_component.ts
+++ b/src/schematic/schematic_component.ts
@@ -59,6 +59,7 @@ export interface SchematicComponent {
   schematic_group_id?: string
   is_schematic_group?: boolean
   source_group_id?: string
+  is_box_with_pins: boolean
 }
 
 export const schematic_component_port_arrangement_by_size = z.object({
@@ -131,6 +132,7 @@ export const schematic_component = z.object({
   schematic_group_id: z.string().optional(),
   is_schematic_group: z.boolean().optional(),
   source_group_id: z.string().optional(),
+  is_box_with_pins: z.boolean().optional().default(true),
 })
 
 export type SchematicComponentInput = z.input<typeof schematic_component>

--- a/tests/schematic_component.test.ts
+++ b/tests/schematic_component.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { schematic_component } from "../src/schematic/schematic_component"
+
+const baseComponent = {
+  type: "schematic_component" as const,
+  size: { width: 10, height: 5 },
+  center: { x: 0, y: 0 },
+  schematic_component_id: "schem_comp_1",
+}
+
+test("schematic_component defaults to box with pins", () => {
+  const component = schematic_component.parse(baseComponent)
+
+  expect(component.is_box_with_pins).toBe(true)
+})
+
+test("schematic_component allows disabling box with pins", () => {
+  const component = schematic_component.parse({
+    ...baseComponent,
+    is_box_with_pins: false,
+  })
+
+  expect(component.is_box_with_pins).toBe(false)
+})


### PR DESCRIPTION
## Summary
- add an `is_box_with_pins` flag to schematic components with a default of `true`
- update the schematic component documentation to mention the new flag
- add tests covering the defaulted flag and explicit overrides

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_b_68cb0b0ef47c8327be9a7bc09066e924