### PR TITLE
Add subcircuit id to source component internal connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ interface SourceComponentInternalConnection {
   source_component_internal_connection_id: string
   source_component_id: string
   source_port_ids: string[]
+  subcircuit_id?: string
 }
 ```
 

--- a/docs/SOURCE_COMPONENT_OVERVIEW.md
+++ b/docs/SOURCE_COMPONENT_OVERVIEW.md
@@ -129,6 +129,7 @@ interface SourceComponentInternalConnection {
   source_component_internal_connection_id: string
   source_component_id: string
   source_port_ids: string[]
+  subcircuit_id?: string
 }
 
 interface SourceSimplePowerSource {

--- a/src/source/source_component_internal_connection.ts
+++ b/src/source/source_component_internal_connection.ts
@@ -6,6 +6,7 @@ export interface SourceComponentInternalConnection {
   source_component_internal_connection_id: string
   source_component_id: string
   source_port_ids: string[]
+  subcircuit_id?: string
 }
 
 export const source_component_internal_connection = z.object({
@@ -13,6 +14,7 @@ export const source_component_internal_connection = z.object({
   source_component_internal_connection_id: z.string(),
   source_component_id: z.string(),
   source_port_ids: z.array(z.string()),
+  subcircuit_id: z.string().optional(),
 })
 
 type InferredSourceComponentInternalConnection = z.infer<

--- a/tests/source_component_internal_connection.test.ts
+++ b/tests/source_component_internal_connection.test.ts
@@ -7,7 +7,9 @@ test("source_component_internal_connection parses source port ids", () => {
     source_component_internal_connection_id: "conn-1",
     source_component_id: "comp-1",
     source_port_ids: ["p1", "p2"],
+    subcircuit_id: "sub-1",
   })
 
   expect(parsed.source_port_ids).toEqual(["p1", "p2"])
+  expect(parsed.subcircuit_id).toEqual("sub-1")
 })


### PR DESCRIPTION
## Summary
- add optional subcircuit_id to source_component_internal_connection types
- document the new field in README and source component overview
- expand internal connection test to cover subcircuit_id parsing

## Testing
- bun test tests/source_component_internal_connection.test.ts
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a09356078832e941fc1505a057be7)