### PR TITLE
feat(probes): Add name property to schematic and simulation voltage probes

### DIFF
--- a/src/schematic/schematic_voltage_probe.ts
+++ b/src/schematic/schematic_voltage_probe.ts
@@ -7,6 +7,7 @@ export interface SchematicVoltageProbe {
   type: "schematic_voltage_probe"
   schematic_voltage_probe_id: string
   source_component_id?: string
+  name?: string
   position: Point
   schematic_trace_id: string
   voltage?: number
@@ -19,6 +20,7 @@ export const schematic_voltage_probe = z
     type: z.literal("schematic_voltage_probe"),
     schematic_voltage_probe_id: z.string(),
     source_component_id: z.string().optional(),
+    name: z.string().optional(),
     position: point,
     schematic_trace_id: z.string(),
     voltage: voltage.optional(),

--- a/src/simulation/simulation_voltage_probe.ts
+++ b/src/simulation/simulation_voltage_probe.ts
@@ -9,6 +9,7 @@ export const simulation_voltage_probe = z
       "simulation_voltage_probe",
     ),
     source_component_id: z.string().optional(),
+    name: z.string().optional(),
     source_port_id: z.string().optional(),
     source_net_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
@@ -37,6 +38,7 @@ export interface SimulationVoltageProbe {
   type: "simulation_voltage_probe"
   simulation_voltage_probe_id: string
   source_component_id?: string
+  name?: string
   source_port_id?: string
   source_net_id?: string
   subcircuit_id?: string

--- a/tests/simulation_voltage_probe.test.ts
+++ b/tests/simulation_voltage_probe.test.ts
@@ -45,6 +45,20 @@ test("simulation_voltage_probe with no connection ids should throw", () => {
   expect(() => simulation_voltage_probe.parse(input)).toThrow()
 })
 
+test("simulation_voltage_probe parses with name", () => {
+  const input: SimulationVoltageProbeInput = {
+    type: "simulation_voltage_probe",
+    source_net_id: "net1",
+    name: "My Probe",
+  }
+
+  const result = simulation_voltage_probe.parse(input)
+  const probe = result as SimulationVoltageProbe
+
+  expect(probe.source_net_id).toBe("net1")
+  expect(probe.name).toBe("My Probe")
+})
+
 test("simulation_voltage_probe with both connection ids should throw", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",

--- a/tests/source_simple_voltage_probe.test.ts
+++ b/tests/source_simple_voltage_probe.test.ts
@@ -49,7 +49,9 @@ test("source_simple_voltage_probe links to schematic and simulation", () => {
   expect(schematicProbe.source_component_id).toBe(
     sourceVoltageProbe.source_component_id,
   )
+  expect(schematicProbe.name).toBe("VP1")
   expect(simulationProbe.source_component_id).toBe(
     sourceVoltageProbe.source_component_id,
   )
+  expect(simulationProbe.name).toBe("VP1")
 })


### PR DESCRIPTION
This change adds the optional name property to both schematic_voltage_probe and simulation_voltage_probe.         
Previously, this property was missing, making it difficult to distinguish between multiple probes.                

The name property has been added to the respective Zod schemas and TypeScript interfaces. Tests have also been    
updated to ensure the name property is correctly parsed and accessible. 