### PR TITLE
feat: add subcircuit connectivity key to pcb via

### DIFF
--- a/README.md
+++ b/README.md
@@ -2055,6 +2055,7 @@ interface PcbVia {
   pcb_via_id: string
   pcb_group_id?: string
   subcircuit_id?: string
+  subcircuit_connectivity_key?: string
   x: Distance
   y: Distance
   outer_diameter: Distance

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -452,6 +452,9 @@ export interface PCBKeepout {
 export interface PcbVia {
   type: "pcb_via"
   pcb_via_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  subcircuit_connectivity_key?: string
   x: Distance
   y: Distance
   outer_diameter: Distance

--- a/src/pcb/pcb_via.ts
+++ b/src/pcb/pcb_via.ts
@@ -10,6 +10,7 @@ export const pcb_via = z
     pcb_via_id: getZodPrefixedIdWithDefault("pcb_via"),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    subcircuit_connectivity_key: z.string().optional(),
     x: distance,
     y: distance,
     outer_diameter: distance.default("0.6mm"),
@@ -36,6 +37,7 @@ export interface PcbVia {
   pcb_via_id: string
   pcb_group_id?: string
   subcircuit_id?: string
+  subcircuit_connectivity_key?: string
   x: Distance
   y: Distance
   outer_diameter: Distance

--- a/tests/pcb_via.test.ts
+++ b/tests/pcb_via.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { pcb_via, type PcbVia } from "../src/pcb/pcb_via"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_via allows subcircuit_connectivity_key", () => {
+  const via = pcb_via.parse({
+    type: "pcb_via",
+    x: 1,
+    y: 2,
+    layers: ["top", "bottom"],
+    subcircuit_connectivity_key: "foo",
+  })
+
+  expect(via.subcircuit_connectivity_key).toBe("foo")
+})
+
+test("any_circuit_element includes pcb_via with subcircuit_connectivity_key", () => {
+  const via = any_circuit_element.parse({
+    type: "pcb_via",
+    x: 1,
+    y: 2,
+    layers: ["top", "bottom"],
+    subcircuit_connectivity_key: "bar",
+  }) as PcbVia
+
+  expect(via.subcircuit_connectivity_key).toBe("bar")
+})


### PR DESCRIPTION
## Summary
- add an optional `subcircuit_connectivity_key` field to the `pcb_via` schema and type
- document the new property in the README and PCB component overview
- cover the change with tests ensuring `pcb_via` and `any_circuit_element` accept the field

## Testing
- bun test tests/pcb_via.test.ts
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69113a407834832eafa3f529a4c2812a)