### PR TITLE
Add outline support to pcb_group elements

### DIFF
--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -13,6 +13,7 @@ export const pcb_group = z
     width: length,
     height: length,
     center: point,
+    outline: z.array(point).optional(),
     anchor_position: point.optional(),
     anchor_alignment: z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
@@ -45,6 +46,7 @@ export interface PcbGroup {
   width: Length
   height: Length
   center: Point
+  outline?: Point[]
   anchor_position?: Point
   anchor_alignment?:
     | "center"

--- a/tests/pcb_group_anchor.test.ts
+++ b/tests/pcb_group_anchor.test.ts
@@ -8,6 +8,12 @@ test("pcb_group with anchor_position and anchor_alignment", () => {
     width: 10,
     height: 10,
     center: { x: 0, y: 0 },
+    outline: [
+      { x: -5, y: -5 },
+      { x: 5, y: -5 },
+      { x: 5, y: 5 },
+      { x: -5, y: 5 },
+    ],
     pcb_component_ids: [],
     anchor_position: { x: 5, y: 5 },
     anchor_alignment: "top_left",
@@ -15,4 +21,10 @@ test("pcb_group with anchor_position and anchor_alignment", () => {
 
   expect(group.anchor_position).toEqual({ x: 5, y: 5 })
   expect(group.anchor_alignment).toBe("top_left")
+  expect(group.outline).toEqual([
+    { x: -5, y: -5 },
+    { x: 5, y: -5 },
+    { x: 5, y: 5 },
+    { x: -5, y: 5 },
+  ])
 })


### PR DESCRIPTION
## Summary
- allow pcb_group schema to accept optional outlines consistent with pcb_board
- validate outline parsing via pcb_group anchor test

## Testing
- bun test tests/pcb_group_anchor.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68f2741f8034832786faed4d5d16a741