### PR TITLE
Add pcb_panelization_placement_error schema and include in unions

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -487,6 +487,16 @@ export interface PcbPlacementError {
   message: string
 }
 
+export interface PcbPanelizationPlacementError {
+  type: "pcb_panelization_placement_error"
+  pcb_panelization_placement_error_id: string
+  error_type: "pcb_panelization_placement_error"
+  message: string
+  pcb_panel_id?: string
+  pcb_board_id?: string
+  subcircuit_id?: string
+}
+
 export interface PcbPort {
   type: "pcb_port"
   pcb_port_id: string

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -76,6 +76,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_trace_error,
   pcb.pcb_trace_missing_error,
   pcb.pcb_placement_error,
+  pcb.pcb_panelization_placement_error,
   pcb.pcb_port_not_matched_error,
   pcb.pcb_port_not_connected_error,
   pcb.pcb_via_clearance_error,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -21,6 +21,7 @@ export * from "./pcb_via"
 export * from "./pcb_board"
 export * from "./pcb_panel"
 export * from "./pcb_placement_error"
+export * from "./pcb_panelization_placement_error"
 export * from "./pcb_trace_hint"
 export * from "./pcb_silkscreen_line"
 export * from "./pcb_silkscreen_path"
@@ -77,6 +78,7 @@ import type { PcbNet } from "./pcb_net"
 import type { PcbBoard } from "./pcb_board"
 import type { PcbPanel } from "./pcb_panel"
 import type { PcbPlacementError } from "./pcb_placement_error"
+import type { PcbPanelizationPlacementError } from "./pcb_panelization_placement_error"
 import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
 import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
@@ -133,6 +135,7 @@ export type PcbCircuitElement =
   | PcbBoard
   | PcbPanel
   | PcbPlacementError
+  | PcbPanelizationPlacementError
   | PcbTraceHint
   | PcbSilkscreenLine
   | PcbSilkscreenPath

--- a/src/pcb/pcb_panelization_placement_error.ts
+++ b/src/pcb/pcb_panelization_placement_error.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_panelization_placement_error = z
+  .object({
+    type: z.literal("pcb_panelization_placement_error"),
+    pcb_panelization_placement_error_id: getZodPrefixedIdWithDefault(
+      "pcb_panelization_placement_error",
+    ),
+    error_type: z
+      .literal("pcb_panelization_placement_error")
+      .default("pcb_panelization_placement_error"),
+    message: z.string(),
+    pcb_panel_id: z.string().optional(),
+    pcb_board_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Defines a panelization placement error on the PCB")
+
+export type PcbPanelizationPlacementErrorInput = z.input<
+  typeof pcb_panelization_placement_error
+>
+type InferredPcbPanelizationPlacementError = z.infer<
+  typeof pcb_panelization_placement_error
+>
+
+/**
+ * Defines a panelization placement error on the PCB
+ */
+export interface PcbPanelizationPlacementError {
+  type: "pcb_panelization_placement_error"
+  pcb_panelization_placement_error_id: string
+  error_type: "pcb_panelization_placement_error"
+  message: string
+  pcb_panel_id?: string
+  pcb_board_id?: string
+  subcircuit_id?: string
+}
+
+/**
+ * @deprecated use PcbPanelizationPlacementError
+ */
+export type PCBPanelizationPlacementError = PcbPanelizationPlacementError
+
+expectTypesMatch<
+  PcbPanelizationPlacementError,
+  InferredPcbPanelizationPlacementError
+>(true)

--- a/tests/pcb_panelization_placement_error.test.ts
+++ b/tests/pcb_panelization_placement_error.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test"
+import { pcb_panelization_placement_error } from "../src/pcb/pcb_panelization_placement_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_panelization_placement_error parses", () => {
+  const error = pcb_panelization_placement_error.parse({
+    type: "pcb_panelization_placement_error",
+    message: "panelized board placement failed",
+    pcb_panel_id: "pcb_panel_1",
+    pcb_board_id: "pcb_board_1",
+  })
+
+  expect(error.pcb_panelization_placement_error_id).toBeDefined()
+  expect(
+    error.pcb_panelization_placement_error_id.startsWith(
+      "pcb_panelization_placement_error",
+    ),
+  ).toBe(true)
+  expect(error.pcb_panel_id).toBe("pcb_panel_1")
+  expect(error.pcb_board_id).toBe("pcb_board_1")
+})
+
+test("any_circuit_element includes pcb_panelization_placement_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_panelization_placement_error",
+    message: "panelized board placement failed",
+  })
+
+  expect(parsed.type).toBe("pcb_panelization_placement_error")
+})


### PR DESCRIPTION
### Motivation
- Introduce a dedicated error type to represent placement failures that occur during PCB panelization so these events can be validated and carried through the type system and tooling. 
- Ensure the new error is available in the PCB element exports and the global `any_circuit_element` union so parsers and consumers can recognize it.

### Description
- Add `src/pcb/pcb_panelization_placement_error.ts` implementing the Zod schema `pcb_panelization_placement_error`, TypeScript interface `PcbPanelizationPlacementError`, and a deprecated alias `PCBPanelizationPlacementError`.
- Export the new error from `src/pcb/index.ts` and include its type in the `PcbCircuitElement` union.
- Include the new `pcb.pcb_panelization_placement_error` variant in the global `any_circuit_element` union in `src/any_circuit_element.ts`.
- Document the new interface in `docs/PCB_COMPONENT_OVERVIEW.md` and add tests in `tests/pcb_panelization_placement_error.test.ts` that assert parsing and `any_circuit_element` inclusion.

### Testing
- Ran typecheck with `bunx tsc --noEmit`, which completed successfully.
- Ran the new test suite with `bun test tests/pcb_panelization_placement_error.test.ts`, which ran 2 tests and passed (2 pass / 0 fail).
- Ran formatting via `bun run format` as part of cleanup, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979625b44d4832eb00c91cb54759e19)