### PR TITLE
Add support for board-relative pcb component positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ interface PcbComponent {
   pcb_group_id?: string
   position_mode?: "packed" | "relative_to_group_anchor" | "none"
   positioned_relative_to_pcb_group_id?: string
+  positioned_relative_to_pcb_board_id?: string
   obstructs_within_bounds: boolean
 }
 ```

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -21,6 +21,7 @@ export const pcb_component = z
       .enum(["packed", "relative_to_group_anchor", "none"])
       .optional(),
     positioned_relative_to_pcb_group_id: z.string().optional(),
+    positioned_relative_to_pcb_board_id: z.string().optional(),
     obstructs_within_bounds: z
       .boolean()
       .default(true)
@@ -50,6 +51,7 @@ export interface PcbComponent {
   pcb_group_id?: string
   position_mode?: "packed" | "relative_to_group_anchor" | "none"
   positioned_relative_to_pcb_group_id?: string
+  positioned_relative_to_pcb_board_id?: string
   obstructs_within_bounds: boolean
 }
 

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -34,6 +34,15 @@ test("pcb_component allows positioned_relative_to_pcb_group_id", () => {
   expect(parsed.positioned_relative_to_pcb_group_id).toBe("pcb_group_1")
 })
 
+test("pcb_component allows positioned_relative_to_pcb_board_id", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    positioned_relative_to_pcb_board_id: "pcb_board_1",
+  })
+
+  expect(parsed.positioned_relative_to_pcb_board_id).toBe("pcb_board_1")
+})
+
 test("pcb_component rejects invalid position_mode", () => {
   expect(() =>
     pcb_component.parse({


### PR DESCRIPTION
## Summary
- allow pcb_component definitions to include positioned_relative_to_pcb_board_id
- document the new board-relative placement field
- add coverage ensuring pcb_component parsing accepts board-relative positioning

## Testing
- bun test tests/pcb_component_position_mode.test.ts
- bunx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a3c41bc98832ead8f1e26bd671c83)