### PR TITLE
Rename rats nest color field to highlight color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ interface PcbNet {
   type: "pcb_net"
   pcb_net_id: string
   source_net_id?: string
-  rats_nest_color?: string
+  highlight_color?: string
 }
 ```
 

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -441,7 +441,7 @@ export interface PcbTrace {
   route_thickness_mode?: "constant" | "interpolated"
   should_round_corners?: boolean
   trace_length?: number
-  rats_nest_color?: string
+  highlight_color?: string
   route: Array<PcbTraceRoutePoint>
 }
 
@@ -449,7 +449,7 @@ export interface PcbNet {
   type: "pcb_net"
   pcb_net_id: string
   source_net_id?: string
-  rats_nest_color?: string
+  highlight_color?: string
 }
 
 export interface PcbBreakoutPoint {

--- a/src/pcb/pcb_net.ts
+++ b/src/pcb/pcb_net.ts
@@ -7,7 +7,7 @@ export const pcb_net = z
     type: z.literal("pcb_net"),
     pcb_net_id: getZodPrefixedIdWithDefault("pcb_net"),
     source_net_id: z.string().optional(),
-    rats_nest_color: z.string().optional(),
+    highlight_color: z.string().optional(),
   })
   .describe("Defines a net on the PCB")
 
@@ -21,7 +21,7 @@ export interface PcbNet {
   type: "pcb_net"
   pcb_net_id: string
   source_net_id?: string
-  rats_nest_color?: string
+  highlight_color?: string
 }
 
 expectTypesMatch<PcbNet, InferredPcbNet>(true)

--- a/src/pcb/pcb_trace.ts
+++ b/src/pcb/pcb_trace.ts
@@ -45,7 +45,7 @@ export const pcb_trace = z
     route_order_index: z.number().optional(),
     should_round_corners: z.boolean().optional(),
     trace_length: z.number().optional(),
-    rats_nest_color: z.string().optional(),
+    highlight_color: z.string().optional(),
     route: z.array(pcb_trace_route_point),
   })
   .describe("Defines a trace on the PCB")
@@ -95,7 +95,7 @@ export interface PcbTrace {
   route_thickness_mode?: "constant" | "interpolated"
   should_round_corners?: boolean
   trace_length?: number
-  rats_nest_color?: string
+  highlight_color?: string
   route: Array<PcbTraceRoutePoint>
 }
 

--- a/tests/pcb_net.test.ts
+++ b/tests/pcb_net.test.ts
@@ -9,7 +9,7 @@ test("pcb_net optional fields default to undefined", () => {
   expect(net.pcb_net_id).toBeDefined()
   expect(net.pcb_net_id.startsWith("pcb_net")).toBe(true)
   expect(net.source_net_id).toBeUndefined()
-  expect(net.rats_nest_color).toBeUndefined()
+  expect(net.highlight_color).toBeUndefined()
 })
 
 test("pcb_net optional fields can be provided", () => {
@@ -17,10 +17,10 @@ test("pcb_net optional fields can be provided", () => {
     type: "pcb_net",
     pcb_net_id: "pcb_net_123",
     source_net_id: "source_net_1",
-    rats_nest_color: "#ffaa00",
+    highlight_color: "#ffaa00",
   })
 
   expect(net.pcb_net_id).toBe("pcb_net_123")
   expect(net.source_net_id).toBe("source_net_1")
-  expect(net.rats_nest_color).toBe("#ffaa00")
+  expect(net.highlight_color).toBe("#ffaa00")
 })

--- a/tests/pcb_trace_highlight_color.test.ts
+++ b/tests/pcb_trace_highlight_color.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { pcb_trace } from "../src/pcb/pcb_trace"
 
-test("pcb_trace.rats_nest_color defaults to undefined", () => {
+test("pcb_trace.highlight_color defaults to undefined", () => {
   const trace = pcb_trace.parse({
     type: "pcb_trace",
     route: [
@@ -15,13 +15,13 @@ test("pcb_trace.rats_nest_color defaults to undefined", () => {
     ],
   })
 
-  expect(trace.rats_nest_color).toBeUndefined()
+  expect(trace.highlight_color).toBeUndefined()
 })
 
-test("pcb_trace.rats_nest_color can be specified", () => {
+test("pcb_trace.highlight_color can be specified", () => {
   const trace = pcb_trace.parse({
     type: "pcb_trace",
-    rats_nest_color: "#00ffcc",
+    highlight_color: "#00ffcc",
     route: [
       {
         route_type: "wire",
@@ -33,5 +33,5 @@ test("pcb_trace.rats_nest_color can be specified", () => {
     ],
   })
 
-  expect(trace.rats_nest_color).toBe("#00ffcc")
+  expect(trace.highlight_color).toBe("#00ffcc")
 })


### PR DESCRIPTION
## Summary
- rename the pcb net and trace schemas and types to use the new `highlight_color` property
- update documentation and tests to reference `highlight_color`

## Testing
- bunx tsc --noEmit
- bun test tests/pcb_net.test.ts
- bun test tests/pcb_trace_highlight_color.test.ts
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68cf107870c4832e99a3062f353f0055