### PR TITLE
Add obstructs_within_bounds flag to pcb_component

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,7 @@ interface PcbComponent {
   height: Length
   do_not_place?: boolean
   pcb_group_id?: string
+  obstructs_within_bounds: boolean
 }
 ```
 

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -23,11 +23,15 @@ export interface PcbComponent {
   type: "pcb_component"
   pcb_component_id: string
   source_component_id: string
+  subcircuit_id?: string
   center: Point
   layer: LayerRef
   rotation: Rotation
   width: Length
   height: Length
+  do_not_place?: boolean
+  pcb_group_id?: string
+  obstructs_within_bounds: boolean
 }
 
 export interface PcbPortNotMatchedError {

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -17,6 +17,12 @@ export const pcb_component = z
     do_not_place: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
+    obstructs_within_bounds: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Does this component take up all the space within its bounds on a layer. This is generally true except for when separated pin headers are being represented by a single component (in which case, chips can be placed between the pin headers) or for tall modules where chips fit underneath",
+      ),
   })
   .describe("Defines a component on the PCB")
 
@@ -38,6 +44,7 @@ export interface PcbComponent {
   height: Length
   do_not_place?: boolean
   pcb_group_id?: string
+  obstructs_within_bounds: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- add an `obstructs_within_bounds` flag with a default of `true` to `pcb_component`
- document the new field in the PCB component overview and README snippets

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68d82b1462bc832e87f44c64c5c9b119