### PR TITLE
Add PCB panel component and link boards to panels

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -58,6 +58,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_smtpad,
   pcb.pcb_solder_paste,
   pcb.pcb_board,
+  pcb.pcb_panel,
   pcb.pcb_group,
   pcb.pcb_trace_hint,
   pcb.pcb_silkscreen_line,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -19,6 +19,7 @@ export * from "./pcb_port_not_connected_error"
 export * from "./pcb_net"
 export * from "./pcb_via"
 export * from "./pcb_board"
+export * from "./pcb_panel"
 export * from "./pcb_placement_error"
 export * from "./pcb_trace_hint"
 export * from "./pcb_silkscreen_line"
@@ -71,6 +72,7 @@ import type { PcbPortNotConnectedError } from "./pcb_port_not_connected_error"
 import type { PcbVia } from "./pcb_via"
 import type { PcbNet } from "./pcb_net"
 import type { PcbBoard } from "./pcb_board"
+import type { PcbPanel } from "./pcb_panel"
 import type { PcbPlacementError } from "./pcb_placement_error"
 import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
 import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
@@ -123,6 +125,7 @@ export type PcbCircuitElement =
   | PcbVia
   | PcbNet
   | PcbBoard
+  | PcbPanel
   | PcbPlacementError
   | PcbTraceHint
   | PcbSilkscreenLine

--- a/src/pcb/pcb_board.ts
+++ b/src/pcb/pcb_board.ts
@@ -7,6 +7,7 @@ export const pcb_board = z
   .object({
     type: z.literal("pcb_board"),
     pcb_board_id: getZodPrefixedIdWithDefault("pcb_board"),
+    pcb_panel_id: z.string().optional(),
     is_subcircuit: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
     width: length,
@@ -25,6 +26,7 @@ export const pcb_board = z
 export interface PcbBoard {
   type: "pcb_board"
   pcb_board_id: string
+  pcb_panel_id?: string
   is_subcircuit?: boolean
   subcircuit_id?: string
   width: Length

--- a/src/pcb/pcb_panel.ts
+++ b/src/pcb/pcb_panel.ts
@@ -1,0 +1,35 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { length, type Length } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_panel = z
+  .object({
+    type: z.literal("pcb_panel"),
+    pcb_panel_id: getZodPrefixedIdWithDefault("pcb_panel"),
+    width: length,
+    height: length,
+    covered_with_solder_mask: z.boolean().optional().default(true),
+  })
+  .describe("Defines a PCB panel that can contain multiple boards")
+
+/**
+ * Defines a PCB panel that can contain multiple boards
+ */
+export interface PcbPanel {
+  type: "pcb_panel"
+  pcb_panel_id: string
+  width: Length
+  height: Length
+  covered_with_solder_mask: boolean
+}
+
+export type PcbPanelInput = z.input<typeof pcb_panel>
+type InferredPcbPanel = z.infer<typeof pcb_panel>
+
+/**
+ * @deprecated use PcbPanel
+ */
+export type PCBPanel = PcbPanel
+
+expectTypesMatch<PcbPanel, InferredPcbPanel>(true)

--- a/tests/pcb_panel.test.ts
+++ b/tests/pcb_panel.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { pcb_panel } from "src/pcb/pcb_panel"
+import { any_circuit_element } from "src/any_circuit_element"
+
+test("pcb_panel parses and defaults covered_with_solder_mask", () => {
+  const panelData = {
+    type: "pcb_panel" as const,
+    pcb_panel_id: "pcb_panel_1",
+    width: "100mm",
+    height: "200mm",
+  }
+
+  const parsed = pcb_panel.parse(panelData)
+
+  expect(parsed.covered_with_solder_mask).toBe(true)
+})
+
+test("any_circuit_element includes pcb_panel", () => {
+  const panelData = {
+    type: "pcb_panel" as const,
+    pcb_panel_id: "pcb_panel_1",
+    width: "100mm",
+    height: "200mm",
+    covered_with_solder_mask: false,
+  }
+
+  expect(() => any_circuit_element.parse(panelData)).not.toThrow()
+})


### PR DESCRIPTION
## Summary
- add a pcb_panel component with dimensions and solder mask defaults
- export the new panel and include it in PCB and any_circuit_element unions
- allow pcb_board to reference an associated panel and cover with unit tests

## Testing
- bun test tests/pcb_panel.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f1b1a7e804832ebdc1594e5908df12