### PR TITLE
Add pcb center details to via clearance error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,30 @@ interface PcbPortNotConnectedError {
 }
 ```
 
+### PcbViaClearanceError
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_via_clearance_error.ts)
+
+Defines an error when vias violate the configured clearance
+
+```typescript
+/** Error emitted when vias are closer than the allowed clearance */
+interface PcbViaClearanceError {
+  type: "pcb_via_clearance_error"
+  pcb_error_id: string
+  error_type: "pcb_via_clearance_error"
+  message: string
+  pcb_via_ids: string[]
+  minimum_clearance?: Distance
+  actual_clearance?: Distance
+  pcb_center?: {
+    x?: number
+    y?: number
+  }
+  subcircuit_id?: string
+}
+```
+
 ### PcbPortNotMatchedError
 
 [Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_port_not_matched_error.ts)

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -70,6 +70,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_placement_error,
   pcb.pcb_port_not_matched_error,
   pcb.pcb_port_not_connected_error,
+  pcb.pcb_via_clearance_error,
   pcb.pcb_fabrication_note_path,
   pcb.pcb_fabrication_note_text,
   pcb.pcb_autorouting_error,
@@ -156,6 +157,7 @@ expectStringUnionsMatch<
   | "pcb_port_not_matched_error DOES NOT HAVE AN pcb_port_not_matched_error_id PROPERTY"
   | "pcb_autorouting_error DOES NOT HAVE AN pcb_autorouting_error_id PROPERTY"
   | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
+  | "pcb_via_clearance_error DOES NOT HAVE AN pcb_via_clearance_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"
   | "schematic_box DOES NOT HAVE AN schematic_box_id PROPERTY"
   | "schematic_path DOES NOT HAVE AN schematic_path_id PROPERTY"

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -44,6 +44,7 @@ export * from "./pcb_ground_plane_region"
 export * from "./pcb_thermal_spoke"
 export * from "./pcb_copper_pour"
 export * from "./pcb_component_outside_board_error"
+export * from "./pcb_via_clearance_error"
 
 import type { PcbComponent } from "./pcb_component"
 import type { PcbHole } from "./pcb_hole"
@@ -80,6 +81,7 @@ import type { PcbThermalSpoke } from "./pcb_thermal_spoke"
 import type { PcbCopperPour } from "./pcb_copper_pour"
 import type { PcbComponentOutsideBoardError } from "./pcb_component_outside_board_error"
 import type { CircuitJsonFootprintLoadError } from "./circuit_json_footprint_load_error"
+import type { PcbViaClearanceError } from "./pcb_via_clearance_error"
 
 export type PcbCircuitElement =
   | PcbComponent
@@ -117,3 +119,4 @@ export type PcbCircuitElement =
   | PcbThermalSpoke
   | PcbCopperPour
   | PcbComponentOutsideBoardError
+  | PcbViaClearanceError

--- a/src/pcb/pcb_via_clearance_error.ts
+++ b/src/pcb/pcb_via_clearance_error.ts
@@ -1,0 +1,46 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { distance, type Distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_via_clearance_error = z
+  .object({
+    type: z.literal("pcb_via_clearance_error"),
+    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    error_type: z
+      .literal("pcb_via_clearance_error")
+      .default("pcb_via_clearance_error"),
+    message: z.string(),
+    pcb_via_ids: z.array(z.string()).min(2),
+    minimum_clearance: distance.optional(),
+    actual_clearance: distance.optional(),
+    pcb_center: z
+      .object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+      })
+      .optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Error emitted when vias are closer than the allowed clearance")
+
+export type PcbViaClearanceErrorInput = z.input<typeof pcb_via_clearance_error>
+type InferredPcbViaClearanceError = z.infer<typeof pcb_via_clearance_error>
+
+/** Error emitted when vias are closer than the allowed clearance */
+export interface PcbViaClearanceError {
+  type: "pcb_via_clearance_error"
+  pcb_error_id: string
+  error_type: "pcb_via_clearance_error"
+  message: string
+  pcb_via_ids: string[]
+  minimum_clearance?: Distance
+  actual_clearance?: Distance
+  pcb_center?: {
+    x?: number
+    y?: number
+  }
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbViaClearanceError, InferredPcbViaClearanceError>(true)

--- a/tests/pcb_via_clearance_error.test.ts
+++ b/tests/pcb_via_clearance_error.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { pcb_via_clearance_error } from "../src/pcb/pcb_via_clearance_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_via_clearance_error parses", () => {
+  const error = pcb_via_clearance_error.parse({
+    type: "pcb_via_clearance_error",
+    message: "vias too close",
+    pcb_via_ids: ["via_1", "via_2"],
+    minimum_clearance: "0.2mm",
+    actual_clearance: "0.1mm",
+    pcb_center: {
+      x: 12.5,
+      y: -3.4,
+    },
+  })
+
+  expect(error.pcb_error_id).toBeDefined()
+  expect(error.pcb_error_id.startsWith("pcb_error")).toBe(true)
+  expect(error.minimum_clearance).toBeCloseTo(0.2)
+  expect(error.actual_clearance).toBeCloseTo(0.1)
+  expect(error.pcb_center).toEqual({ x: 12.5, y: -3.4 })
+})
+
+test("any_circuit_element includes pcb_via_clearance_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_via_clearance_error",
+    message: "vias too close",
+    pcb_via_ids: ["via_1", "via_2"],
+  })
+
+  expect(parsed.type).toBe("pcb_via_clearance_error")
+})


### PR DESCRIPTION
## Summary
- include optional pcb_center coordinates on the pcb_via_clearance_error schema and interface
- document the pcb_center field in the README error reference
- extend the pcb_via_clearance_error test coverage to assert pcb_center parsing

## Testing
- bun test tests/pcb_via_clearance_error.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e1b1c5dec8832eb5fb48ed5a9dea1e