### PR TITLE
Add simulation switch component schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,11 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [SchematicText](#schematictext)
     - [SchematicTrace](#schematictrace)
     - [SchematicVoltageProbe](#schematicvoltageprobe)
-  - [Simulation Elements](#simulation-elements)
-    - [SimulationExperiment](#simulationexperiment)
-    - [SimulationTransientVoltageGraph](#simulationtransientvoltagegraph)
-    - [SimulationVoltageSource](#simulationvoltagesource)
+- [Simulation Elements](#simulation-elements)
+  - [SimulationExperiment](#simulationexperiment)
+  - [SimulationTransientVoltageGraph](#simulationtransientvoltagegraph)
+  - [SimulationVoltageSource](#simulationvoltagesource)
+  - [SimulationSwitch](#simulationswitch)
 
 <!-- toc:end -->
 
@@ -2184,6 +2185,21 @@ interface SimulationAcVoltageSource {
   wave_shape?: WaveShape
   phase?: number
   duty_cycle?: number
+}
+```
+
+### SimulationSwitch
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/simulation/simulation_switch.ts)
+
+```typescript
+interface SimulationSwitch {
+  type: "simulation_switch"
+  simulation_switch_id: string
+  closes_at?: number
+  opens_at?: number
+  starts_closed?: boolean
+  switching_frequency?: number
 }
 ```
 

--- a/src/simulation/index.ts
+++ b/src/simulation/index.ts
@@ -1,3 +1,4 @@
 export * from "./simulation_voltage_source"
 export * from "./simulation_experiment"
 export * from "./simulation_transient_voltage_graph"
+export * from "./simulation_switch"

--- a/src/simulation/simulation_switch.ts
+++ b/src/simulation/simulation_switch.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { frequency, time } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const simulation_switch = z
+  .object({
+    type: z.literal("simulation_switch"),
+    simulation_switch_id: getZodPrefixedIdWithDefault("simulation_switch"),
+    closes_at: time.optional(),
+    opens_at: time.optional(),
+    starts_closed: z.boolean().optional(),
+    switching_frequency: frequency.optional(),
+  })
+  .describe("Defines a switch for simulation timing control")
+
+export type SimulationSwitchInput = z.input<typeof simulation_switch>
+
+type InferredSimulationSwitch = z.infer<typeof simulation_switch>
+
+export interface SimulationSwitch {
+  type: "simulation_switch"
+  simulation_switch_id: string
+  closes_at?: number
+  opens_at?: number
+  starts_closed?: boolean
+  switching_frequency?: number
+}
+
+expectTypesMatch<SimulationSwitch, InferredSimulationSwitch>(true)

--- a/tests/simulation_switch.test.ts
+++ b/tests/simulation_switch.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import {
+  simulation_switch,
+  type SimulationSwitch,
+  type SimulationSwitchInput,
+} from "../src/simulation/simulation_switch"
+
+test("simulation_switch parses optional timing fields", () => {
+  const input: SimulationSwitchInput = {
+    type: "simulation_switch",
+    closes_at: "5ms",
+    opens_at: "10ms",
+    starts_closed: true,
+    switching_frequency: "2kHz",
+  }
+
+  const result = simulation_switch.parse(input)
+
+  const simSwitch = result as SimulationSwitch
+  expect(simSwitch.closes_at).toBeCloseTo(5)
+  expect(simSwitch.opens_at).toBeCloseTo(10)
+  expect(simSwitch.starts_closed).toBe(true)
+  expect(simSwitch.switching_frequency).toBeCloseTo(2000)
+  expect(simSwitch.simulation_switch_id).toBeString()
+})
+
+test("simulation_switch allows minimal definition", () => {
+  const input: SimulationSwitchInput = {
+    type: "simulation_switch",
+  }
+
+  const result = simulation_switch.parse(input)
+
+  const simSwitch = result as SimulationSwitch
+  expect(simSwitch.closes_at).toBeUndefined()
+  expect(simSwitch.opens_at).toBeUndefined()
+  expect(simSwitch.starts_closed).toBeUndefined()
+  expect(simSwitch.switching_frequency).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add a simulation_switch schema with optional timing and frequency configuration
- expose the new component in the simulation exports and README documentation
- cover the parser with dedicated unit tests

## Testing
- bunx tsc --noEmit
- bun test tests/simulation_switch.test.ts
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e152095f68832e80367254cc3bfdb6