### PR TITLE
Allow pcb_group width and height to be optional

### DIFF
--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -10,8 +10,8 @@ export const pcb_group = z
     source_group_id: z.string(),
     is_subcircuit: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
-    width: length,
-    height: length,
+    width: length.optional(),
+    height: length.optional(),
     center: point,
     outline: z.array(point).optional(),
     anchor_position: point.optional(),
@@ -43,8 +43,8 @@ export interface PcbGroup {
   source_group_id: string
   is_subcircuit?: boolean
   subcircuit_id?: string
-  width: Length
-  height: Length
+  width?: Length
+  height?: Length
   center: Point
   outline?: Point[]
   anchor_position?: Point

--- a/tests/pcb_group_autorouter.test.ts
+++ b/tests/pcb_group_autorouter.test.ts
@@ -7,9 +7,9 @@ test("pcb_group.autorouter_configuration.trace_clearance parses", () => {
   const group = pcb_group.parse({
     type: "pcb_group",
     source_group_id: "g1",
+    center: { x: 0, y: 0 },
     width: 10,
     height: 10,
-    center: { x: 0, y: 0 },
     pcb_component_ids: [],
     autorouter_configuration: { trace_clearance: 0.2 },
   })
@@ -20,9 +20,9 @@ test("pcb_group.autorouter_used_string is optional", () => {
   const group = pcb_group.parse({
     type: "pcb_group",
     source_group_id: "g1",
+    center: { x: 0, y: 0 },
     width: 10,
     height: 10,
-    center: { x: 0, y: 0 },
     pcb_component_ids: [],
   })
   expect(group.autorouter_used_string).toBeUndefined()
@@ -32,9 +32,9 @@ test("pcb_group.layout_mode is optional string", () => {
   const group = pcb_group.parse({
     type: "pcb_group",
     source_group_id: "g1",
+    center: { x: 0, y: 0 },
     width: 10,
     height: 10,
-    center: { x: 0, y: 0 },
     pcb_component_ids: [],
     layout_mode: "manual",
   })
@@ -43,10 +43,27 @@ test("pcb_group.layout_mode is optional string", () => {
   const withoutLayoutMode = pcb_group.parse({
     type: "pcb_group",
     source_group_id: "g1",
-    width: 10,
-    height: 10,
     center: { x: 0, y: 0 },
     pcb_component_ids: [],
   })
   expect(withoutLayoutMode.layout_mode).toBeUndefined()
+})
+
+test("pcb_group allows width and height to be omitted when outline is provided", () => {
+  const group = pcb_group.parse({
+    type: "pcb_group",
+    source_group_id: "g1",
+    center: { x: 0, y: 0 },
+    outline: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ],
+    pcb_component_ids: [],
+  })
+
+  expect(group.width).toBeUndefined()
+  expect(group.height).toBeUndefined()
+  expect(group.outline?.length).toBe(4)
 })


### PR DESCRIPTION
## Summary
- allow pcb_group width and height fields to be optional in the schema and type
- add a unit test ensuring pcb_group parses when only an outline is provided

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_b_68f28ff0ad7083279d6dbadee910c7b3