### PR TITLE
feat: add automatic name flag to source group

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ interface SourceGroup {
   is_subcircuit?: boolean
   show_as_schematic_box?: boolean
   name?: string
+  was_automatically_named?: boolean
 }
 ```
 

--- a/docs/SOURCE_COMPONENT_OVERVIEW.md
+++ b/docs/SOURCE_COMPONENT_OVERVIEW.md
@@ -109,6 +109,7 @@ interface SourceGroup {
   type: "source_group"
   source_group_id: string
   name?: string
+  was_automatically_named?: boolean
 }
 
 interface SourcePort {

--- a/src/source/source_group.ts
+++ b/src/source/source_group.ts
@@ -10,6 +10,7 @@ export const source_group = z.object({
   is_subcircuit: z.boolean().optional(),
   show_as_schematic_box: z.boolean().optional(),
   name: z.string().optional(),
+  was_automatically_named: z.boolean().optional(),
 })
 
 export type SourceGroupInput = z.input<typeof source_group>
@@ -24,6 +25,7 @@ export interface SourceGroup {
   is_subcircuit?: boolean
   show_as_schematic_box?: boolean
   name?: string
+  was_automatically_named?: boolean
 }
 
 expectTypesMatch<SourceGroup, InferredSourceGroup>(true)


### PR DESCRIPTION
## Summary
- add an optional was_automatically_named flag to source_group definitions
- document the new property in README and source component overview

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e57f126210832e9cc4532f7fa2d1af