### PR TITLE
Add offset configuration to PCB dimension elements

### DIFF
--- a/src/pcb/pcb_fabrication_note_dimension.ts
+++ b/src/pcb/pcb_fabrication_note_dimension.ts
@@ -18,6 +18,13 @@ export const pcb_fabrication_note_dimension = z
     to: point,
     text: z.string().optional(),
     offset: length.optional(),
+    offset_distance: length.optional(),
+    offset_direction: z
+      .object({
+        x: z.number(),
+        y: z.number(),
+      })
+      .optional(),
     font: z.literal("tscircuit2024").default("tscircuit2024"),
     font_size: length.default("1mm"),
     color: z.string().optional(),
@@ -46,6 +53,11 @@ export interface PcbFabricationNoteDimension {
   to: Point
   text?: string
   offset?: Length
+  offset_distance?: Length
+  offset_direction?: {
+    x: number
+    y: number
+  }
   font: "tscircuit2024"
   font_size: Length
   color?: string

--- a/src/pcb/pcb_note_dimension.ts
+++ b/src/pcb/pcb_note_dimension.ts
@@ -14,6 +14,13 @@ export const pcb_note_dimension = z
     from: point,
     to: point,
     text: z.string().optional(),
+    offset_distance: length.optional(),
+    offset_direction: z
+      .object({
+        x: z.number(),
+        y: z.number(),
+      })
+      .optional(),
     font: z.literal("tscircuit2024").default("tscircuit2024"),
     font_size: length.default("1mm"),
     color: z.string().optional(),
@@ -37,6 +44,11 @@ export interface PcbNoteDimension {
   from: Point
   to: Point
   text?: string
+  offset_distance?: Length
+  offset_direction?: {
+    x: number
+    y: number
+  }
   font: "tscircuit2024"
   font_size: Length
   color?: string


### PR DESCRIPTION
## Summary
- add optional offset_distance and offset_direction to PCB note dimension schema and types
- extend PCB fabrication note dimension definitions with new offset configuration

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fd3e9ac4f0832e98bc6515c2698b43