### PR TITLE
feat(schematic): Add name property to schematic voltage probe

### DIFF
--- a/src/schematic/schematic_voltage_probe.ts
+++ b/src/schematic/schematic_voltage_probe.ts
@@ -9,6 +9,7 @@ export interface SchematicVoltageProbe {
   position: Point
   schematic_trace_id: string
   voltage?: number
+  name?: string
   subcircuit_id?: string
 }
 
@@ -19,6 +20,7 @@ export const schematic_voltage_probe = z
     position: point,
     schematic_trace_id: z.string(),
     voltage: voltage.optional(),
+    name: z.string().optional(),
     subcircuit_id: z.string().optional(),
   })
   .describe("Defines a voltage probe measurement point on a schematic trace")


### PR DESCRIPTION
This change adds an optional name property to SchematicVoltageProbe.                                              

This allows a name to be assigned to a voltage probe in the schematic, which can be used to identify simulation   
results associated with that probe.                                                                               

The name property has been added to both the TypeScript interface and the Zod schema in                           
src/schematic/schematic_voltage_probe.ts.