### PR TITLE
Add center property to PCB panel schema

### DIFF
--- a/src/pcb/pcb_panel.ts
+++ b/src/pcb/pcb_panel.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { getZodPrefixedIdWithDefault } from "src/common"
+import { getZodPrefixedIdWithDefault, point, type Point } from "src/common"
 import { length, type Length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
@@ -9,6 +9,7 @@ export const pcb_panel = z
     pcb_panel_id: getZodPrefixedIdWithDefault("pcb_panel"),
     width: length,
     height: length,
+    center: point,
     covered_with_solder_mask: z.boolean().optional().default(true),
   })
   .describe("Defines a PCB panel that can contain multiple boards")
@@ -21,6 +22,7 @@ export interface PcbPanel {
   pcb_panel_id: string
   width: Length
   height: Length
+  center: Point
   covered_with_solder_mask: boolean
 }
 

--- a/tests/pcb_panel.test.ts
+++ b/tests/pcb_panel.test.ts
@@ -8,6 +8,7 @@ test("pcb_panel parses and defaults covered_with_solder_mask", () => {
     pcb_panel_id: "pcb_panel_1",
     width: "100mm",
     height: "200mm",
+    center: { x: 0, y: 0 },
   }
 
   const parsed = pcb_panel.parse(panelData)
@@ -21,6 +22,7 @@ test("any_circuit_element includes pcb_panel", () => {
     pcb_panel_id: "pcb_panel_1",
     width: "100mm",
     height: "200mm",
+    center: { x: 0, y: 0 },
     covered_with_solder_mask: false,
   }
 


### PR DESCRIPTION
## Summary
- add a required center point to the pcb_panel schema and TypeScript interface
- update pcb panel tests to include the center position

## Testing
- bun test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914bfcec4f88333af0f832c99939675)