### PR TITLE
Add do_not_place flag to source component base

### DIFF
--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -17,6 +17,7 @@ export interface SourceComponentBase {
   internally_connected_source_port_ids?: string[][]
   source_group_id?: string
   subcircuit_id?: string
+  do_not_place: boolean
 }
 
 export const source_component_base = z.object({
@@ -33,6 +34,7 @@ export const source_component_base = z.object({
   internally_connected_source_port_ids: z.array(z.array(z.string())).optional(),
   source_group_id: z.string().optional(),
   subcircuit_id: z.string().optional(),
+  do_not_place: z.boolean().default(false),
 })
 
 type InferredSourceComponentBase = z.infer<typeof source_component_base>

--- a/src/source/source_simple_pin_header.ts
+++ b/src/source/source_simple_pin_header.ts
@@ -1,4 +1,7 @@
-import { source_component_base } from "src/source/base/source_component_base"
+import {
+  source_component_base,
+  type SourceComponentBase,
+} from "src/source/base/source_component_base"
 import { z } from "zod"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
@@ -13,7 +16,7 @@ export type SourceSimplePinHeaderInput = z.input<
 >
 type InferredSourceSimplePinHeader = z.infer<typeof source_simple_pin_header>
 
-export interface SourceSimplePinHeader extends SourceSimplePinHeaderInput {
+export interface SourceSimplePinHeader extends SourceComponentBase {
   ftype: "simple_pin_header"
   pin_count: number
   gender: "male" | "female"

--- a/src/source/source_simple_potentiometer.ts
+++ b/src/source/source_simple_potentiometer.ts
@@ -1,5 +1,8 @@
 import { z } from "zod"
-import { source_component_base } from "src/source/base/source_component_base"
+import {
+  source_component_base,
+  type SourceComponentBase,
+} from "src/source/base/source_component_base"
 import { resistance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
@@ -15,8 +18,7 @@ type InferredSourceSimplePotentiometer = z.infer<
   typeof source_simple_potentiometer
 >
 
-export interface SourceSimplePotentiometer
-  extends SourceSimplePotentiometerInput {
+export interface SourceSimplePotentiometer extends SourceComponentBase {
   ftype: "simple_potentiometer"
   max_resistance: number
 }


### PR DESCRIPTION
## Summary
- add a `do_not_place` boolean with a default of `false` to the source component base schema
- align source simple pin header and potentiometer interfaces with `SourceComponentBase`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d0579d38ec8327af5f6c9fb8883056