### PR TITLE
Remove stroke and fill options from PCB courtyard rectangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,10 +1009,6 @@ interface PcbCourtyardRect {
   width: Length
   height: Length
   layer: VisibleLayer
-  stroke_width: Length
-  is_filled?: boolean
-  has_stroke?: boolean
-  is_stroke_dashed?: boolean
   color?: string
 }
 ```

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -361,10 +361,6 @@ export interface PcbCourtyardRect {
   width: Length
   height: Length
   layer: VisibleLayer
-  stroke_width: Length
-  is_filled?: boolean
-  has_stroke?: boolean
-  is_stroke_dashed?: boolean
   color?: string
 }
 

--- a/src/pcb/pcb_courtyard_rect.ts
+++ b/src/pcb/pcb_courtyard_rect.ts
@@ -15,10 +15,6 @@ export const pcb_courtyard_rect = z
     width: length,
     height: length,
     layer: visible_layer,
-    stroke_width: length.default("0.1mm"),
-    is_filled: z.boolean().optional(),
-    has_stroke: z.boolean().optional(),
-    is_stroke_dashed: z.boolean().optional(),
     color: z.string().optional(),
   })
   .describe("Defines a courtyard rectangle on the PCB")
@@ -39,10 +35,6 @@ export interface PcbCourtyardRect {
   width: Length
   height: Length
   layer: VisibleLayer
-  stroke_width: Length
-  is_filled?: boolean
-  has_stroke?: boolean
-  is_stroke_dashed?: boolean
   color?: string
 }
 

--- a/tests/pcb_courtyard.test.ts
+++ b/tests/pcb_courtyard.test.ts
@@ -10,16 +10,13 @@ test("parse courtyard rect", () => {
     width: 3,
     height: 4,
     layer: "bottom",
-    is_filled: false,
-    has_stroke: true,
-    is_stroke_dashed: true,
   })
 
   expect(rect.layer).toBe("bottom")
-  expect(rect.stroke_width).toBeCloseTo(0.1)
-  expect(rect.is_filled).toBe(false)
-  expect(rect.has_stroke).toBe(true)
-  expect(rect.is_stroke_dashed).toBe(true)
+  expect(rect).not.toHaveProperty("stroke_width")
+  expect(rect).not.toHaveProperty("is_filled")
+  expect(rect).not.toHaveProperty("has_stroke")
+  expect(rect).not.toHaveProperty("is_stroke_dashed")
 })
 
 test("parse courtyard outline", () => {


### PR DESCRIPTION
## Summary
- remove stroke and fill related properties from `pcb_courtyard_rect`
- update documentation to match the simplified courtyard rectangle definition
- adjust courtyard schema tests to assert the removed properties are absent

## Testing
- bunx tsc --noEmit
- bun test tests/pcb_courtyard.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68f3a2c3ffdc832ea1d8cf0c773eb1f3