### PR TITLE
Make PCBBoard width and height optional for outlined boards

### DIFF
--- a/src/pcb/pcb_board.ts
+++ b/src/pcb/pcb_board.ts
@@ -10,8 +10,8 @@ export const pcb_board = z
     pcb_panel_id: z.string().optional(),
     is_subcircuit: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
-    width: length,
-    height: length,
+    width: length.optional(),
+    height: length.optional(),
     center: point,
     thickness: length.optional().default(1.4),
     num_layers: z.number().optional().default(4),
@@ -29,8 +29,8 @@ export interface PcbBoard {
   pcb_panel_id?: string
   is_subcircuit?: boolean
   subcircuit_id?: string
-  width: Length
-  height: Length
+  width?: Length
+  height?: Length
   thickness: Length
   num_layers: number
   center: Point

--- a/tests/pcb_board.test.ts
+++ b/tests/pcb_board.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "bun:test"
+import { pcb_board } from "../src/pcb/pcb_board"
+
+test("pcb_board with width and height (rectangular board)", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    width: "10mm",
+    height: "20mm",
+    center: { x: 0, y: 0 },
+  })
+
+  expect(board.width).toBe(10)
+  expect(board.height).toBe(20)
+  expect(board.center).toEqual({ x: 0, y: 0 })
+})
+
+test("pcb_board with outline allows width and height to be omitted", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    center: { x: 0, y: 0 },
+    outline: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ],
+  })
+
+  expect(board.width).toBeUndefined()
+  expect(board.height).toBeUndefined()
+  expect(board.outline?.length).toBe(4)
+})
+
+test("pcb_board can have both width/height and outline", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    width: "10mm",
+    height: "20mm",
+    center: { x: 0, y: 0 },
+    outline: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ],
+  })
+
+  expect(board.width).toBe(10)
+  expect(board.height).toBe(20)
+  expect(board.outline?.length).toBe(4)
+})


### PR DESCRIPTION
This PR makes the `width` and `height` properties optional on the `PCBBoard` interface to support boards with custom outlines.

Currently, `PCBBoard` requires `width` and `height` as mandatory properties. However, when a board has a custom `outline` (defined by an array of points), these dimensions should not be present since the board's shape and size are determined by the outline itself.

## Changes
- Changed `width: number` to `width?: number` 
- Changed `height: number` to `height?: number`

## Use Cases
- **Rectangular boards**: specify `width` and `height`
- **Outlined/custom-shaped boards**: omit `width`/`height`, use `outline` instead

## Related
This change enables proper support for non-rectangular board shapes in tscircuit/core (tscircuit/core#1516).
Which in turn will also help PR#1614

- New test file added to check for this (pcb_board.test.ts)
- Existing tests should pass (rectangular boards still work)
- New functionality: boards with outlines can now properly omit width/height