### PR TITLE
feat: add pcb copper text element

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbSilkscreenPill](#pcbsilkscreenpill)
     - [PcbSilkscreenRect](#pcbsilkscreenrect)
     - [PcbSilkscreenText](#pcbsilkscreentext)
+    - [PcbCopperText](#pcbcoppertext)
     - [PcbSolderPaste](#pcbsolderpaste)
     - [PcbText](#pcbtext)
     - [PcbThermalSpoke](#pcbthermalspoke)
@@ -1829,6 +1830,38 @@ Defines silkscreen text on the PCB
 interface PcbSilkscreenText {
   type: "pcb_silkscreen_text"
   pcb_silkscreen_text_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  font: "tscircuit2024"
+  font_size: Length
+  pcb_component_id: string
+  text: string
+  is_knockout?: boolean
+  knockout_padding?: {
+    left: Length
+    top: Length
+    bottom: Length
+    right: Length
+  }
+  ccw_rotation?: number
+  layer: LayerRef
+  is_mirrored?: boolean
+  anchor_position: Point
+  anchor_alignment: NinePointAnchor
+}
+```
+
+### PcbCopperText
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_copper_text.ts)
+
+Defines copper text on the PCB
+
+```typescript
+/** Defines copper text on the PCB */
+interface PcbCopperText {
+  type: "pcb_copper_text"
+  pcb_copper_text_id: string
   pcb_group_id?: string
   subcircuit_id?: string
   font: "tscircuit2024"

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -97,6 +97,24 @@ export interface PcbSilkscreenText {
     | "bottom_right"
 }
 
+export interface PcbCopperText {
+  type: "pcb_copper_text"
+  pcb_copper_text_id: string
+  font: "tscircuit2024"
+  font_size: Length
+  pcb_component_id: string
+  text: string
+  layer: LayerRef
+  is_mirrored?: boolean
+  anchor_position: Point
+  anchor_alignment:
+    | "center"
+    | "top_left"
+    | "top_right"
+    | "bottom_left"
+    | "bottom_right"
+}
+
 export interface PcbTraceError {
   type: "pcb_trace_error"
   pcb_trace_error_id: string

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -65,6 +65,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_silkscreen_line,
   pcb.pcb_silkscreen_path,
   pcb.pcb_silkscreen_text,
+  pcb.pcb_copper_text,
   pcb.pcb_silkscreen_rect,
   pcb.pcb_silkscreen_circle,
   pcb.pcb_silkscreen_oval,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -25,6 +25,7 @@ export * from "./pcb_trace_hint"
 export * from "./pcb_silkscreen_line"
 export * from "./pcb_silkscreen_path"
 export * from "./pcb_silkscreen_text"
+export * from "./pcb_copper_text"
 export * from "./pcb_silkscreen_rect"
 export * from "./pcb_silkscreen_circle"
 export * from "./pcb_silkscreen_oval"
@@ -84,6 +85,7 @@ import type { PcbSilkscreenPath } from "./pcb_silkscreen_path"
 import type { PcbSilkscreenText } from "./pcb_silkscreen_text"
 import type { PcbSilkscreenRect } from "./pcb_silkscreen_rect"
 import type { PcbSilkscreenCircle } from "./pcb_silkscreen_circle"
+import type { PcbCopperText } from "./pcb_copper_text"
 import type { PcbFabricationNoteRect } from "./pcb_fabrication_note_rect"
 import type { PcbFabricationNoteDimension } from "./pcb_fabrication_note_dimension"
 import type { PcbNoteText } from "./pcb_note_text"
@@ -133,6 +135,7 @@ export type PcbCircuitElement =
   | PcbSilkscreenLine
   | PcbSilkscreenPath
   | PcbSilkscreenText
+  | PcbCopperText
   | PcbSilkscreenRect
   | PcbSilkscreenCircle
   | PcbFabricationNoteRect

--- a/src/pcb/pcb_copper_text.ts
+++ b/src/pcb/pcb_copper_text.ts
@@ -1,0 +1,78 @@
+import { z } from "zod"
+import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
+import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
+import { distance, length, type Length } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import {
+  ninePointAnchor,
+  type NinePointAnchor,
+} from "src/common/NinePointAnchor"
+
+export const pcb_copper_text = z
+  .object({
+    type: z.literal("pcb_copper_text"),
+    pcb_copper_text_id: getZodPrefixedIdWithDefault("pcb_copper_text"),
+    pcb_group_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+    font: z.literal("tscircuit2024").default("tscircuit2024"),
+    font_size: distance.default("0.2mm"),
+    pcb_component_id: z.string(),
+    text: z.string(),
+    is_knockout: z.boolean().default(false).optional(),
+    knockout_padding: z
+      .object({
+        left: length,
+        top: length,
+        bottom: length,
+        right: length,
+      })
+      .default({
+        left: "0.2mm",
+        top: "0.2mm",
+        bottom: "0.2mm",
+        right: "0.2mm",
+      })
+      .optional(),
+    ccw_rotation: z.number().optional(),
+    layer: layer_ref,
+    is_mirrored: z.boolean().default(false).optional(),
+    anchor_position: point.default({ x: 0, y: 0 }),
+    anchor_alignment: ninePointAnchor.default("center"),
+  })
+  .describe("Defines copper text on the PCB")
+
+export type PcbCopperTextInput = z.input<typeof pcb_copper_text>
+type InferredPcbCopperText = z.infer<typeof pcb_copper_text>
+
+/**
+ * Defines copper text on the PCB
+ */
+export interface PcbCopperText {
+  type: "pcb_copper_text"
+  pcb_copper_text_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  font: "tscircuit2024"
+  font_size: Length
+  pcb_component_id: string
+  text: string
+  is_knockout?: boolean
+  knockout_padding?: {
+    left: Length
+    top: Length
+    bottom: Length
+    right: Length
+  }
+  ccw_rotation?: number
+  layer: LayerRef
+  is_mirrored?: boolean
+  anchor_position: Point
+  anchor_alignment: NinePointAnchor
+}
+
+/**
+ * @deprecated use PcbCopperText
+ */
+export type PCBCopperText = PcbCopperText
+
+expectTypesMatch<PcbCopperText, InferredPcbCopperText>(true)

--- a/tests/pcb_copper_text.test.ts
+++ b/tests/pcb_copper_text.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { pcb_copper_text } from "../src/pcb/pcb_copper_text"
+
+test("pcb_copper_text defaults", () => {
+  const text = pcb_copper_text.parse({
+    type: "pcb_copper_text",
+    pcb_component_id: "pcb_component_123",
+    text: "Copper",
+    layer: "top",
+  })
+
+  expect(text.font).toBe("tscircuit2024")
+  expect(text.font_size).toBeCloseTo(0.2)
+  expect(text.is_knockout).toBeUndefined()
+  expect(text.knockout_padding).toBeUndefined()
+  expect(text.is_mirrored).toBeUndefined()
+  expect(text.anchor_position).toEqual({ x: 0, y: 0 })
+  expect(text.anchor_alignment).toBe("center")
+})
+
+test("pcb_copper_text allows overrides", () => {
+  const text = pcb_copper_text.parse({
+    type: "pcb_copper_text",
+    pcb_component_id: "pcb_component_123",
+    text: "Bottom Copper",
+    layer: "bottom",
+    font_size: "0.4mm",
+    is_knockout: true,
+    knockout_padding: {
+      left: "0.1mm",
+      top: "0.3mm",
+      bottom: "0.1mm",
+      right: "0.3mm",
+    },
+    ccw_rotation: 45,
+    is_mirrored: true,
+    anchor_position: { x: 1, y: 2 },
+    anchor_alignment: "bottom_right",
+  })
+
+  expect(text.font_size).toBeCloseTo(0.4)
+  expect(text.is_knockout).toBe(true)
+  expect(text.knockout_padding).toEqual({
+    left: 0.1,
+    top: 0.3,
+    bottom: 0.1,
+    right: 0.3,
+  })
+  expect(text.ccw_rotation).toBe(45)
+  expect(text.is_mirrored).toBe(true)
+  expect(text.anchor_position).toEqual({ x: 1, y: 2 })
+  expect(text.anchor_alignment).toBe("bottom_right")
+})


### PR DESCRIPTION
## Summary
- add pcb_copper_text schema for modeling copper layer text
- export the new element through pcb aggregations and any_circuit_element
- document the new element and cover defaults with targeted tests

## Testing
- bun test tests/pcb_copper_text.test.ts
- bunx tsc --noEmit && echo "tsc ok"
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68fda65f3474832eb653b1ed9d9ac1b5