### PR TITLE
feat: Add support for simple_source_fiducial

### DIFF
--- a/src/source/any_source_component.ts
+++ b/src/source/any_source_component.ts
@@ -13,6 +13,10 @@ import {
   source_simple_diode,
   type SourceSimpleDiode,
 } from "./source_simple_diode"
+import {
+  source_simple_fiducial,
+  type SourceSimpleFiducial,
+} from "./source_simple_fiducial"
 import { source_simple_led, type SourceSimpleLed } from "./source_simple_led"
 import {
   source_simple_ground,
@@ -108,6 +112,7 @@ export const any_source_component = z.union([
   source_simple_resistor,
   source_simple_capacitor,
   source_simple_diode,
+  source_simple_fiducial,
   source_simple_led,
   source_simple_ground,
   source_simple_chip,
@@ -144,6 +149,7 @@ export type AnySourceElement =
   | SourceSimpleResistor
   | SourceSimpleCapacitor
   | SourceSimpleDiode
+  | SourceSimpleFiducial
   | SourceSimpleLed
   | SourceSimpleGround
   | SourceSimpleChip

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -1,6 +1,7 @@
 export * from "./source_simple_capacitor"
 export * from "./source_simple_resistor"
 export * from "./source_simple_diode"
+export * from "./source_simple_fiducial"
 export * from "./source_simple_led"
 export * from "./source_simple_ground"
 export * from "./source_simple_chip"

--- a/src/source/source_simple_fiducial.ts
+++ b/src/source/source_simple_fiducial.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+import {
+  source_component_base,
+  type SourceComponentBase,
+} from "src/source/base/source_component_base"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const source_simple_fiducial = source_component_base.extend({
+  ftype: z.literal("simple_fiducial"),
+})
+
+export type SourceSimpleFiducialInput = z.input<typeof source_simple_fiducial>
+type InferredSourceSimpleFiducial = z.infer<typeof source_simple_fiducial>
+
+/**
+ * Defines a simple fiducial component
+ */
+export interface SourceSimpleFiducial extends SourceComponentBase {
+  ftype: "simple_fiducial"
+}
+
+expectTypesMatch<SourceSimpleFiducial, InferredSourceSimpleFiducial>(true)

--- a/tests/source_simple_fiducial.test.ts
+++ b/tests/source_simple_fiducial.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { source_simple_fiducial } from "../src/source/source_simple_fiducial"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("source_simple_fiducial parses", () => {
+  const fiducial = source_simple_fiducial.parse({
+    type: "source_component",
+    ftype: "simple_fiducial",
+    source_component_id: "fiducial1",
+    name: "F1",
+  })
+  expect(fiducial.ftype).toBe("simple_fiducial")
+})
+
+test("any_circuit_element includes source_simple_fiducial", () => {
+  const parsed = any_circuit_element.parse({
+    type: "source_component",
+    ftype: "simple_fiducial",
+    source_component_id: "fiducial1",
+    name: "F1",
+  })
+  if ("ftype" in parsed && parsed.ftype === "simple_fiducial") {
+    expect(parsed.ftype).toBe("simple_fiducial")
+  } else {
+    throw new Error("Parsed element not a source_simple_fiducial")
+  }
+})


### PR DESCRIPTION
This change introduces support for fiducial source components, which will use pcb smtpads as their pcb component.            

 • Adds a source_simple_fiducial source component.                                                  
 • Includes new tests to validate the functionality of both components.                                    
 • Updates relevant union types and index files to integrate the new components. 