### PR TITLE
Fix fabrication note dimensions to require explicit points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,8 +1030,8 @@ interface PcbFabricationNoteDimension {
   pcb_group_id?: string
   subcircuit_id?: string
   layer: VisibleLayer
-  from: Point | string
-  to: Point | string
+  from: Point
+  to: Point
   text?: string
   offset?: Length
   font: "tscircuit2024"

--- a/src/pcb/pcb_fabrication_note_dimension.ts
+++ b/src/pcb/pcb_fabrication_note_dimension.ts
@@ -14,8 +14,8 @@ export const pcb_fabrication_note_dimension = z
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
     layer: visible_layer,
-    from: point.or(z.string()),
-    to: point.or(z.string()),
+    from: point,
+    to: point,
     text: z.string().optional(),
     offset: length.optional(),
     font: z.literal("tscircuit2024").default("tscircuit2024"),
@@ -42,8 +42,8 @@ export interface PcbFabricationNoteDimension {
   pcb_group_id?: string
   subcircuit_id?: string
   layer: VisibleLayer
-  from: Point | string
-  to: Point | string
+  from: Point
+  to: Point
   text?: string
   offset?: Length
   font: "tscircuit2024"

--- a/tests/pcb_fabrication_note_dimension.test.ts
+++ b/tests/pcb_fabrication_note_dimension.test.ts
@@ -16,17 +16,14 @@ test("parse fabrication note dimension with defaults", () => {
   expect(dimension.to).toEqual({ x: 10, y: 0 })
 })
 
-test("fabrication note dimension accepts reference strings", () => {
-  const dimension = pcb_fabrication_note_dimension.parse({
-    type: "pcb_fabrication_note_dimension",
-    pcb_component_id: "pcb_component_1",
-    layer: "top",
-    from: "pcb_point_start",
-    to: "pcb_point_end",
-    offset: "2mm",
-  })
-
-  expect(dimension.from).toBe("pcb_point_start")
-  expect(dimension.to).toBe("pcb_point_end")
-  expect(dimension.offset).toBeCloseTo(2)
+test("fabrication note dimension requires explicit points", () => {
+  expect(() =>
+    pcb_fabrication_note_dimension.parse({
+      type: "pcb_fabrication_note_dimension",
+      pcb_component_id: "pcb_component_1",
+      layer: "top",
+      from: "pcb_point_start",
+      to: "pcb_point_end",
+    }),
+  ).toThrow()
 })


### PR DESCRIPTION
## Summary
- require explicit point objects for pcb_fabrication_note_dimension endpoints
- update type definitions, documentation, and tests to match point-only coordinates
- ensure fabrication note dimensions reject string references in parsing

## Testing
- bun test tests/pcb_fabrication_note_dimension.test.ts
- bun test tests/pcb_note_components.test.ts
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68eeb3d601e0832e8c6480205d73b64e