### PR TITLE
feat(simulation): Add source_component_id to simulation_switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2467,6 +2467,7 @@ interface SimulationExperiment {
 interface SimulationSwitch {
   type: "simulation_switch"
   simulation_switch_id: string
+  source_component_id?: string
   closes_at?: number
   opens_at?: number
   starts_closed?: boolean

--- a/src/simulation/simulation_switch.ts
+++ b/src/simulation/simulation_switch.ts
@@ -7,6 +7,7 @@ export const simulation_switch = z
   .object({
     type: z.literal("simulation_switch"),
     simulation_switch_id: getZodPrefixedIdWithDefault("simulation_switch"),
+    source_component_id: z.string().optional(),
     closes_at: ms.optional(),
     opens_at: ms.optional(),
     starts_closed: z.boolean().optional(),
@@ -21,6 +22,7 @@ type InferredSimulationSwitch = z.infer<typeof simulation_switch>
 export interface SimulationSwitch {
   type: "simulation_switch"
   simulation_switch_id: string
+  source_component_id?: string
   closes_at?: number
   opens_at?: number
   starts_closed?: boolean

--- a/tests/simulation_switch.test.ts
+++ b/tests/simulation_switch.test.ts
@@ -36,4 +36,18 @@ test("simulation_switch allows minimal definition", () => {
   expect(simSwitch.opens_at).toBeUndefined()
   expect(simSwitch.starts_closed).toBeUndefined()
   expect(simSwitch.switching_frequency).toBeUndefined()
+  expect(simSwitch.source_component_id).toBeUndefined()
+})
+
+test("simulation_switch with source_component_id", () => {
+  const input: SimulationSwitchInput = {
+    type: "simulation_switch",
+    source_component_id: "component1",
+  }
+
+  const result = simulation_switch.parse(input)
+  const simSwitch = result as SimulationSwitch
+
+  expect(simSwitch.source_component_id).toBe("component1")
+  expect(simSwitch.simulation_switch_id).toBeString()
 })


### PR DESCRIPTION
This adds an optional source_component_id to the simulation_switch element. This allows a simulation switch to  
be associated with a source_component, improving traceability between the simulation and source domains.              

 • Added source_component_id to the simulation_switch schema and interface.                                           
 • Updated tests for simulation_switch to cover the new field.                                                        
 • Regenerated the documentation.