### PR TITLE
feat: Add layout_mode property to PcbPanel

### DIFF
--- a/src/pcb/pcb_panel.ts
+++ b/src/pcb/pcb_panel.ts
@@ -11,6 +11,7 @@ export const pcb_panel = z
     height: length,
     center: point,
     covered_with_solder_mask: z.boolean().optional().default(true),
+    layout_mode: z.enum(["none", "grid"]).optional(),
   })
   .describe("Defines a PCB panel that can contain multiple boards")
 
@@ -24,6 +25,7 @@ export interface PcbPanel {
   height: Length
   center: Point
   covered_with_solder_mask: boolean
+  layout_mode?: "none" | "grid"
 }
 
 export type PcbPanelInput = z.input<typeof pcb_panel>

--- a/tests/pcb_panel.test.ts
+++ b/tests/pcb_panel.test.ts
@@ -9,11 +9,13 @@ test("pcb_panel parses and defaults covered_with_solder_mask", () => {
     width: "100mm",
     height: "200mm",
     center: { x: 0, y: 0 },
+    layout_mode: "none",
   }
 
   const parsed = pcb_panel.parse(panelData)
 
   expect(parsed.covered_with_solder_mask).toBe(true)
+  expect(parsed.layout_mode).toBe("none")
 })
 
 test("any_circuit_element includes pcb_panel", () => {
@@ -27,4 +29,19 @@ test("any_circuit_element includes pcb_panel", () => {
   }
 
   expect(() => any_circuit_element.parse(panelData)).not.toThrow()
+})
+
+test("pcb_panel parses with layoutMode grid", () => {
+  const panelData = {
+    type: "pcb_panel" as const,
+    pcb_panel_id: "pcb_panel_1",
+    width: "100mm",
+    height: "200mm",
+    center: { x: 0, y: 0 },
+    layout_mode: "grid" as const,
+  }
+
+  const parsed = pcb_panel.parse(panelData)
+
+  expect(parsed.layout_mode).toBe("grid")
 })


### PR DESCRIPTION
Adds an optional layout_mode property to the PcbPanel type that accepts values "none" or "grid". Includes test coverage for parsing both layout modes. This enables specifying panel layout behavior in PCB designs.