### PR TITLE
Add pcb_panelization_placement_warning

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -77,6 +77,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_trace_missing_error,
   pcb.pcb_placement_error,
   pcb.pcb_panelization_placement_error,
+  pcb.pcb_panelization_placement_warning,
   pcb.pcb_port_not_matched_error,
   pcb.pcb_port_not_connected_error,
   pcb.pcb_via_clearance_error,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -22,6 +22,7 @@ export * from "./pcb_board"
 export * from "./pcb_panel"
 export * from "./pcb_placement_error"
 export * from "./pcb_panelization_placement_error"
+export * from "./pcb_panelization_placement_warning"
 export * from "./pcb_trace_hint"
 export * from "./pcb_silkscreen_line"
 export * from "./pcb_silkscreen_path"
@@ -79,6 +80,7 @@ import type { PcbBoard } from "./pcb_board"
 import type { PcbPanel } from "./pcb_panel"
 import type { PcbPlacementError } from "./pcb_placement_error"
 import type { PcbPanelizationPlacementError } from "./pcb_panelization_placement_error"
+import type { PcbPanelizationPlacementWarning } from "./pcb_panelization_placement_warning"
 import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
 import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
@@ -136,6 +138,7 @@ export type PcbCircuitElement =
   | PcbPanel
   | PcbPlacementError
   | PcbPanelizationPlacementError
+  | PcbPanelizationPlacementWarning
   | PcbTraceHint
   | PcbSilkscreenLine
   | PcbSilkscreenPath

--- a/src/pcb/pcb_panelization_placement_warning.ts
+++ b/src/pcb/pcb_panelization_placement_warning.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_panelization_placement_warning = z
+  .object({
+    type: z.literal("pcb_panelization_placement_warning"),
+    pcb_panelization_placement_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_panelization_placement_warning",
+    ),
+    warning_type: z
+      .literal("pcb_panelization_placement_warning")
+      .default("pcb_panelization_placement_warning"),
+    message: z.string(),
+    pcb_panel_id: z.string().optional(),
+    pcb_board_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Defines a panelization placement warning on the PCB")
+
+export type PcbPanelizationPlacementWarningInput = z.input<
+  typeof pcb_panelization_placement_warning
+>
+type InferredPcbPanelizationPlacementWarning = z.infer<
+  typeof pcb_panelization_placement_warning
+>
+
+/**
+ * Defines a panelization placement warning on the PCB
+ */
+export interface PcbPanelizationPlacementWarning {
+  type: "pcb_panelization_placement_warning"
+  pcb_panelization_placement_warning_id: string
+  warning_type: "pcb_panelization_placement_warning"
+  message: string
+  pcb_panel_id?: string
+  pcb_board_id?: string
+  subcircuit_id?: string
+}
+
+/**
+ * @deprecated use PcbPanelizationPlacementWarning
+ */
+export type PCBPanelizationPlacementWarning = PcbPanelizationPlacementWarning
+
+expectTypesMatch<
+  PcbPanelizationPlacementWarning,
+  InferredPcbPanelizationPlacementWarning
+>(true)

--- a/tests/pcb_panelization_placement_warning.test.ts
+++ b/tests/pcb_panelization_placement_warning.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test"
+import { pcb_panelization_placement_warning } from "../src/pcb/pcb_panelization_placement_warning"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_panelization_placement_warning parses", () => {
+  const warning = pcb_panelization_placement_warning.parse({
+    type: "pcb_panelization_placement_warning",
+    message: "panelized board placement has minor issues",
+    pcb_panel_id: "pcb_panel_1",
+    pcb_board_id: "pcb_board_1",
+  })
+
+  expect(warning.pcb_panelization_placement_warning_id).toBeDefined()
+  expect(
+    warning.pcb_panelization_placement_warning_id.startsWith(
+      "pcb_panelization_placement_warning",
+    ),
+  ).toBe(true)
+  expect(warning.pcb_panel_id).toBe("pcb_panel_1")
+  expect(warning.pcb_board_id).toBe("pcb_board_1")
+})
+
+test("any_circuit_element includes pcb_panelization_placement_warning", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_panelization_placement_warning",
+    message: "panelized board placement has minor issues",
+  })
+
+  expect(parsed.type).toBe("pcb_panelization_placement_warning")
+})


### PR DESCRIPTION
### Motivation
- Provide a non-fatal warning counterpart to `pcb_panelization_placement_error` so minor panelization placement issues can be represented separately from errors.
- Ensure the new warning is discoverable and parseable across the codebase by including it in the central PCB exports and the `any_circuit_element` union.

### Description
- Add a new Zod schema and TypeScript types in `src/pcb/pcb_panelization_placement_warning.ts` that define `pcb_panelization_placement_warning` with ID, `warning_type`, `message`, and optional context fields.
- Export the new warning from `src/pcb/index.ts` and import its type so it is included in the `PcbCircuitElement` union.
- Include `pcb.pcb_panelization_placement_warning` in the `any_circuit_element` union in `src/any_circuit_element.ts` so it can be parsed by the general parser.
- Add unit tests in `tests/pcb_panelization_placement_warning.test.ts` to validate parsing and union membership.

### Testing
- Ran `bun test tests/pcb_panelization_placement_warning.test.ts` and it passed (2 tests, 0 failures).
- Ran `bunx tsc --noEmit` for a TypeScript typecheck and it completed with no type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6979735ee1a8832ea7388e4b7a96d4f1)