### PR TITLE
Add must_be_connected attribute to source_port

### DIFF
--- a/src/source/source_port.ts
+++ b/src/source/source_port.ts
@@ -11,18 +11,7 @@ export const source_port = z.object({
   source_group_id: z.string().optional(),
   subcircuit_id: z.string().optional(),
   subcircuit_connectivity_map_key: z.string().optional(),
-
-  // DRC attributes
   must_be_connected: z.boolean().optional(),
-  requires_power: z.boolean().optional(),
-  requires_ground: z.boolean().optional(),
-  requires_voltage: z.union([z.string(), z.number()]).optional(),
-  do_not_connect: z.boolean().optional(),
-  include_in_board_pinout: z.boolean().optional(),
-  highlight_color: z.string().optional(),
-  provides_power: z.boolean().optional(),
-  provides_ground: z.boolean().optional(),
-  provides_voltage: z.union([z.string(), z.number()]).optional(),
 })
 
 export type SourcePortInput = z.input<typeof source_port>
@@ -41,18 +30,7 @@ export interface SourcePort {
   source_group_id?: string
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
-
-  // DRC attributes
   must_be_connected?: boolean
-  requires_power?: boolean
-  requires_ground?: boolean
-  requires_voltage?: string | number
-  do_not_connect?: boolean
-  include_in_board_pinout?: boolean
-  highlight_color?: string
-  provides_power?: boolean
-  provides_ground?: boolean
-  provides_voltage?: string | number
 }
 
 expectTypesMatch<SourcePort, InferredSourcePort>(true)


### PR DESCRIPTION
- Add attributes to source_port for DRC
- Ensures pin attributes are preserved in the serialized format
- Supports separation of concerns: core generates JSON, checks package validates it
- Allows checks package to read port attributes during DRC validation

