### PR TITLE
Add schematic pin arrangement schema support for schematic box groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ interface SourceFailedToCreateComponentError {
 [Source](https://github.com/tscircuit/circuit-json/blob/main/src/source/source_group.ts)
 
 ```typescript
+type SchematicPinArrangement = SchematicPortArrangement
+
 interface SourceGroup {
   type: "source_group"
   source_group_id: string
@@ -274,6 +276,8 @@ interface SourceGroup {
   parent_source_group_id?: string
   is_subcircuit?: boolean
   show_as_schematic_box?: boolean
+  schematic_box_port_alias_map?: Record<string, string>
+  schematic_box_pin_arrangement?: SchematicPinArrangement
   name?: string
 }
 ```
@@ -1717,13 +1721,14 @@ interface SchematicComponent {
   >
   box_width?: number
   symbol_name?: string
-  port_arrangement?: SchematicPortArrangement
+  schematic_pin_arrangement?: SchematicPinArrangement
   port_labels?: Record<string, string>
   symbol_display_value?: string
   subcircuit_id?: string
   schematic_group_id?: string
   is_schematic_group?: boolean
   source_group_id?: string
+  schematic_box_port_alias_map?: Record<string, string>
   is_box_with_pins: boolean
 }
 
@@ -1735,11 +1740,20 @@ interface SchematicPortArrangementBySize {
 }
 
 interface SchematicPortArrangementBySides {
-  left_side?: { pins: number[]; direction?: "top-to-bottom" | "bottom-to-top" }
-  right_side?: { pins: number[]; direction?: "top-to-bottom" | "bottom-to-top" }
-  top_side?: { pins: number[]; direction?: "left-to-right" | "right-to-left" }
+  left_side?: {
+    pins: Array<number | string>
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  right_side?: {
+    pins: Array<number | string>
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  top_side?: {
+    pins: Array<number | string>
+    direction?: "left-to-right" | "right-to-left"
+  }
   bottom_side?: {
-    pins: number[]
+    pins: Array<number | string>
     direction?: "left-to-right" | "right-to-left"
   }
 }
@@ -1819,6 +1833,8 @@ interface SchematicGroup {
   center: Point
   schematic_component_ids: string[]
   show_as_schematic_box?: boolean
+  schematic_box_port_alias_map?: Record<string, string>
+  schematic_box_pin_arrangement?: SchematicPinArrangement
   name?: string
   description?: string
 }

--- a/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
+++ b/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
@@ -58,6 +58,36 @@ interface SchematicError {
   message: string
 }
 
+type SchematicPortArrangementBySize = {
+  left_size: number
+  right_size: number
+  top_size?: number
+  bottom_size?: number
+}
+
+type SchematicPortArrangementBySides = {
+  left_side?: {
+    pins: Array<number | string>
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  right_side?: {
+    pins: Array<number | string>
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  top_side?: {
+    pins: Array<number | string>
+    direction?: "left-to-right" | "right-to-left"
+  }
+  bottom_side?: {
+    pins: Array<number | string>
+    direction?: "left-to-right" | "right-to-left"
+  }
+}
+
+type SchematicPinArrangement =
+  | SchematicPortArrangementBySize
+  | SchematicPortArrangementBySides
+
 interface SchematicComponent {
   type: "schematic_component"
   rotation: number
@@ -77,32 +107,9 @@ interface SchematicComponent {
   >
   box_width?: number
   symbol_name?: string
-  port_arrangement?:
-    | {
-        left_size: number
-        right_size: number
-        top_size?: number
-        bottom_size?: number
-      }
-    | {
-        left_side?: {
-          pins: number[]
-          direction?: "top-to-bottom" | "bottom-to-top"
-        }
-        right_side?: {
-          pins: number[]
-          direction?: "top-to-bottom" | "bottom-to-top"
-        }
-        top_side?: {
-          pins: number[]
-          direction?: "left-to-right" | "right-to-left"
-        }
-        bottom_side?: {
-          pins: number[]
-          direction?: "left-to-right" | "right-to-left"
-        }
-      }
+  schematic_pin_arrangement?: SchematicPinArrangement
   port_labels?: Record<string, string>
+  schematic_box_port_alias_map?: Record<string, string>
   is_box_with_pins: boolean
 }
 

--- a/src/schematic/schematic_component.ts
+++ b/src/schematic/schematic_component.ts
@@ -20,12 +20,23 @@ export interface SchematicPortArrangementBySize {
   bottom_size?: number
 }
 
+export type SchematicPortArrangementPin = number | string
+
 export interface SchematicPortArrangementBySides {
-  left_side?: { pins: number[]; direction?: "top-to-bottom" | "bottom-to-top" }
-  right_side?: { pins: number[]; direction?: "top-to-bottom" | "bottom-to-top" }
-  top_side?: { pins: number[]; direction?: "left-to-right" | "right-to-left" }
+  left_side?: {
+    pins: SchematicPortArrangementPin[]
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  right_side?: {
+    pins: SchematicPortArrangementPin[]
+    direction?: "top-to-bottom" | "bottom-to-top"
+  }
+  top_side?: {
+    pins: SchematicPortArrangementPin[]
+    direction?: "left-to-right" | "right-to-left"
+  }
   bottom_side?: {
-    pins: number[]
+    pins: SchematicPortArrangementPin[]
     direction?: "left-to-right" | "right-to-left"
   }
 }
@@ -33,6 +44,8 @@ export interface SchematicPortArrangementBySides {
 export type SchematicPortArrangement =
   | SchematicPortArrangementBySize
   | SchematicPortArrangementBySides
+
+export type SchematicPinArrangement = SchematicPortArrangement
 
 export interface SchematicComponent {
   type: "schematic_component"
@@ -52,13 +65,16 @@ export interface SchematicComponent {
   >
   box_width?: number
   symbol_name?: string
+  /** @deprecated use schematic_pin_arrangement */
   port_arrangement?: SchematicPortArrangement
+  schematic_pin_arrangement?: SchematicPinArrangement
   port_labels?: Record<string, string>
   symbol_display_value?: string
   subcircuit_id?: string
   schematic_group_id?: string
   is_schematic_group?: boolean
   source_group_id?: string
+  schematic_box_port_alias_map?: Record<string, string>
   is_box_with_pins: boolean
 }
 
@@ -74,31 +90,33 @@ expectTypesMatch<
   z.infer<typeof schematic_component_port_arrangement_by_size>
 >(true)
 
+const schematic_port_arrangement_pin = z.union([z.number(), z.string()])
+
 export const schematic_component_port_arrangement_by_sides = z.object({
   left_side: z
     .object({
-      pins: z.array(z.number()),
+      pins: z.array(schematic_port_arrangement_pin),
       // @ts-ignore
       direction: z.enum(["top-to-bottom", "bottom-to-top"]).optional(),
     })
     .optional(),
   right_side: z
     .object({
-      pins: z.array(z.number()),
+      pins: z.array(schematic_port_arrangement_pin),
       // @ts-ignore
       direction: z.enum(["top-to-bottom", "bottom-to-top"]).optional(),
     })
     .optional(),
   top_side: z
     .object({
-      pins: z.array(z.number()),
+      pins: z.array(schematic_port_arrangement_pin),
       // @ts-ignore
       direction: z.enum(["left-to-right", "right-to-left"]).optional(),
     })
     .optional(),
   bottom_side: z
     .object({
-      pins: z.array(z.number()),
+      pins: z.array(schematic_port_arrangement_pin),
       // @ts-ignore
       direction: z.enum(["left-to-right", "right-to-left"]).optional(),
     })
@@ -110,10 +128,12 @@ expectTypesMatch<
   z.infer<typeof schematic_component_port_arrangement_by_sides>
 >(true)
 
-export const port_arrangement = z.union([
+export const schematic_pin_arrangement = z.union([
   schematic_component_port_arrangement_by_size,
   schematic_component_port_arrangement_by_sides,
 ])
+
+export const port_arrangement = schematic_pin_arrangement
 
 export const schematic_component = z.object({
   type: z.literal("schematic_component"),
@@ -125,13 +145,15 @@ export const schematic_component = z.object({
   pin_styles: schematic_pin_styles.optional(),
   box_width: length.optional(),
   symbol_name: z.string().optional(),
-  port_arrangement: port_arrangement.optional(),
+  port_arrangement: schematic_pin_arrangement.optional(),
+  schematic_pin_arrangement: schematic_pin_arrangement.optional(),
   port_labels: z.record(z.string()).optional(),
   symbol_display_value: z.string().optional(),
   subcircuit_id: z.string().optional(),
   schematic_group_id: z.string().optional(),
   is_schematic_group: z.boolean().optional(),
   source_group_id: z.string().optional(),
+  schematic_box_port_alias_map: z.record(z.string()).optional(),
   is_box_with_pins: z.boolean().optional().default(true),
 })
 

--- a/src/schematic/schematic_group.ts
+++ b/src/schematic/schematic_group.ts
@@ -2,6 +2,10 @@ import { z } from "zod"
 import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
 import { length, type Length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import {
+  schematic_pin_arrangement,
+  type SchematicPinArrangement,
+} from "./schematic_component"
 
 export const schematic_group = z
   .object({
@@ -15,6 +19,8 @@ export const schematic_group = z
     center: point,
     schematic_component_ids: z.array(z.string()),
     show_as_schematic_box: z.boolean().optional(),
+    schematic_box_port_alias_map: z.record(z.string()).optional(),
+    schematic_box_pin_arrangement: schematic_pin_arrangement.optional(),
     name: z.string().optional(),
     description: z.string().optional(),
   })
@@ -37,6 +43,8 @@ export interface SchematicGroup {
   center: Point
   schematic_component_ids: string[]
   show_as_schematic_box?: boolean
+  schematic_box_port_alias_map?: Record<string, string>
+  schematic_box_pin_arrangement?: SchematicPinArrangement
   name?: string
   description?: string
 }

--- a/src/source/source_group.ts
+++ b/src/source/source_group.ts
@@ -1,5 +1,9 @@
 import { z } from "zod"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import {
+  schematic_pin_arrangement,
+  type SchematicPinArrangement,
+} from "../schematic/schematic_component"
 
 export const source_group = z.object({
   type: z.literal("source_group"),
@@ -9,6 +13,8 @@ export const source_group = z.object({
   parent_source_group_id: z.string().optional(),
   is_subcircuit: z.boolean().optional(),
   show_as_schematic_box: z.boolean().optional(),
+  schematic_box_port_alias_map: z.record(z.string()).optional(),
+  schematic_box_pin_arrangement: schematic_pin_arrangement.optional(),
   name: z.string().optional(),
 })
 
@@ -23,6 +29,8 @@ export interface SourceGroup {
   parent_source_group_id?: string
   is_subcircuit?: boolean
   show_as_schematic_box?: boolean
+  schematic_box_port_alias_map?: Record<string, string>
+  schematic_box_pin_arrangement?: SchematicPinArrangement
   name?: string
 }
 

--- a/tests/schematic_component_pin_arrangement_strings.test.ts
+++ b/tests/schematic_component_pin_arrangement_strings.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { schematic_component } from "../src/schematic/schematic_component"
+
+test("schematic_component accepts schematic_pin_arrangement with string pins", () => {
+  const parsed = schematic_component.parse({
+    type: "schematic_component",
+    schematic_component_id: "schem_comp_1",
+    size: { width: 10, height: 10 },
+    center: { x: 0, y: 0 },
+    is_box_with_pins: true,
+    schematic_box_port_alias_map: { D1: "source_port_1" },
+    schematic_pin_arrangement: {
+      left_side: {
+        pins: ["D1"],
+      },
+    },
+  })
+
+  const arrangement = parsed.schematic_pin_arrangement
+  if (!arrangement || !("left_side" in arrangement)) {
+    throw new Error("expected left_side pins to be present")
+  }
+
+  expect(arrangement.left_side?.pins).toEqual(["D1"])
+  expect(parsed.schematic_box_port_alias_map?.D1).toBe("source_port_1")
+})

--- a/tests/schematic_component_port_arrangement_legacy.test.ts
+++ b/tests/schematic_component_port_arrangement_legacy.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { schematic_component } from "../src/schematic/schematic_component"
+
+test("schematic_component still accepts legacy port_arrangement", () => {
+  const parsed = schematic_component.parse({
+    type: "schematic_component",
+    schematic_component_id: "schem_comp_legacy",
+    size: { width: 10, height: 10 },
+    center: { x: 0, y: 0 },
+    is_box_with_pins: true,
+    port_arrangement: {
+      left_side: {
+        pins: [1, 2, 3],
+      },
+    },
+  })
+
+  expect(parsed.port_arrangement).toBeDefined()
+})

--- a/tests/source_group_schematic_box_pin_arrangement.test.ts
+++ b/tests/source_group_schematic_box_pin_arrangement.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { source_group } from "../src/source/source_group"
+import type { SchematicPortArrangementBySides } from "../src/schematic/schematic_component"
+
+test("source_group supports schematic box alias map and pin arrangement", () => {
+  const parsed = source_group.parse({
+    type: "source_group",
+    source_group_id: "group_1",
+    schematic_box_port_alias_map: { D1: "source_port_1" },
+    schematic_box_pin_arrangement: {
+      left_side: {
+        pins: ["D1"],
+      },
+    },
+  })
+
+  expect(parsed.schematic_box_port_alias_map?.D1).toBe("source_port_1")
+
+  const arrangement = parsed.schematic_box_pin_arrangement
+  if (!arrangement || !("left_side" in arrangement)) {
+    throw new Error("expected left_side arrangement to exist")
+  }
+
+  const sides = arrangement as SchematicPortArrangementBySides
+  expect(sides.left_side?.pins).toEqual(["D1"])
+})


### PR DESCRIPTION
**PR Body**
- add `schematic_pin_arrangement` (with alias map support) to schematic components while keeping `port_arrangement` for backwards compatibility  
- allow source/schematic groups to publish `schematic_box_pin_arrangement` + alias maps so `showAsSchematicBox` groups can collapse into a single symbol  
- document the new schema fields and add tests covering both the new string-pin flow and legacy numeric layout


Ref https://github.com/tscircuit/core/issues/1348