### PR TITLE
Add PCB group and component positioning metadata

### DIFF
--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -17,6 +17,10 @@ export const pcb_component = z
     do_not_place: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
+    position_mode: z
+      .enum(["packed", "relative_to_group_anchor", "none"])
+      .optional(),
+    positioned_relative_to_pcb_group_id: z.string().optional(),
     obstructs_within_bounds: z
       .boolean()
       .default(true)
@@ -44,6 +48,8 @@ export interface PcbComponent {
   height: Length
   do_not_place?: boolean
   pcb_group_id?: string
+  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  positioned_relative_to_pcb_group_id?: string
   obstructs_within_bounds: boolean
 }
 

--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -19,6 +19,7 @@ export const pcb_group = z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
       .optional(),
     pcb_component_ids: z.array(z.string()),
+    child_layout_mode: z.enum(["packed", "none"]).optional(),
     name: z.string().optional(),
     description: z.string().optional(),
     layout_mode: z.string().optional(),
@@ -55,6 +56,7 @@ export interface PcbGroup {
     | "bottom_left"
     | "bottom_right"
   pcb_component_ids: string[]
+  child_layout_mode?: "packed" | "none"
   name?: string
   description?: string
   layout_mode?: string

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { pcb_component } from "src/pcb/pcb_component"
+
+const baseComponent = {
+  type: "pcb_component" as const,
+  pcb_component_id: "pcb_component_1",
+  source_component_id: "source_component_1",
+  center: { x: 0, y: 0 },
+  layer: "top" as const,
+  rotation: 0,
+  width: 1,
+  height: 1,
+}
+
+const positionModes = ["packed", "relative_to_group_anchor", "none"] as const
+
+for (const position_mode of positionModes) {
+  test(`pcb_component allows position_mode ${position_mode}`, () => {
+    const parsed = pcb_component.parse({
+      ...baseComponent,
+      position_mode,
+    })
+
+    expect(parsed.position_mode).toBe(position_mode)
+  })
+}
+
+test("pcb_component allows positioned_relative_to_pcb_group_id", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    positioned_relative_to_pcb_group_id: "pcb_group_1",
+  })
+
+  expect(parsed.positioned_relative_to_pcb_group_id).toBe("pcb_group_1")
+})
+
+test("pcb_component rejects invalid position_mode", () => {
+  expect(() =>
+    pcb_component.parse({
+      ...baseComponent,
+      position_mode: "invalid",
+    }),
+  ).toThrowError()
+})

--- a/tests/pcb_group_child_layout_mode.test.ts
+++ b/tests/pcb_group_child_layout_mode.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { pcb_group } from "src/pcb/pcb_group"
+
+const childLayoutModes = ["packed", "none"] as const
+
+for (const child_layout_mode of childLayoutModes) {
+  test(`pcb_group allows child_layout_mode ${child_layout_mode}`, () => {
+    const parsed = pcb_group.parse({
+      type: "pcb_group",
+      pcb_group_id: "pcb_group_1",
+      source_group_id: "source_group_1",
+      center: { x: 0, y: 0 },
+      pcb_component_ids: [],
+      child_layout_mode,
+    })
+
+    expect(parsed.child_layout_mode).toBe(child_layout_mode)
+  })
+}
+
+test("pcb_group rejects invalid child_layout_mode", () => {
+  expect(() =>
+    pcb_group.parse({
+      type: "pcb_group",
+      pcb_group_id: "pcb_group_1",
+      source_group_id: "source_group_1",
+      center: { x: 0, y: 0 },
+      pcb_component_ids: [],
+      child_layout_mode: "invalid",
+    }),
+  ).toThrowError()
+})


### PR DESCRIPTION
## Summary
- add an optional `child_layout_mode` enum to `pcb_group`
- support optional `position_mode` and `positioned_relative_to_pcb_group_id` fields on `pcb_component`
- cover the new schema fields with dedicated bun tests

## Testing
- bunx tsc --noEmit
- bun test tests/pcb_group_child_layout_mode.test.ts
- bun test tests/pcb_component_position_mode.test.ts

------
https://chatgpt.com/codex/tasks/task_b_69096bdd1240832e8c930b678376c8fe