### PR TITLE
Refactor time into timestamp and duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The default units when reading a number are defined as follows:
 | ---------------- | --------- | ------------ |
 | Length           | mm        | Millimeters  |
 | Duration         | ms        | Milliseconds |
-| Timestamp        | ms        | Milliseconds |
+| Timestamp        | string    | ISO 8601 Timestamp |
 | Mass             | g         | Grams        |
 | Angle            | deg       | Degrees      |
 | Frequency        | Hz        | Hertz        |
@@ -2182,13 +2182,13 @@ interface SimulationTransientVoltageGraph {
   type: "simulation_transient_voltage_graph"
   simulation_transient_voltage_graph_id: string
   simulation_experiment_id: string
-  timestamps?: number[]
+  timestamps_ms?: number[]
   voltage_levels: number[]
   schematic_voltage_probe_id?: string
-  subcircuit_connecivity_map_key?: string
+  subcircuit_connectivity_map_key?: string
   time_per_step: number
-  start_timestamp: number
-  end_timestamp: number
+  start_time_ms: number
+  end_time_ms: number
   name?: string
 }
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ The default units when reading a number are defined as follows:
 | Measurement Type | Base Unit | Description  |
 | ---------------- | --------- | ------------ |
 | Length           | mm        | Millimeters  |
-| Time             | ms        | Milliseconds |
+| Duration         | ms        | Milliseconds |
+| Timestamp        | ms        | Milliseconds |
 | Mass             | g         | Grams        |
 | Angle            | deg       | Degrees      |
 | Frequency        | Hz        | Hertz        |
@@ -2181,13 +2182,13 @@ interface SimulationTransientVoltageGraph {
   type: "simulation_transient_voltage_graph"
   simulation_transient_voltage_graph_id: string
   simulation_experiment_id: string
-  timestamps_ms?: number[]
+  timestamps?: number[]
   voltage_levels: number[]
   schematic_voltage_probe_id?: string
   subcircuit_connecivity_map_key?: string
   time_per_step: number
-  start_time_ms: number
-  end_time_ms: number
+  start_timestamp: number
+  end_timestamp: number
   name?: string
 }
 ```

--- a/src/simulation/simulation_switch.ts
+++ b/src/simulation/simulation_switch.ts
@@ -1,14 +1,14 @@
 import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
-import { frequency, time } from "src/units"
+import { frequency, timestamp } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export const simulation_switch = z
   .object({
     type: z.literal("simulation_switch"),
     simulation_switch_id: getZodPrefixedIdWithDefault("simulation_switch"),
-    closes_at: time.optional(),
-    opens_at: time.optional(),
+    closes_at: timestamp.optional(),
+    opens_at: timestamp.optional(),
     starts_closed: z.boolean().optional(),
     switching_frequency: frequency.optional(),
   })

--- a/src/simulation/simulation_switch.ts
+++ b/src/simulation/simulation_switch.ts
@@ -1,14 +1,14 @@
 import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
-import { frequency, timestamp } from "src/units"
+import { frequency, ms } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export const simulation_switch = z
   .object({
     type: z.literal("simulation_switch"),
     simulation_switch_id: getZodPrefixedIdWithDefault("simulation_switch"),
-    closes_at: timestamp.optional(),
-    opens_at: timestamp.optional(),
+    closes_at: ms.optional(),
+    opens_at: ms.optional(),
     starts_closed: z.boolean().optional(),
     switching_frequency: frequency.optional(),
   })

--- a/src/simulation/simulation_transient_voltage_graph.ts
+++ b/src/simulation/simulation_transient_voltage_graph.ts
@@ -1,19 +1,19 @@
 import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
-import { duration, timestamp } from "src/units"
+import { duration_ms, ms } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export interface SimulationTransientVoltageGraph {
   type: "simulation_transient_voltage_graph"
   simulation_transient_voltage_graph_id: string
   simulation_experiment_id: string
-  timestamps?: number[]
+  timestamps_ms?: number[]
   voltage_levels: number[]
   schematic_voltage_probe_id?: string
-  subcircuit_connecivity_map_key?: string
+  subcircuit_connectivity_map_key?: string
   time_per_step: number
-  start_timestamp: number
-  end_timestamp: number
+  start_time_ms: number
+  end_time_ms: number
   name?: string
 }
 
@@ -24,13 +24,13 @@ export const simulation_transient_voltage_graph = z
       "simulation_transient_voltage_graph",
     ),
     simulation_experiment_id: z.string(),
-    timestamps: z.array(timestamp).optional(),
+    timestamps_ms: z.array(z.number()).optional(),
     voltage_levels: z.array(z.number()),
     schematic_voltage_probe_id: z.string().optional(),
-    subcircuit_connecivity_map_key: z.string().optional(),
-    time_per_step: duration,
-    start_timestamp: timestamp,
-    end_timestamp: timestamp,
+    subcircuit_connectivity_map_key: z.string().optional(),
+    time_per_step: duration_ms,
+    start_time_ms: ms,
+    end_time_ms: ms,
     name: z.string().optional(),
   })
   .describe("Stores voltage measurements over time for a simulation")

--- a/src/simulation/simulation_transient_voltage_graph.ts
+++ b/src/simulation/simulation_transient_voltage_graph.ts
@@ -1,18 +1,19 @@
 import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
+import { duration, timestamp } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export interface SimulationTransientVoltageGraph {
   type: "simulation_transient_voltage_graph"
   simulation_transient_voltage_graph_id: string
   simulation_experiment_id: string
-  timestamps_ms?: number[]
+  timestamps?: number[]
   voltage_levels: number[]
   schematic_voltage_probe_id?: string
   subcircuit_connecivity_map_key?: string
   time_per_step: number
-  start_time_ms: number
-  end_time_ms: number
+  start_timestamp: number
+  end_timestamp: number
   name?: string
 }
 
@@ -23,13 +24,13 @@ export const simulation_transient_voltage_graph = z
       "simulation_transient_voltage_graph",
     ),
     simulation_experiment_id: z.string(),
-    timestamps_ms: z.array(z.number()).optional(),
+    timestamps: z.array(timestamp).optional(),
     voltage_levels: z.array(z.number()),
     schematic_voltage_probe_id: z.string().optional(),
     subcircuit_connecivity_map_key: z.string().optional(),
-    time_per_step: z.number(),
-    start_time_ms: z.number(),
-    end_time_ms: z.number(),
+    time_per_step: duration,
+    start_timestamp: timestamp,
+    end_timestamp: timestamp,
     name: z.string().optional(),
   })
   .describe("Stores voltage measurements over time for a simulation")

--- a/src/source/source_project_metadata.ts
+++ b/src/source/source_project_metadata.ts
@@ -1,5 +1,6 @@
 import { expectTypesMatch } from "src/utils/expect-types-match"
 import { z } from "zod"
+import { timestamp } from "src/units"
 
 export interface SourceProjectMetadata {
   type: "source_project_metadata"
@@ -14,7 +15,7 @@ export const source_project_metadata = z.object({
   name: z.string().optional(),
   software_used_string: z.string().optional(),
   project_url: z.string().optional(),
-  created_at: z.string().datetime().optional(),
+  created_at: timestamp.optional(),
 })
 
 export type InferredProjectMetadata = z.infer<typeof source_project_metadata>

--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -99,17 +99,16 @@ export const current = z
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v).value!)
 
-export const duration = z
+export const duration_ms = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v).value!)
 
-export const time = duration
+export const time = duration_ms
 
-export const timestamp = z
-  .string()
-  .or(z.number())
-  .transform((v) => parseAndConvertSiUnit(v).value!)
+export const ms = duration_ms
+
+export const timestamp = z.string().datetime()
 
 /**
  * Rotation is always converted to degrees

--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -99,7 +99,12 @@ export const current = z
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v).value!)
 
-export const time = z
+export const duration = z
+  .string()
+  .or(z.number())
+  .transform((v) => parseAndConvertSiUnit(v).value!)
+
+export const timestamp = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v).value!)

--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -104,6 +104,8 @@ export const duration = z
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v).value!)
 
+export const time = duration
+
 export const timestamp = z
   .string()
   .or(z.number())

--- a/src/utils/convert-si-unit-to-number.ts
+++ b/src/utils/convert-si-unit-to-number.ts
@@ -87,6 +87,12 @@ const unitMappings: Record<
   ms: {
     baseUnit: "ms",
     variants: {
+      fs: 1e-12,
+      ps: 1e-9,
+      ns: 1e-6,
+      us: 1e-3,
+      µs: 1e-3,
+      ms: 1,
       s: 1000,
     },
   },

--- a/src/utils/convert-si-unit-to-number.ts
+++ b/src/utils/convert-si-unit-to-number.ts
@@ -177,40 +177,55 @@ type BaseTscircuitUnit =
   | "F"
   | "H"
 
-export const parseAndConvertSiUnit = <
-  T extends
+export function parseAndConvertSiUnit(v: {
+  x: string | number
+  y: string | number
+}): {
+  parsedUnit: string | null
+  unitOfValue: BaseTscircuitUnit | null
+  value: { x: number; y: number } | null
+}
+export function parseAndConvertSiUnit(v: string | number | undefined | null): {
+  parsedUnit: string | null
+  unitOfValue: BaseTscircuitUnit | null
+  value: number | null
+}
+export function parseAndConvertSiUnit(
+  v:
     | string
     | number
     | undefined
+    | null
     | { x: string | number; y: string | number },
->(
-  v: T,
 ): {
   parsedUnit: string | null
   unitOfValue: BaseTscircuitUnit | null
-  value: T extends { x: string | number; y: string | number }
-    ? null | { x: number; y: number }
-    : null | number
-} => {
-  if (typeof v === "undefined")
+  value: null | number | { x: number; y: number }
+} {
+  if (v === undefined || v === null)
     return { parsedUnit: null, unitOfValue: null, value: null }
   if (typeof v === "string" && v.match(/^-?[\d\.]+$/))
     return {
-      value: Number.parseFloat(v) as any,
+      value: Number.parseFloat(v),
       parsedUnit: null,
       unitOfValue: null,
     }
   if (typeof v === "number")
-    return { value: v as any, parsedUnit: null, unitOfValue: null }
+    return { value: v, parsedUnit: null, unitOfValue: null }
   if (typeof v === "object" && "x" in v && "y" in v) {
     const { parsedUnit, unitOfValue } = parseAndConvertSiUnit(v.x)
+    const xResult = parseAndConvertSiUnit(v.x)
+    const yResult = parseAndConvertSiUnit(v.y)
+    if (xResult.value === null || yResult.value === null) {
+      return { parsedUnit: null, unitOfValue: null, value: null }
+    }
     return {
       parsedUnit: parsedUnit,
       unitOfValue: unitOfValue,
       value: {
-        x: parseAndConvertSiUnit(v.x as any).value as number,
-        y: parseAndConvertSiUnit(v.y as any).value as number,
-      } as any,
+        x: xResult.value,
+        y: yResult.value,
+      },
     }
   }
   const reversed_input_string = v.toString().split("").reverse().join("")
@@ -230,7 +245,7 @@ export const parseAndConvertSiUnit = <
     return {
       parsedUnit: null,
       unitOfValue: null,
-      value: (Number.parseFloat(numberPart) * siMultiplier) as any,
+      value: Number.parseFloat(numberPart) * siMultiplier,
     }
   }
 
@@ -239,6 +254,6 @@ export const parseAndConvertSiUnit = <
   return {
     parsedUnit: unit,
     unitOfValue: baseUnit,
-    value: (conversionFactor * Number.parseFloat(numberPart)) as any,
+    value: conversionFactor * Number.parseFloat(numberPart),
   }
 }

--- a/tests/simulation_experiment.test.ts
+++ b/tests/simulation_experiment.test.ts
@@ -22,14 +22,17 @@ test("simulation_transient_voltage_graph parses required data", () => {
     type: "simulation_transient_voltage_graph",
     simulation_experiment_id: "simulation_experiment_123",
     voltage_levels: [0, 1, 0.5],
-    time_per_step: 0.1,
-    start_time_ms: 0,
-    end_time_ms: 2,
+    time_per_step: "0.1ms",
+    start_timestamp: "0ms",
+    end_timestamp: "2ms",
     name: "Output voltage",
   })
 
   expect(graph.simulation_transient_voltage_graph_id).toBeString()
   expect(graph.simulation_experiment_id).toBe("simulation_experiment_123")
   expect(graph.voltage_levels).toEqual([0, 1, 0.5])
-  expect(graph.timestamps_ms).toBeUndefined()
+  expect(graph.timestamps).toBeUndefined()
+  expect(graph.time_per_step).toBe(0.1)
+  expect(graph.start_timestamp).toBe(0)
+  expect(graph.end_timestamp).toBe(2)
 })

--- a/tests/simulation_experiment.test.ts
+++ b/tests/simulation_experiment.test.ts
@@ -23,16 +23,16 @@ test("simulation_transient_voltage_graph parses required data", () => {
     simulation_experiment_id: "simulation_experiment_123",
     voltage_levels: [0, 1, 0.5],
     time_per_step: "0.1ms",
-    start_timestamp: "0ms",
-    end_timestamp: "2ms",
+    start_time_ms: "0ms",
+    end_time_ms: "2ms",
     name: "Output voltage",
   })
 
   expect(graph.simulation_transient_voltage_graph_id).toBeString()
   expect(graph.simulation_experiment_id).toBe("simulation_experiment_123")
   expect(graph.voltage_levels).toEqual([0, 1, 0.5])
-  expect(graph.timestamps).toBeUndefined()
+  expect(graph.timestamps_ms).toBeUndefined()
   expect(graph.time_per_step).toBe(0.1)
-  expect(graph.start_timestamp).toBe(0)
-  expect(graph.end_timestamp).toBe(2)
+  expect(graph.start_time_ms).toBe(0)
+  expect(graph.end_time_ms).toBe(2)
 })

--- a/tests/time-units.test.ts
+++ b/tests/time-units.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test"
+import { duration, timestamp } from "src/units"
+
+test("duration and timestamp parse various time units", () => {
+  // Test seconds
+  expect(duration.parse("1s")).toBeCloseTo(1000)
+  expect(timestamp.parse("1s")).toBeCloseTo(1000)
+
+  // Test milliseconds
+  expect(duration.parse("500ms")).toBeCloseTo(500)
+  expect(timestamp.parse("500ms")).toBeCloseTo(500)
+
+  // Test microseconds
+  expect(duration.parse("250us")).toBeCloseTo(0.25)
+  expect(timestamp.parse("250us")).toBeCloseTo(0.25)
+  expect(duration.parse("250µs")).toBeCloseTo(0.25)
+  expect(timestamp.parse("250µs")).toBeCloseTo(0.25)
+
+  // Test nanoseconds
+  expect(duration.parse("100ns")).toBeCloseTo(0.0001)
+  expect(timestamp.parse("100ns")).toBeCloseTo(0.0001)
+
+  // Test picoseconds
+  expect(duration.parse("75ps")).toBeCloseTo(0.000000075)
+  expect(timestamp.parse("75ps")).toBeCloseTo(0.000000075)
+
+  // Test femtoseconds
+  expect(duration.parse("50fs")).toBeCloseTo(0.00000000005)
+  expect(timestamp.parse("50fs")).toBeCloseTo(0.00000000005)
+})

--- a/tests/time-units.test.ts
+++ b/tests/time-units.test.ts
@@ -1,30 +1,30 @@
 import { test, expect } from "bun:test"
-import { duration, timestamp } from "src/units"
+import { duration_ms, ms } from "src/units"
 
-test("duration and timestamp parse various time units", () => {
+test("duration_ms and ms parse various time units", () => {
   // Test seconds
-  expect(duration.parse("1s")).toBeCloseTo(1000)
-  expect(timestamp.parse("1s")).toBeCloseTo(1000)
+  expect(duration_ms.parse("1s")).toBeCloseTo(1000)
+  expect(ms.parse("1s")).toBeCloseTo(1000)
 
   // Test milliseconds
-  expect(duration.parse("500ms")).toBeCloseTo(500)
-  expect(timestamp.parse("500ms")).toBeCloseTo(500)
+  expect(duration_ms.parse("500ms")).toBeCloseTo(500)
+  expect(ms.parse("500ms")).toBeCloseTo(500)
 
   // Test microseconds
-  expect(duration.parse("250us")).toBeCloseTo(0.25)
-  expect(timestamp.parse("250us")).toBeCloseTo(0.25)
-  expect(duration.parse("250µs")).toBeCloseTo(0.25)
-  expect(timestamp.parse("250µs")).toBeCloseTo(0.25)
+  expect(duration_ms.parse("250us")).toBeCloseTo(0.25)
+  expect(ms.parse("250us")).toBeCloseTo(0.25)
+  expect(duration_ms.parse("250µs")).toBeCloseTo(0.25)
+  expect(ms.parse("250µs")).toBeCloseTo(0.25)
 
   // Test nanoseconds
-  expect(duration.parse("100ns")).toBeCloseTo(0.0001)
-  expect(timestamp.parse("100ns")).toBeCloseTo(0.0001)
+  expect(duration_ms.parse("100ns")).toBeCloseTo(0.0001)
+  expect(ms.parse("100ns")).toBeCloseTo(0.0001)
 
   // Test picoseconds
-  expect(duration.parse("75ps")).toBeCloseTo(0.000000075)
-  expect(timestamp.parse("75ps")).toBeCloseTo(0.000000075)
+  expect(duration_ms.parse("75ps")).toBeCloseTo(0.000000075)
+  expect(ms.parse("75ps")).toBeCloseTo(0.000000075)
 
   // Test femtoseconds
-  expect(duration.parse("50fs")).toBeCloseTo(0.00000000005)
-  expect(timestamp.parse("50fs")).toBeCloseTo(0.00000000005)
+  expect(duration_ms.parse("50fs")).toBeCloseTo(0.00000000005)
+  expect(ms.parse("50fs")).toBeCloseTo(0.00000000005)
 })


### PR DESCRIPTION
This pull request refactors the generic time unit into two more specific units: timestamp and duration.                    

 • timestamp is used to represent a specific point in time.                                                                
 • duration is used to represent a length of time.                                                                         

This change improves clarity and type-safety throughout the codebase. The simulation_switch and                            
simulation_transient_voltage_graph elements, along with their corresponding tests and documentation, have been updated to use these new, more descriptive types.                                                                                     
