### PR TITLE
Add color property to voltage probes and simulation graphs

### DIFF
--- a/src/schematic/schematic_voltage_probe.ts
+++ b/src/schematic/schematic_voltage_probe.ts
@@ -11,6 +11,7 @@ export interface SchematicVoltageProbe {
   schematic_trace_id: string
   voltage?: number
   subcircuit_id?: string
+  color?: string
 }
 
 export const schematic_voltage_probe = z
@@ -22,6 +23,7 @@ export const schematic_voltage_probe = z
     schematic_trace_id: z.string(),
     voltage: voltage.optional(),
     subcircuit_id: z.string().optional(),
+    color: z.string().optional(),
   })
   .describe("Defines a voltage probe measurement point on a schematic trace")
 

--- a/src/simulation/simulation_transient_voltage_graph.ts
+++ b/src/simulation/simulation_transient_voltage_graph.ts
@@ -15,6 +15,7 @@ export interface SimulationTransientVoltageGraph {
   start_time_ms: number
   end_time_ms: number
   name?: string
+  color?: string
 }
 
 export const simulation_transient_voltage_graph = z
@@ -32,6 +33,7 @@ export const simulation_transient_voltage_graph = z
     start_time_ms: ms,
     end_time_ms: ms,
     name: z.string().optional(),
+    color: z.string().optional(),
   })
   .describe("Stores voltage measurements over time for a simulation")
 

--- a/src/simulation/simulation_voltage_probe.ts
+++ b/src/simulation/simulation_voltage_probe.ts
@@ -12,6 +12,7 @@ export const simulation_voltage_probe = z
     source_port_id: z.string().optional(),
     source_net_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
+    color: z.string().optional(),
   })
   .describe(
     "Defines a voltage probe for simulation, connected to a port or a net",
@@ -39,6 +40,7 @@ export interface SimulationVoltageProbe {
   source_port_id?: string
   source_net_id?: string
   subcircuit_id?: string
+  color?: string
 }
 
 expectTypesMatch<SimulationVoltageProbe, InferredSimulationVoltageProbe>(true)


### PR DESCRIPTION
 Summary
- Add optional `color` property to simulation voltage probes, schematic voltage probes, and simulation transient voltage graphs
- Enables custom color styling for voltage measurements in visualizations

 Changes
- **SimulationVoltageProbe**: Added optional `color` field (src/simulation/simulation_voltage_probe.ts)
- **SimulationTransientVoltageGraph**: Added optional `color` field (src/simulation/simulation_transient_voltage_graph.ts)
- **SchematicVoltageProbe**: Added optional `color` field (src/schematic/schematic_voltage_probe.ts)
The color property accepts any CSS color string (e.g., "red", "#ff0000", "rgb(255, 0, 0)") and can be used to customize the appearance of voltage probes and graphs in circuit visualizations.