### PR TITLE
Move do_not_place flag to PCB component

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ interface SourceComponentBase {
   internally_connected_source_port_ids?: string[][]
   source_group_id?: string
   subcircuit_id?: string
-  do_not_place: boolean
 }
 ```
 
@@ -825,6 +824,7 @@ interface PcbComponent {
   rotation: Rotation
   width: Length
   height: Length
+  do_not_place: boolean
   pcb_group_id?: string
 }
 ```

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -14,6 +14,7 @@ export const pcb_component = z
     rotation: rotation,
     width: length,
     height: length,
+    do_not_place: z.boolean().optional().default(false),
     subcircuit_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
   })
@@ -35,6 +36,7 @@ export interface PcbComponent {
   rotation: Rotation
   width: Length
   height: Length
+  do_not_place: boolean
   pcb_group_id?: string
 }
 

--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -17,7 +17,6 @@ export interface SourceComponentBase {
   internally_connected_source_port_ids?: string[][]
   source_group_id?: string
   subcircuit_id?: string
-  do_not_place: boolean
 }
 
 export const source_component_base = z.object({
@@ -34,7 +33,6 @@ export const source_component_base = z.object({
   internally_connected_source_port_ids: z.array(z.array(z.string())).optional(),
   source_group_id: z.string().optional(),
   subcircuit_id: z.string().optional(),
-  do_not_place: z.boolean().optional().default(false),
 })
 
 type InferredSourceComponentBase = z.infer<typeof source_component_base>


### PR DESCRIPTION
## Summary
- remove the `do_not_place` field from the source component schema
- add the `do_not_place` flag to the PCB component schema and documentation

## Testing
- npm run lint:zod

------
https://chatgpt.com/codex/tasks/task_b_68d079367b488327ba432043b3b00830