### PR TITLE
fix: update hole_diameter default value to 0.3mm in pcb_via

### DIFF
--- a/src/pcb/pcb_via.ts
+++ b/src/pcb/pcb_via.ts
@@ -13,8 +13,8 @@ export const pcb_via = z
     subcircuit_connectivity_map_key: z.string().optional(),
     x: distance,
     y: distance,
-    outer_diameter: distance.default("0.6mm").optional(),
-    hole_diameter: distance.default("0.3mm").optional(),
+    outer_diameter: distance.default("0.6mm"),
+    hole_diameter: distance.default("0.3mm"),
     /** @deprecated */
     from_layer: layer_ref.optional(),
     /** @deprecated */
@@ -40,8 +40,8 @@ export interface PcbVia {
   subcircuit_connectivity_map_key?: string
   x: Distance
   y: Distance
-  outer_diameter?: Distance
-  hole_diameter?: Distance
+  outer_diameter: Distance
+  hole_diameter: Distance
   /** @deprecated */
   from_layer?: LayerRef
   /** @deprecated */


### PR DESCRIPTION
This pull request makes a minor update to the default value for the `hole_diameter` property in the `pcb_via` schema, increasing it from 0.25mm to 0.3mm for consistency.