### PR TITLE
Add optional net assignment flags to PCB via

### DIFF
--- a/README.md
+++ b/README.md
@@ -2059,6 +2059,8 @@ interface PcbVia {
   to_layer?: LayerRef
   layers: LayerRef[]
   pcb_trace_id?: string
+  net_is_assignable?: boolean
+  net_assigned?: boolean
 }
 ```
 

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -458,6 +458,8 @@ export interface PcbVia {
   hole_diameter: Distance
   layers: LayerRef[]
   pcb_trace_id?: string
+  net_is_assignable?: boolean
+  net_assigned?: boolean
 }
 
 export interface PcbSilkscreenOval {

--- a/src/pcb/pcb_via.ts
+++ b/src/pcb/pcb_via.ts
@@ -20,6 +20,8 @@ export const pcb_via = z
     to_layer: layer_ref.optional(),
     layers: z.array(layer_ref),
     pcb_trace_id: z.string().optional(),
+    net_is_assignable: z.boolean().optional(),
+    net_assigned: z.boolean().optional(),
   })
   .describe("Defines a via on the PCB")
 
@@ -44,6 +46,8 @@ export interface PcbVia {
   to_layer?: LayerRef
   layers: LayerRef[]
   pcb_trace_id?: string
+  net_is_assignable?: boolean
+  net_assigned?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- add optional `net_is_assignable` and `net_assigned` boolean properties to the `pcb_via` schema and type
- document the new optional net properties in README and PCB component overview

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_6904f6cf3bbc832ea9e444b1326fc4d8