### PR TITLE
Add text_ccw_rotation support to PCB dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,7 @@ interface PcbFabricationNoteDimension {
   from: Point
   to: Point
   text?: string
+  text_ccw_rotation?: number
   offset?: Length
   offset_distance?: Length
   offset_direction?: {
@@ -1366,6 +1367,7 @@ interface PcbNoteDimension {
   from: Point
   to: Point
   text?: string
+  text_ccw_rotation?: number
   offset_distance?: Length
   offset_direction?: {
     x: number

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -276,6 +276,7 @@ export interface PcbNoteDimension {
   from: Point
   to: Point
   text?: string
+  text_ccw_rotation?: number
   font: "tscircuit2024"
   font_size: Length
   color?: string

--- a/src/pcb/pcb_fabrication_note_dimension.ts
+++ b/src/pcb/pcb_fabrication_note_dimension.ts
@@ -17,6 +17,7 @@ export const pcb_fabrication_note_dimension = z
     from: point,
     to: point,
     text: z.string().optional(),
+    text_ccw_rotation: z.number().optional(),
     offset: length.optional(),
     offset_distance: length.optional(),
     offset_direction: z
@@ -52,6 +53,7 @@ export interface PcbFabricationNoteDimension {
   from: Point
   to: Point
   text?: string
+  text_ccw_rotation?: number
   offset?: Length
   offset_distance?: Length
   offset_direction?: {

--- a/src/pcb/pcb_note_dimension.ts
+++ b/src/pcb/pcb_note_dimension.ts
@@ -14,6 +14,7 @@ export const pcb_note_dimension = z
     from: point,
     to: point,
     text: z.string().optional(),
+    text_ccw_rotation: z.number().optional(),
     offset_distance: length.optional(),
     offset_direction: z
       .object({
@@ -44,6 +45,7 @@ export interface PcbNoteDimension {
   from: Point
   to: Point
   text?: string
+  text_ccw_rotation?: number
   offset_distance?: Length
   offset_direction?: {
     x: number


### PR DESCRIPTION
## Summary
- allow pcb_note_dimension text to specify an optional counter-clockwise rotation
- expose the same optional text rotation on pcb_fabrication_note_dimension entries
- document the new text_ccw_rotation property across README and component overview

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fd636f3128832e9cb025067c84bbc3