### PR TITLE
Add simulation experiment and transient graph schemas

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -102,6 +102,8 @@ export const any_circuit_element = z.union([
   sch.schematic_table_cell,
   cad.cad_component,
   sim.simulation_voltage_source,
+  sim.simulation_experiment,
+  sim.simulation_transient_voltage_graph,
 ])
 
 /**

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -1,1 +1,3 @@
 export * from "./simulation_voltage_source"
+export * from "./simulation_experiment"
+export * from "./simulation_transient_voltage_graph"

--- a/src/simulation/simulation_experiment.ts
+++ b/src/simulation/simulation_experiment.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const experiment_type = z.union([
+  z.literal("spice_dc_sweep"),
+  z.literal("spice_dc_operating_point"),
+  z.literal("spice_transient_analysis"),
+  z.literal("spice_ac_analysis"),
+])
+
+export type ExperimentType = z.infer<typeof experiment_type>
+
+export interface SimulationExperiment {
+  type: "simulation_experiment"
+  simulation_experiment_id: string
+  name: string
+  experiment_type: ExperimentType
+}
+
+export const simulation_experiment = z
+  .object({
+    type: z.literal("simulation_experiment"),
+    simulation_experiment_id: getZodPrefixedIdWithDefault(
+      "simulation_experiment",
+    ),
+    name: z.string(),
+    experiment_type,
+  })
+  .describe("Defines a simulation experiment configuration")
+
+export type SimulationExperimentInput = z.input<typeof simulation_experiment>
+type InferredSimulationExperiment = z.infer<typeof simulation_experiment>
+
+expectTypesMatch<SimulationExperiment, InferredSimulationExperiment>(true)

--- a/src/simulation/simulation_transient_voltage_graph.ts
+++ b/src/simulation/simulation_transient_voltage_graph.ts
@@ -1,0 +1,45 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export interface SimulationTransientVoltageGraph {
+  type: "simulation_transient_voltage_graph"
+  simulation_transient_voltage_graph_id: string
+  timestamps_ms?: number[]
+  voltage_levels: number[]
+  schematic_voltage_probe_id?: string
+  subcircuit_connecivity_map_key?: string
+  time_per_step: number
+  start_time_ms: number
+  end_time_ms: number
+  name?: string
+}
+
+export const simulation_transient_voltage_graph = z
+  .object({
+    type: z.literal("simulation_transient_voltage_graph"),
+    simulation_transient_voltage_graph_id: getZodPrefixedIdWithDefault(
+      "simulation_transient_voltage_graph",
+    ),
+    timestamps_ms: z.array(z.number()).optional(),
+    voltage_levels: z.array(z.number()),
+    schematic_voltage_probe_id: z.string().optional(),
+    subcircuit_connecivity_map_key: z.string().optional(),
+    time_per_step: z.number(),
+    start_time_ms: z.number(),
+    end_time_ms: z.number(),
+    name: z.string().optional(),
+  })
+  .describe("Stores voltage measurements over time for a simulation")
+
+export type SimulationTransientVoltageGraphInput = z.input<
+  typeof simulation_transient_voltage_graph
+>
+type InferredSimulationTransientVoltageGraph = z.infer<
+  typeof simulation_transient_voltage_graph
+>
+
+expectTypesMatch<
+  SimulationTransientVoltageGraph,
+  InferredSimulationTransientVoltageGraph
+>(true)

--- a/tests/simulation_experiment.test.ts
+++ b/tests/simulation_experiment.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import {
+  experiment_type,
+  simulation_experiment,
+} from "../src/simulation/simulation_experiment"
+import { simulation_transient_voltage_graph } from "../src/simulation/simulation_transient_voltage_graph"
+
+test("simulation_experiment requires valid experiment_type", () => {
+  const parsed = simulation_experiment.parse({
+    type: "simulation_experiment",
+    name: "Transient analysis",
+    experiment_type: "spice_transient_analysis",
+  })
+
+  expect(parsed.simulation_experiment_id).toBeString()
+  expect(parsed.experiment_type).toBe("spice_transient_analysis")
+  expect(() => experiment_type.parse("spice_ac_analysis")).not.toThrow()
+})
+
+test("simulation_transient_voltage_graph parses required data", () => {
+  const graph = simulation_transient_voltage_graph.parse({
+    type: "simulation_transient_voltage_graph",
+    voltage_levels: [0, 1, 0.5],
+    time_per_step: 0.1,
+    start_time_ms: 0,
+    end_time_ms: 2,
+    name: "Output voltage",
+  })
+
+  expect(graph.simulation_transient_voltage_graph_id).toBeString()
+  expect(graph.voltage_levels).toEqual([0, 1, 0.5])
+  expect(graph.timestamps_ms).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add a schema for simulation experiments with supported SPICE experiment types
- add a transient voltage graph schema for simulation waveform results
- export the new simulation elements, include them in the circuit union, and cover them with tests

## Testing
- bunx tsc --noEmit
- bun test tests/simulation_experiment.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d9983692d0832e8c335a4cd5837bb4