### PR TITLE
Move display offsets into PCB models, introduce position mode metadata on pcb_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,14 +273,6 @@ interface SourceComponentBase {
   manufacturer_part_number?: string
   supplier_part_numbers?: Partial<Record<SupplierName, string[]>>
   display_value?: string
-  /** How to display the x offset for this part, usually corresponding with how
-   * the user specified it */
-
-  display_x_offset?: string
-  /** How to display the y offset for this part, usually corresponding with how
-   * the user specified it */
-
-  display_y_offset?: string
   are_pins_interchangeable?: boolean
   internally_connected_source_port_ids?: string[][]
   source_group_id?: string
@@ -988,6 +980,8 @@ interface PcbComponent {
   center: Point
   layer: LayerRef
   rotation: Rotation
+  display_offset_x?: string
+  display_offset_y?: string
   width: Length
   height: Length
   do_not_place?: boolean
@@ -1373,6 +1367,8 @@ interface PcbGroup {
   width?: Length
   height?: Length
   center: Point
+  display_offset_x?: string
+  display_offset_y?: string
   outline?: Point[]
   anchor_position?: Point
   anchor_alignment?:
@@ -1381,6 +1377,9 @@ interface PcbGroup {
     | "top_right"
     | "bottom_left"
     | "bottom_right"
+  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  positioned_relative_to_pcb_group_id?: string
+  positioned_relative_to_pcb_board_id?: string
   pcb_component_ids: string[]
   child_layout_mode?: "packed" | "none"
   name?: string

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -27,10 +27,15 @@ export interface PcbComponent {
   center: Point
   layer: LayerRef
   rotation: Rotation
+  display_offset_x?: string
+  display_offset_y?: string
   width: Length
   height: Length
   do_not_place?: boolean
   pcb_group_id?: string
+  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  positioned_relative_to_pcb_group_id?: string
+  positioned_relative_to_pcb_board_id?: string
   obstructs_within_bounds: boolean
 }
 

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -12,6 +12,18 @@ export const pcb_component = z
     center: point,
     layer: layer_ref,
     rotation: rotation,
+    display_offset_x: z
+      .string()
+      .optional()
+      .describe(
+        "How to display the x offset for this part, usually corresponding with how the user specified it",
+      ),
+    display_offset_y: z
+      .string()
+      .optional()
+      .describe(
+        "How to display the y offset for this part, usually corresponding with how the user specified it",
+      ),
     width: length,
     height: length,
     do_not_place: z.boolean().optional(),
@@ -45,6 +57,8 @@ export interface PcbComponent {
   center: Point
   layer: LayerRef
   rotation: Rotation
+  display_offset_x?: string
+  display_offset_y?: string
   width: Length
   height: Length
   do_not_place?: boolean

--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -13,11 +13,28 @@ export const pcb_group = z
     width: length.optional(),
     height: length.optional(),
     center: point,
+    display_offset_x: z
+      .string()
+      .optional()
+      .describe(
+        "How to display the x offset for this group, usually corresponding with how the user specified it",
+      ),
+    display_offset_y: z
+      .string()
+      .optional()
+      .describe(
+        "How to display the y offset for this group, usually corresponding with how the user specified it",
+      ),
     outline: z.array(point).optional(),
     anchor_position: point.optional(),
     anchor_alignment: z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
       .optional(),
+    position_mode: z
+      .enum(["packed", "relative_to_group_anchor", "none"])
+      .optional(),
+    positioned_relative_to_pcb_group_id: z.string().optional(),
+    positioned_relative_to_pcb_board_id: z.string().optional(),
     pcb_component_ids: z.array(z.string()),
     child_layout_mode: z.enum(["packed", "none"]).optional(),
     name: z.string().optional(),
@@ -47,6 +64,8 @@ export interface PcbGroup {
   width?: Length
   height?: Length
   center: Point
+  display_offset_x?: string
+  display_offset_y?: string
   outline?: Point[]
   anchor_position?: Point
   anchor_alignment?:
@@ -55,6 +74,9 @@ export interface PcbGroup {
     | "top_right"
     | "bottom_left"
     | "bottom_right"
+  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  positioned_relative_to_pcb_group_id?: string
+  positioned_relative_to_pcb_board_id?: string
   pcb_component_ids: string[]
   child_layout_mode?: "packed" | "none"
   name?: string

--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -13,16 +13,6 @@ export interface SourceComponentBase {
   manufacturer_part_number?: string
   supplier_part_numbers?: Partial<Record<SupplierName, string[]>>
   display_value?: string
-  /**
-   * How to display the x offset for this part, usually corresponding with how
-   * the user specified it
-   */
-  display_x_offset?: string
-  /**
-   * How to display the y offset for this part, usually corresponding with how
-   * the user specified it
-   */
-  display_y_offset?: string
   are_pins_interchangeable?: boolean
   internally_connected_source_port_ids?: string[][]
   source_group_id?: string
@@ -39,18 +29,6 @@ export const source_component_base = z.object({
     .record(supplier_name, z.array(z.string()))
     .optional(),
   display_value: z.string().optional(),
-  display_x_offset: z
-    .string()
-    .optional()
-    .describe(
-      "How to display the x offset for this part, usually corresponding with how the user specified it",
-    ),
-  display_y_offset: z
-    .string()
-    .optional()
-    .describe(
-      "How to display the y offset for this part, usually corresponding with how the user specified it",
-    ),
   are_pins_interchangeable: z.boolean().optional(),
   internally_connected_source_port_ids: z.array(z.array(z.string())).optional(),
   source_group_id: z.string().optional(),

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -43,6 +43,17 @@ test("pcb_component allows positioned_relative_to_pcb_board_id", () => {
   expect(parsed.positioned_relative_to_pcb_board_id).toBe("pcb_board_1")
 })
 
+test("pcb_component allows display offsets", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    display_offset_x: "1mm",
+    display_offset_y: "-2mm",
+  })
+
+  expect(parsed.display_offset_x).toBe("1mm")
+  expect(parsed.display_offset_y).toBe("-2mm")
+})
+
 test("pcb_component rejects invalid position_mode", () => {
   expect(() =>
     pcb_component.parse({

--- a/tests/pcb_group_position_metadata.test.ts
+++ b/tests/pcb_group_position_metadata.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { pcb_group } from "src/pcb/pcb_group"
+
+const baseGroup = {
+  type: "pcb_group" as const,
+  pcb_group_id: "pcb_group_1",
+  source_group_id: "source_group_1",
+  center: { x: 0, y: 0 },
+  pcb_component_ids: [] as const,
+}
+
+test("pcb_group allows position metadata fields", () => {
+  const parsed = pcb_group.parse({
+    ...baseGroup,
+    display_offset_x: "1mm",
+    display_offset_y: "-1mm",
+    position_mode: "relative_to_group_anchor",
+    positioned_relative_to_pcb_group_id: "pcb_group_2",
+    positioned_relative_to_pcb_board_id: "pcb_board_1",
+  })
+
+  expect(parsed.display_offset_x).toBe("1mm")
+  expect(parsed.display_offset_y).toBe("-1mm")
+  expect(parsed.position_mode).toBe("relative_to_group_anchor")
+  expect(parsed.positioned_relative_to_pcb_group_id).toBe("pcb_group_2")
+  expect(parsed.positioned_relative_to_pcb_board_id).toBe("pcb_board_1")
+})
+
+test("pcb_group rejects invalid position_mode", () => {
+  expect(() =>
+    pcb_group.parse({
+      ...baseGroup,
+      position_mode: "invalid",
+    }),
+  ).toThrowError()
+})


### PR DESCRIPTION
## Summary
- add display offset metadata to pcb_component and align pcb_group position fields
- remove display offset properties from source_component definitions and update docs
- expand tests to cover new pcb_component and pcb_group position metadata

## Testing
- bun test tests/pcb_component_position_mode.test.ts tests/pcb_group_position_metadata.test.ts
- bunx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a56c1480c832eb2849a17c10af35c)