### PR TITLE
Added missing is_covered_with_solder_mask in circle plated hole

### DIFF
--- a/src/pcb/pcb_plated_hole.ts
+++ b/src/pcb/pcb_plated_hole.ts
@@ -11,6 +11,7 @@ const pcb_plated_hole_circle = z.object({
   subcircuit_id: z.string().optional(),
   outer_diameter: z.number(),
   hole_diameter: z.number(),
+  is_covered_with_solder_mask: z.boolean().optional(),
   x: distance,
   y: distance,
   layers: z.array(layer_ref),
@@ -31,6 +32,7 @@ export interface PcbPlatedHoleCircle {
   subcircuit_id?: string
   outer_diameter: number
   hole_diameter: number
+  is_covered_with_solder_mask?: boolean
   x: Distance
   y: Distance
   layers: LayerRef[]


### PR DESCRIPTION
This PR adds an optional is_covered_with_solder_mask field to PcbPlatedHoleCircle, updating both the Zod schema and TypeScript interface. This allows consumers to explicitly control solder-mask coverage for plated holes.


This will fix the CI fail on this PR : https://github.com/tscircuit/circuit-to-svg/pull/441