### PR TITLE
Add path support to pcb_cutout with slot properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 package-lock.json
 .aider*
 .env
+opencode

--- a/src/pcb/pcb_cutout.ts
+++ b/src/pcb/pcb_cutout.ts
@@ -88,17 +88,55 @@ export interface PcbCutoutPolygon {
 }
 expectTypesMatch<PcbCutoutPolygon, InferredPcbCutoutPolygon>(true)
 
+// Path Cutout (for slots along a path)
+export const pcb_cutout_path = pcb_cutout_base.extend({
+  shape: z.literal("path"),
+  route: z.array(point),
+  slot_width: length,
+  slot_length: length.optional(),
+  space_between_slots: length.optional(),
+  slot_corner_radius: length.optional(),
+})
+export type PcbCutoutPathInput = z.input<typeof pcb_cutout_path>
+type InferredPcbCutoutPath = z.infer<typeof pcb_cutout_path>
+/**
+ * Defines a path-based cutout on the PCB, creating slots along the specified path.
+ * When slot_length and space_between_slots are specified, creates a dashed pattern of slots.
+ * When they are omitted, creates a continuous slot along the entire path.
+ * The slot_corner_radius controls the rounding of slot corners (0 = square, slot_width/2 = circle).
+ */
+export interface PcbCutoutPath {
+  type: "pcb_cutout"
+  pcb_cutout_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  pcb_board_id?: string
+  pcb_panel_id?: string
+  shape: "path"
+  route: Point[]
+  slot_width: Length
+  slot_length?: Length
+  space_between_slots?: Length
+  slot_corner_radius?: Length
+}
+expectTypesMatch<PcbCutoutPath, InferredPcbCutoutPath>(true)
+
 // Union of all cutout shapes
 export const pcb_cutout = z
   .discriminatedUnion("shape", [
     pcb_cutout_rect,
     pcb_cutout_circle,
     pcb_cutout_polygon,
+    pcb_cutout_path,
   ])
   .describe("Defines a cutout on the PCB, removing board material.")
 
 export type PcbCutoutInput = z.input<typeof pcb_cutout>
-export type PcbCutout = PcbCutoutRect | PcbCutoutCircle | PcbCutoutPolygon
+export type PcbCutout =
+  | PcbCutoutRect
+  | PcbCutoutCircle
+  | PcbCutoutPolygon
+  | PcbCutoutPath
 
 type InferredPcbCutout = z.infer<typeof pcb_cutout>
 expectTypesMatch<PcbCutout, InferredPcbCutout>(true)

--- a/tests/pcb_cutout_path.test.ts
+++ b/tests/pcb_cutout_path.test.ts
@@ -1,0 +1,148 @@
+import { test, expect } from "bun:test"
+import { pcb_cutout_path } from "src/pcb/pcb_cutout"
+
+test("pcb_cutout_path with continuous slot", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    pcb_cutout_id: "pcb_cutout_1",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    slot_width: "2mm",
+  })
+
+  expect(cutout.shape).toBe("path")
+  expect(cutout.route).toHaveLength(3)
+  expect(cutout.slot_width).toBe(2)
+  expect(cutout.slot_length).toBeUndefined()
+  expect(cutout.space_between_slots).toBeUndefined()
+})
+
+test("pcb_cutout_path with dashed slots", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    pcb_cutout_id: "pcb_cutout_2",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 20, y: 0 },
+    ],
+    slot_width: "1.5mm",
+    slot_length: "3mm",
+    space_between_slots: "2mm",
+  })
+
+  expect(cutout.shape).toBe("path")
+  expect(cutout.slot_width).toBe(1.5)
+  expect(cutout.slot_length).toBe(3)
+  expect(cutout.space_between_slots).toBe(2)
+})
+
+test("pcb_cutout_path with numeric values", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    pcb_cutout_id: "pcb_cutout_3",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 5, y: 5 },
+      { x: 10, y: 5 },
+    ],
+    slot_width: 2,
+    slot_length: 3,
+    space_between_slots: 1,
+  })
+
+  expect(cutout.shape).toBe("path")
+  expect(cutout.slot_width).toBe(2)
+  expect(cutout.slot_length).toBe(3)
+  expect(cutout.space_between_slots).toBe(1)
+})
+
+test("pcb_cutout_path with optional board and panel ids", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    pcb_cutout_id: "pcb_cutout_4",
+    pcb_board_id: "pcb_board_1",
+    pcb_panel_id: "pcb_panel_1",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    slot_width: "1mm",
+  })
+
+  expect(cutout.pcb_board_id).toBe("pcb_board_1")
+  expect(cutout.pcb_panel_id).toBe("pcb_panel_1")
+})
+
+test("pcb_cutout_path supports union type", () => {
+  // Import the full union type
+  const { pcb_cutout } = require("src/pcb/pcb_cutout")
+
+  const cutout = pcb_cutout.parse({
+    type: "pcb_cutout",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+      { x: 5, y: 5 },
+    ],
+    slot_width: "1.5mm",
+    slot_length: "2mm",
+    space_between_slots: "1mm",
+  })
+
+  expect(cutout.type).toBe("pcb_cutout")
+  expect(cutout.shape).toBe("path")
+})
+
+test("pcb_cutout_path with square corners (corner_radius = 0)", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+    ],
+    slot_width: "2mm",
+    slot_corner_radius: 0,
+  })
+
+  expect(cutout.slot_corner_radius).toBe(0)
+})
+
+test("pcb_cutout_path with rounded corners", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+    ],
+    slot_width: "2mm",
+    slot_corner_radius: "0.5mm",
+  })
+
+  expect(cutout.slot_corner_radius).toBe(0.5)
+})
+
+test("pcb_cutout_path with fully circular slot (corner_radius = slot_width/2)", () => {
+  const cutout = pcb_cutout_path.parse({
+    type: "pcb_cutout",
+    shape: "path",
+    route: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+    ],
+    slot_width: "2mm",
+    slot_corner_radius: "1mm", // Half of slot_width for circular
+  })
+
+  expect(cutout.slot_width).toBe(2)
+  expect(cutout.slot_corner_radius).toBe(1)
+})


### PR DESCRIPTION
Adds a new `path` shape variant to `pcb_cutout` for creating slots along a defined path with customizable slot properties.
 
- Add `pcb_cutout_path` with the following properties:
  - `route: Point[]` - Array of points defining the path
  - `slot_width: Length` - Width of the slot (required)
  - `slot_length?: Length` - Length of individual slots for dashed pattern (optional)
  - `space_between_slots?: Length` - Spacing between slots for dashed pattern (optional)
  - `slot_corner_radius?: Length` - Corner radius for slot rounding (optional)
- Update `PcbCutout` union type to include `PcbCutoutPath`