### PR TITLE
feat(simulation): Add support for differential voltage probes

### DIFF
--- a/src/simulation/simulation_voltage_probe.ts
+++ b/src/simulation/simulation_voltage_probe.ts
@@ -10,7 +10,6 @@ export const simulation_voltage_probe = z
     ),
     source_component_id: z.string().optional(),
     name: z.string().optional(),
-    probe_type: z.enum(["voltage", "differential_voltage"]).default("voltage"),
     signal_input_source_port_id: z.string().optional(),
     signal_input_source_net_id: z.string().optional(),
     reference_input_source_port_id: z.string().optional(),
@@ -19,30 +18,13 @@ export const simulation_voltage_probe = z
     color: z.string().optional(),
   })
   .describe(
-    "Defines a voltage probe for simulation. A 'voltage' probe_type measures against ground. A 'differential_voltage' probe_type measures between two points.",
+    "Defines a voltage probe for simulation. If a reference input is not provided, it measures against ground. If a reference input is provided, it measures the differential voltage between two points.",
   )
   .superRefine((data, ctx) => {
-    if (data.probe_type === "voltage") {
-      if (
-        data.reference_input_source_port_id ||
-        data.reference_input_source_net_id
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            "A single-ended voltage probe cannot have a reference input.",
-        })
-      }
-      if (
-        !!data.signal_input_source_port_id === !!data.signal_input_source_net_id
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            "A single-ended voltage probe must have exactly one of signal_input_source_port_id or signal_input_source_net_id.",
-        })
-      }
-    } else if (data.probe_type === "differential_voltage") {
+    const is_differential =
+      data.reference_input_source_port_id || data.reference_input_source_net_id
+
+    if (is_differential) {
       const has_ports =
         !!data.signal_input_source_port_id ||
         !!data.reference_input_source_port_id
@@ -78,11 +60,16 @@ export const simulation_voltage_probe = z
               "Differential net probe requires both signal_input_source_net_id and reference_input_source_net_id.",
           })
         }
-      } else {
+      }
+    } else {
+      // Single-ended probe
+      if (
+        !!data.signal_input_source_port_id === !!data.signal_input_source_net_id
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message:
-            "Differential probe requires either two port ids or two net ids.",
+            "A voltage probe must have exactly one of signal_input_source_port_id or signal_input_source_net_id.",
         })
       }
     }
@@ -94,16 +81,15 @@ export type SimulationVoltageProbeInput = z.input<
 type InferredSimulationVoltageProbe = z.infer<typeof simulation_voltage_probe>
 
 /**
- * Defines a voltage probe for simulation.
- * A 'voltage' probe_type measures against ground. A 'differential_voltage'
- * probe_type measures between two points.
+ * Defines a voltage probe for simulation. If a reference input is not provided,
+ * it measures against ground. If a reference input is provided, it measures
+ * the differential voltage between two points.
  */
 export interface SimulationVoltageProbe {
   type: "simulation_voltage_probe"
   simulation_voltage_probe_id: string
   source_component_id?: string
   name?: string
-  probe_type: "voltage" | "differential_voltage"
   signal_input_source_port_id?: string
   signal_input_source_net_id?: string
   reference_input_source_port_id?: string

--- a/tests/simulation_voltage_probe.test.ts
+++ b/tests/simulation_voltage_probe.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/simulation/simulation_voltage_probe"
 import { any_circuit_element } from "../src/any_circuit_element"
 
-test("simulation_voltage_probe (single-ended default) parses with port id", () => {
+test("simulation_voltage_probe (single-ended) parses with port id", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",
     signal_input_source_port_id: "port1",
@@ -15,8 +15,8 @@ test("simulation_voltage_probe (single-ended default) parses with port id", () =
   const result = simulation_voltage_probe.parse(input)
   const probe = result as SimulationVoltageProbe
 
-  expect(probe.probe_type).toBe("voltage")
   expect(probe.signal_input_source_port_id).toBe("port1")
+  expect(probe.reference_input_source_port_id).toBeUndefined()
   expect(probe.signal_input_source_net_id).toBeUndefined()
   expect(probe.simulation_voltage_probe_id).toBeString()
 
@@ -26,7 +26,6 @@ test("simulation_voltage_probe (single-ended default) parses with port id", () =
 test("simulation_voltage_probe (single-ended) parses with net id", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",
-    probe_type: "voltage",
     signal_input_source_net_id: "net1",
   }
 
@@ -50,7 +49,6 @@ test("simulation_voltage_probe with no connection ids should throw", () => {
 test("simulation_voltage_probe (differential) parses with port ids", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",
-    probe_type: "differential_voltage",
     signal_input_source_port_id: "port1",
     reference_input_source_port_id: "port2",
   }
@@ -58,7 +56,6 @@ test("simulation_voltage_probe (differential) parses with port ids", () => {
   const result = simulation_voltage_probe.parse(input)
   const probe = result as SimulationVoltageProbe
 
-  expect(probe.probe_type).toBe("differential_voltage")
   expect(probe.signal_input_source_port_id).toEqual("port1")
   expect(probe.reference_input_source_port_id).toEqual("port2")
   expect(probe.signal_input_source_net_id).toBeUndefined()
@@ -71,7 +68,6 @@ test("simulation_voltage_probe (differential) parses with port ids", () => {
 test("simulation_voltage_probe (differential) parses with net ids", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",
-    probe_type: "differential_voltage",
     signal_input_source_net_id: "net1",
     reference_input_source_net_id: "net2",
   }
@@ -103,7 +99,6 @@ test("simulation_voltage_probe parses with name", () => {
 test("simulation_voltage_probe (differential) with mixed connections should throw", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",
-    probe_type: "differential_voltage",
     signal_input_source_port_id: "port1",
     reference_input_source_net_id: "net1",
   }
@@ -113,7 +108,6 @@ test("simulation_voltage_probe (differential) with mixed connections should thro
 test("simulation_voltage_probe (single-ended) with both port and net should throw", () => {
   const input: SimulationVoltageProbeInput = {
     type: "simulation_voltage_probe",
-    probe_type: "voltage",
     signal_input_source_port_id: "port1",
     signal_input_source_net_id: "net1",
   }

--- a/tests/source_simple_voltage_probe.test.ts
+++ b/tests/source_simple_voltage_probe.test.ts
@@ -41,7 +41,6 @@ test("source_simple_voltage_probe links to schematic and simulation", () => {
     type: "simulation_voltage_probe",
     simulation_voltage_probe_id: "simulation_vp_1",
     source_component_id: "source_vp_1",
-    probe_type: "voltage",
     signal_input_source_port_id: "port_1",
     name: "VP1",
   })


### PR DESCRIPTION
This refactors simulation_voltage_probe to support both single-ended (vs. ground) and differential voltage measurements. 

 • source_port_id and source_net_id are replaced with signal_input_* and reference_input_* fields.                       
 • If a reference_input_* is provided, the probe measures the differential voltage. Otherwise, it measures the signal    
   against ground.                                                                                                       
 • Validation logic is added via superRefine to ensure correct configuration.                                            
 • Tests have been updated to cover both single-ended and differential probe scenarios.