### PR TITLE
Allow optional component references on ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,8 @@ interface SourcePort {
   port_hints?: string[]
   name: string
   source_port_id: string
-  source_component_id: string
+  source_component_id?: string
+  source_group_id?: string
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
 }
@@ -1660,7 +1661,7 @@ interface PcbPort {
   pcb_group_id?: string
   subcircuit_id?: string
   source_port_id: string
-  pcb_component_id: string
+  pcb_component_id?: string
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -481,7 +481,7 @@ export interface PcbPort {
   type: "pcb_port"
   pcb_port_id: string
   source_port_id: string
-  pcb_component_id: string
+  pcb_component_id?: string
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/docs/SOURCE_COMPONENT_OVERVIEW.md
+++ b/docs/SOURCE_COMPONENT_OVERVIEW.md
@@ -118,7 +118,8 @@ interface SourcePort {
   port_hints?: string[]
   name: string
   source_port_id: string
-  source_component_id: string
+  source_component_id?: string
+  source_group_id?: string
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
 }

--- a/src/pcb/pcb_port.ts
+++ b/src/pcb/pcb_port.ts
@@ -11,7 +11,7 @@ export const pcb_port = z
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
     source_port_id: z.string(),
-    pcb_component_id: z.string(),
+    pcb_component_id: z.string().optional(),
     x: distance,
     y: distance,
     layers: z.array(layer_ref),
@@ -31,7 +31,7 @@ export interface PcbPort {
   pcb_group_id?: string
   subcircuit_id?: string
   source_port_id: string
-  pcb_component_id: string
+  pcb_component_id?: string
   x: Distance
   y: Distance
   layers: LayerRef[]

--- a/src/source/source_port.ts
+++ b/src/source/source_port.ts
@@ -7,7 +7,8 @@ export const source_port = z.object({
   port_hints: z.array(z.string()).optional(),
   name: z.string(),
   source_port_id: z.string(),
-  source_component_id: z.string(),
+  source_component_id: z.string().optional(),
+  source_group_id: z.string().optional(),
   subcircuit_id: z.string().optional(),
   subcircuit_connectivity_map_key: z.string().optional(),
 })
@@ -24,7 +25,8 @@ export interface SourcePort {
   port_hints?: string[]
   name: string
   source_port_id: string
-  source_component_id: string
+  source_component_id?: string
+  source_group_id?: string
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
 }


### PR DESCRIPTION
## Summary
- allow source ports to omit a source component identifier and optionally reference a source group
- allow pcb ports to omit the related pcb component identifier
- document the new optional fields across the README and component overviews

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68fef583c0d4832ea6b86443cc3a1d5c