### PR TITLE
Added error schema for invalid layer placement

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -90,6 +90,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_thermal_spoke,
   pcb.pcb_copper_pour,
   pcb.pcb_component_outside_board_error,
+  pcb.pcb_component_invalid_layer_error,
   pcb.pcb_courtyard_rect,
   pcb.pcb_courtyard_outline,
   sch.schematic_box,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -51,6 +51,7 @@ export * from "./pcb_ground_plane_region"
 export * from "./pcb_thermal_spoke"
 export * from "./pcb_copper_pour"
 export * from "./pcb_component_outside_board_error"
+export * from "./pcb_component_invalid_layer_error"
 export * from "./pcb_via_clearance_error"
 export * from "./pcb_courtyard_rect"
 export * from "./pcb_courtyard_outline"
@@ -96,6 +97,7 @@ import type { PcbGroundPlaneRegion } from "./pcb_ground_plane_region"
 import type { PcbThermalSpoke } from "./pcb_thermal_spoke"
 import type { PcbCopperPour } from "./pcb_copper_pour"
 import type { PcbComponentOutsideBoardError } from "./pcb_component_outside_board_error"
+import type { PcbComponentInvalidLayerError } from "./pcb_component_invalid_layer_error"
 import type { CircuitJsonFootprintLoadError } from "./circuit_json_footprint_load_error"
 import type { PcbViaClearanceError } from "./pcb_via_clearance_error"
 import type { PcbCourtyardRect } from "./pcb_courtyard_rect"
@@ -144,6 +146,7 @@ export type PcbCircuitElement =
   | PcbThermalSpoke
   | PcbCopperPour
   | PcbComponentOutsideBoardError
+  | PcbComponentInvalidLayerError
   | PcbViaClearanceError
   | PcbCourtyardRect
   | PcbCourtyardOutline

--- a/src/pcb/pcb_component_invalid_layer_error.ts
+++ b/src/pcb/pcb_component_invalid_layer_error.ts
@@ -1,0 +1,47 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_component_invalid_layer_error = z
+  .object({
+    type: z.literal("pcb_component_invalid_layer_error"),
+    pcb_component_invalid_layer_error_id: getZodPrefixedIdWithDefault(
+      "pcb_component_invalid_layer_error",
+    ),
+    error_type: z
+      .literal("pcb_component_invalid_layer_error")
+      .default("pcb_component_invalid_layer_error"),
+    message: z.string(),
+    pcb_component_id: z.string().optional(),
+    source_component_id: z.string(),
+    layer: layer_ref,
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Error emitted when a component is placed on an invalid layer (components can only be on 'top' or 'bottom' layers)",
+  )
+
+export type PcbComponentInvalidLayerErrorInput = z.input<
+  typeof pcb_component_invalid_layer_error
+>
+type InferredPcbComponentInvalidLayerError = z.infer<
+  typeof pcb_component_invalid_layer_error
+>
+
+/** Error emitted when a component is placed on an invalid layer (components can only be on 'top' or 'bottom' layers) */
+export interface PcbComponentInvalidLayerError {
+  type: "pcb_component_invalid_layer_error"
+  pcb_component_invalid_layer_error_id: string
+  error_type: "pcb_component_invalid_layer_error"
+  message: string
+  pcb_component_id?: string
+  source_component_id: string
+  layer: LayerRef
+  subcircuit_id?: string
+}
+
+expectTypesMatch<
+  PcbComponentInvalidLayerError,
+  InferredPcbComponentInvalidLayerError
+>(true)

--- a/tests/pcb_component_invalid_layer_error.test.ts
+++ b/tests/pcb_component_invalid_layer_error.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { pcb_component_invalid_layer_error } from "../src/pcb/pcb_component_invalid_layer_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_component_invalid_layer_error parses", () => {
+  const error = pcb_component_invalid_layer_error.parse({
+    type: "pcb_component_invalid_layer_error",
+    message: 'Component "R1" cannot be placed on layer "inner1"',
+    source_component_id: "source_component_1",
+    layer: "inner1",
+  })
+
+  expect(error.type).toBe("pcb_component_invalid_layer_error")
+  expect(error.error_type).toBe("pcb_component_invalid_layer_error")
+  expect(error.layer).toBe("inner1")
+  expect(error.source_component_id).toBe("source_component_1")
+})
+
+test("any_circuit_element includes pcb_component_invalid_layer_error", () => {
+  const error = any_circuit_element.parse({
+    type: "pcb_component_invalid_layer_error",
+    message: 'Component "R1" cannot be placed on layer "inner2"',
+    source_component_id: "source_component_2",
+    layer: "inner2",
+    subcircuit_id: "subcircuit_1",
+  })
+
+  expect(error.type).toBe("pcb_component_invalid_layer_error")
+})


### PR DESCRIPTION
## PR description

- Added new error schema for invalid layer placement, includes source_component_id, layer name, and descriptive message
- Created tests to verify the error schema works correctly

Ref https://github.com/tscircuit/core/issues/1523