### PR TITLE
Rename pcb_via connectivity key property

### DIFF
--- a/README.md
+++ b/README.md
@@ -2055,7 +2055,7 @@ interface PcbVia {
   pcb_via_id: string
   pcb_group_id?: string
   subcircuit_id?: string
-  subcircuit_connectivity_key?: string
+  subcircuit_connectivity_map_key?: string
   x: Distance
   y: Distance
   outer_diameter: Distance

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -454,7 +454,7 @@ export interface PcbVia {
   pcb_via_id: string
   pcb_group_id?: string
   subcircuit_id?: string
-  subcircuit_connectivity_key?: string
+  subcircuit_connectivity_map_key?: string
   x: Distance
   y: Distance
   outer_diameter: Distance

--- a/src/pcb/pcb_via.ts
+++ b/src/pcb/pcb_via.ts
@@ -10,7 +10,7 @@ export const pcb_via = z
     pcb_via_id: getZodPrefixedIdWithDefault("pcb_via"),
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
-    subcircuit_connectivity_key: z.string().optional(),
+    subcircuit_connectivity_map_key: z.string().optional(),
     x: distance,
     y: distance,
     outer_diameter: distance.default("0.6mm"),
@@ -37,7 +37,7 @@ export interface PcbVia {
   pcb_via_id: string
   pcb_group_id?: string
   subcircuit_id?: string
-  subcircuit_connectivity_key?: string
+  subcircuit_connectivity_map_key?: string
   x: Distance
   y: Distance
   outer_diameter: Distance

--- a/tests/pcb_via.test.ts
+++ b/tests/pcb_via.test.ts
@@ -2,26 +2,26 @@ import { expect, test } from "bun:test"
 import { pcb_via, type PcbVia } from "../src/pcb/pcb_via"
 import { any_circuit_element } from "../src/any_circuit_element"
 
-test("pcb_via allows subcircuit_connectivity_key", () => {
+test("pcb_via allows subcircuit_connectivity_map_key", () => {
   const via = pcb_via.parse({
     type: "pcb_via",
     x: 1,
     y: 2,
     layers: ["top", "bottom"],
-    subcircuit_connectivity_key: "foo",
+    subcircuit_connectivity_map_key: "foo",
   })
 
-  expect(via.subcircuit_connectivity_key).toBe("foo")
+  expect(via.subcircuit_connectivity_map_key).toBe("foo")
 })
 
-test("any_circuit_element includes pcb_via with subcircuit_connectivity_key", () => {
+test("any_circuit_element includes pcb_via with subcircuit_connectivity_map_key", () => {
   const via = any_circuit_element.parse({
     type: "pcb_via",
     x: 1,
     y: 2,
     layers: ["top", "bottom"],
-    subcircuit_connectivity_key: "bar",
+    subcircuit_connectivity_map_key: "bar",
   }) as PcbVia
 
-  expect(via.subcircuit_connectivity_key).toBe("bar")
+  expect(via.subcircuit_connectivity_map_key).toBe("bar")
 })


### PR DESCRIPTION
## Summary
- rename the pcb_via subcircuit connectivity property to `subcircuit_connectivity_map_key`
- update documentation and tests to match the new property name

## Testing
- bunx tsc --noEmit
- bun test tests/pcb_via.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691142a79638832ea33996845e1c8985)