### PR TITLE
Add optional metadata fields to PCB note components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,7 @@ interface PcbNoteDimension {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
   from: Point
   to: Point
   text?: string
@@ -1362,6 +1363,8 @@ interface PcbNoteLine {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   x1: Distance
   y1: Distance
   x2: Distance
@@ -1386,6 +1389,8 @@ interface PcbNotePath {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   route: Point[]
   stroke_width: Length
   color?: string
@@ -1406,6 +1411,8 @@ interface PcbNoteRect {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   center: Point
   width: Length
   height: Length
@@ -1431,9 +1438,10 @@ interface PcbNoteText {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
   font: "tscircuit2024"
   font_size: Length
-  text: string
+  text?: string
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -272,6 +272,7 @@ export interface PcbNoteDimension {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
   from: Point
   to: Point
   text?: string
@@ -287,6 +288,8 @@ export interface PcbNoteLine {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   x1: Distance
   y1: Distance
   x2: Distance
@@ -302,6 +305,8 @@ export interface PcbNotePath {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   route: Point[]
   stroke_width: Length
   color?: string
@@ -313,6 +318,8 @@ export interface PcbNoteRect {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   center: Point
   width: Length
   height: Length
@@ -329,9 +336,10 @@ export interface PcbNoteText {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
   font: "tscircuit2024"
   font_size: Length
-  text: string
+  text?: string
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/src/pcb/pcb_note_dimension.ts
+++ b/src/pcb/pcb_note_dimension.ts
@@ -10,6 +10,7 @@ export const pcb_note_dimension = z
     pcb_component_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    name: z.string().optional(),
     from: point,
     to: point,
     text: z.string().optional(),
@@ -32,6 +33,7 @@ export interface PcbNoteDimension {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
   from: Point
   to: Point
   text?: string

--- a/src/pcb/pcb_note_line.ts
+++ b/src/pcb/pcb_note_line.ts
@@ -10,6 +10,8 @@ export const pcb_note_line = z
     pcb_component_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    name: z.string().optional(),
+    text: z.string().optional(),
     x1: distance,
     y1: distance,
     x2: distance,
@@ -32,6 +34,8 @@ export interface PcbNoteLine {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   x1: Distance
   y1: Distance
   x2: Distance

--- a/src/pcb/pcb_note_path.ts
+++ b/src/pcb/pcb_note_path.ts
@@ -10,6 +10,8 @@ export const pcb_note_path = z
     pcb_component_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    name: z.string().optional(),
+    text: z.string().optional(),
     route: z.array(point),
     stroke_width: length.default("0.1mm"),
     color: z.string().optional(),
@@ -28,6 +30,8 @@ export interface PcbNotePath {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   route: Point[]
   stroke_width: Length
   color?: string

--- a/src/pcb/pcb_note_rect.ts
+++ b/src/pcb/pcb_note_rect.ts
@@ -10,6 +10,8 @@ export const pcb_note_rect = z
     pcb_component_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    name: z.string().optional(),
+    text: z.string().optional(),
     center: point,
     width: length,
     height: length,
@@ -33,6 +35,8 @@ export interface PcbNoteRect {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
+  text?: string
   center: Point
   width: Length
   height: Length

--- a/src/pcb/pcb_note_text.ts
+++ b/src/pcb/pcb_note_text.ts
@@ -10,9 +10,10 @@ export const pcb_note_text = z
     pcb_component_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    name: z.string().optional(),
     font: z.literal("tscircuit2024").default("tscircuit2024"),
     font_size: distance.default("1mm"),
-    text: z.string(),
+    text: z.string().optional(),
     anchor_position: point.default({ x: 0, y: 0 }),
     anchor_alignment: z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
@@ -33,9 +34,10 @@ export interface PcbNoteText {
   pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
+  name?: string
   font: "tscircuit2024"
   font_size: Length
-  text: string
+  text?: string
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/tests/pcb_note_components.test.ts
+++ b/tests/pcb_note_components.test.ts
@@ -22,11 +22,15 @@ test("pcb note rect defaults", () => {
     center: { x: "10mm", y: "5mm" },
     width: "4mm",
     height: "2mm",
+    name: "Keepout",
+    text: "Do not place vias",
   })
 
   expect(rect.stroke_width).toBeCloseTo(0.1)
   expect(rect.center.x).toBeCloseTo(10)
   expect(rect.center.y).toBeCloseTo(5)
+  expect(rect.name).toBe("Keepout")
+  expect(rect.text).toBe("Do not place vias")
 })
 
 test("pcb note path defaults", () => {
@@ -36,10 +40,14 @@ test("pcb note path defaults", () => {
       { x: 0, y: 0 },
       { x: "2mm", y: "1mm" },
     ],
+    name: "Route outline",
+    text: "Follow this path",
   })
 
   expect(path.stroke_width).toBeCloseTo(0.1)
   expect(path.route[1]!.x).toBeCloseTo(2)
+  expect(path.name).toBe("Route outline")
+  expect(path.text).toBe("Follow this path")
 })
 
 test("pcb note line defaults", () => {
@@ -49,11 +57,15 @@ test("pcb note line defaults", () => {
     y1: 0,
     x2: "1mm",
     y2: "2mm",
+    name: "Edge guide",
+    text: "Align connector",
   })
 
   expect(line.stroke_width).toBeCloseTo(0.1)
   expect(line.x2).toBeCloseTo(1)
   expect(line.y2).toBeCloseTo(2)
+  expect(line.name).toBe("Edge guide")
+  expect(line.text).toBe("Align connector")
 })
 
 test("pcb note dimension defaults", () => {
@@ -61,9 +73,23 @@ test("pcb note dimension defaults", () => {
     type: "pcb_note_dimension",
     from: { x: 0, y: 0 },
     to: { x: "10mm", y: 0 },
+    name: "Width",
+    text: "10mm",
   })
 
   expect(dimension.font_size).toBeCloseTo(1)
   expect(dimension.arrow_size).toBeCloseTo(1)
   expect(dimension.to.x).toBeCloseTo(10)
+  expect(dimension.name).toBe("Width")
+  expect(dimension.text).toBe("10mm")
+})
+
+test("pcb note text allows optional name and text", () => {
+  const note = pcb_note_text.parse({
+    type: "pcb_note_text",
+    name: "Callout",
+  })
+
+  expect(note.name).toBe("Callout")
+  expect(note.text).toBeUndefined()
 })


### PR DESCRIPTION
## Summary
- add optional name and text properties to all pcb note schemas and interfaces
- update documentation to reflect the new optional metadata fields
- extend pcb note tests to cover the new metadata and optional text handling

## Testing
- bun test tests/pcb_note_components.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f7ddc1cf4c832e92c4a4580a89761b