### PR TITLE
feat: Add label_side field to schematic_voltage_probe for overlap prevention

### DIFF
--- a/src/schematic/schematic_voltage_probe.ts
+++ b/src/schematic/schematic_voltage_probe.ts
@@ -2,7 +2,10 @@ import { z } from "zod"
 import { point, type Point } from "../common/point"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 import { voltage } from "src/units"
-import { ninePointAnchor, type NinePointAnchor } from "src/common/NinePointAnchor"
+import {
+  ninePointAnchor,
+  type NinePointAnchor,
+} from "src/common/NinePointAnchor"
 
 export interface SchematicVoltageProbe {
   type: "schematic_voltage_probe"


### PR DESCRIPTION
## PR Description

This implementation adds label_side field that enables voltage probe labels to be positioned on either side of the arrow to avoid overlaps

### Changes made
- Added optional `label_side` field ("left" | "right") to SchematicVoltageProbe interface
- Updated zod schema to include label_side validation

### Next Steps

Updating rendering logic in `circuit-to-svg` repo to support flipping the probe

Ref: https://github.com/tscircuit/core/issues/1739