### PR TITLE
Add base_circuit_json_error and have error types extend it, add `is_fatal` support

### DIFF
--- a/src/base_circuit_json_error.ts
+++ b/src/base_circuit_json_error.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const base_circuit_json_error = z.object({
+  error_type: z.string(),
+  message: z.string(),
+  is_fatal: z.boolean().optional(),
+})
+
+export type BaseCircuitJsonErrorInput = z.input<typeof base_circuit_json_error>
+type InferredBaseCircuitJsonError = z.infer<typeof base_circuit_json_error>
+
+export interface BaseCircuitJsonError {
+  error_type: string
+  message: string
+  is_fatal?: boolean
+}
+
+expectTypesMatch<BaseCircuitJsonError, InferredBaseCircuitJsonError>(true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./units"
 export * from "./common"
+export * from "./base_circuit_json_error"
 export * from "./source"
 export * from "./schematic"
 export * from "./pcb"

--- a/src/pcb/circuit_json_footprint_load_error.ts
+++ b/src/pcb/circuit_json_footprint_load_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const circuit_json_footprint_load_error = z
-  .object({
+export const circuit_json_footprint_load_error = base_circuit_json_error
+  .extend({
     type: z.literal("circuit_json_footprint_load_error"),
     circuit_json_footprint_load_error_id: getZodPrefixedIdWithDefault(
       "circuit_json_footprint_load_error",
@@ -15,7 +19,6 @@ export const circuit_json_footprint_load_error = z
     error_type: z
       .literal("circuit_json_footprint_load_error")
       .default("circuit_json_footprint_load_error"),
-    message: z.string(),
     circuit_json: z.array(z.any()).optional(),
   })
   .describe("Defines an error when a circuit JSON footprint fails to load")
@@ -27,7 +30,7 @@ type InferredCircuitJsonFootprintLoadError = z.infer<
   typeof circuit_json_footprint_load_error
 >
 
-export interface CircuitJsonFootprintLoadError {
+export interface CircuitJsonFootprintLoadError extends BaseCircuitJsonError {
   type: "circuit_json_footprint_load_error"
   circuit_json_footprint_load_error_id: string
   pcb_component_id: string
@@ -35,7 +38,6 @@ export interface CircuitJsonFootprintLoadError {
   pcb_group_id?: string
   subcircuit_id?: string
   error_type: "circuit_json_footprint_load_error"
-  message: string
   circuit_json?: any[]
 }
 

--- a/src/pcb/external_footprint_load_error.ts
+++ b/src/pcb/external_footprint_load_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const external_footprint_load_error = z
-  .object({
+export const external_footprint_load_error = base_circuit_json_error
+  .extend({
     type: z.literal("external_footprint_load_error"),
     external_footprint_load_error_id: getZodPrefixedIdWithDefault(
       "external_footprint_load_error",
@@ -16,7 +20,6 @@ export const external_footprint_load_error = z
     error_type: z
       .literal("external_footprint_load_error")
       .default("external_footprint_load_error"),
-    message: z.string(),
   })
   .describe("Defines an error when an external footprint fails to load")
 
@@ -27,7 +30,7 @@ type InferredExternalFootprintLoadError = z.infer<
   typeof external_footprint_load_error
 >
 
-export interface ExternalFootprintLoadError {
+export interface ExternalFootprintLoadError extends BaseCircuitJsonError {
   type: "external_footprint_load_error"
   external_footprint_load_error_id: string
   pcb_component_id: string
@@ -36,7 +39,6 @@ export interface ExternalFootprintLoadError {
   subcircuit_id?: string
   footprinter_string?: string
   error_type: "external_footprint_load_error"
-  message: string
 }
 
 expectTypesMatch<

--- a/src/pcb/pcb_autorouting_error.ts
+++ b/src/pcb/pcb_autorouting_error.ts
@@ -1,15 +1,18 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_autorouting_error = z
-  .object({
+export const pcb_autorouting_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_autorouting_error"),
     pcb_error_id: getZodPrefixedIdWithDefault("pcb_autorouting_error"),
     error_type: z
       .literal("pcb_autorouting_error")
       .default("pcb_autorouting_error"),
-    message: z.string(),
     subcircuit_id: z.string().optional(),
   })
   .describe("The autorouting has failed to route a portion of the board")
@@ -17,11 +20,10 @@ export const pcb_autorouting_error = z
 export type PcbAutoroutingErrorInput = z.input<typeof pcb_autorouting_error>
 type PcbInferredAutoroutingError = z.infer<typeof pcb_autorouting_error>
 
-export interface PcbAutoroutingErrorInterface {
+export interface PcbAutoroutingErrorInterface extends BaseCircuitJsonError {
   type: "pcb_autorouting_error"
   pcb_error_id: string
   error_type: "pcb_autorouting_error"
-  message: string
   subcircuit_id?: string
 }
 

--- a/src/pcb/pcb_component_invalid_layer_error.ts
+++ b/src/pcb/pcb_component_invalid_layer_error.ts
@@ -1,10 +1,14 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_component_invalid_layer_error = z
-  .object({
+export const pcb_component_invalid_layer_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_component_invalid_layer_error"),
     pcb_component_invalid_layer_error_id: getZodPrefixedIdWithDefault(
       "pcb_component_invalid_layer_error",
@@ -12,7 +16,6 @@ export const pcb_component_invalid_layer_error = z
     error_type: z
       .literal("pcb_component_invalid_layer_error")
       .default("pcb_component_invalid_layer_error"),
-    message: z.string(),
     pcb_component_id: z.string().optional(),
     source_component_id: z.string(),
     layer: layer_ref,
@@ -30,11 +33,10 @@ type InferredPcbComponentInvalidLayerError = z.infer<
 >
 
 /** Error emitted when a component is placed on an invalid layer (components can only be on 'top' or 'bottom' layers) */
-export interface PcbComponentInvalidLayerError {
+export interface PcbComponentInvalidLayerError extends BaseCircuitJsonError {
   type: "pcb_component_invalid_layer_error"
   pcb_component_invalid_layer_error_id: string
   error_type: "pcb_component_invalid_layer_error"
-  message: string
   pcb_component_id?: string
   source_component_id: string
   layer: LayerRef

--- a/src/pcb/pcb_component_outside_board_error.ts
+++ b/src/pcb/pcb_component_outside_board_error.ts
@@ -1,10 +1,14 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { point, type Point } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_component_outside_board_error = z
-  .object({
+export const pcb_component_outside_board_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_component_outside_board_error"),
     pcb_component_outside_board_error_id: getZodPrefixedIdWithDefault(
       "pcb_component_outside_board_error",
@@ -12,7 +16,6 @@ export const pcb_component_outside_board_error = z
     error_type: z
       .literal("pcb_component_outside_board_error")
       .default("pcb_component_outside_board_error"),
-    message: z.string(),
     pcb_component_id: z.string(),
     pcb_board_id: z.string(),
     component_center: point,
@@ -37,11 +40,10 @@ type InferredPcbComponentOutsideBoardError = z.infer<
 >
 
 /** Error emitted when a PCB component is placed outside the board boundaries */
-export interface PcbComponentOutsideBoardError {
+export interface PcbComponentOutsideBoardError extends BaseCircuitJsonError {
   type: "pcb_component_outside_board_error"
   pcb_component_outside_board_error_id: string
   error_type: "pcb_component_outside_board_error"
-  message: string
   pcb_component_id: string
   pcb_board_id: string
   component_center: Point

--- a/src/pcb/pcb_footprint_overlap_error.ts
+++ b/src/pcb/pcb_footprint_overlap_error.ts
@@ -1,15 +1,18 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_footprint_overlap_error = z
-  .object({
+export const pcb_footprint_overlap_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_footprint_overlap_error"),
     pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
     error_type: z
       .literal("pcb_footprint_overlap_error")
       .default("pcb_footprint_overlap_error"),
-    message: z.string(),
     pcb_smtpad_ids: z.array(z.string()).optional(),
     pcb_plated_hole_ids: z.array(z.string()).optional(),
     pcb_hole_ids: z.array(z.string()).optional(),
@@ -25,11 +28,10 @@ type InferredPcbFootprintOverlapError = z.infer<
 >
 
 /** Error emitted when a pcb footprint overlaps with another element */
-export interface PcbFootprintOverlapError {
+export interface PcbFootprintOverlapError extends BaseCircuitJsonError {
   type: "pcb_footprint_overlap_error"
   pcb_error_id: string
   error_type: "pcb_footprint_overlap_error"
-  message: string
   pcb_smtpad_ids?: string[]
   pcb_plated_hole_ids?: string[]
   pcb_hole_ids?: string[]

--- a/src/pcb/pcb_missing_footprint_error.ts
+++ b/src/pcb/pcb_missing_footprint_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_missing_footprint_error = z
-  .object({
+export const pcb_missing_footprint_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_missing_footprint_error"),
     pcb_missing_footprint_error_id: getZodPrefixedIdWithDefault(
       "pcb_missing_footprint_error",
@@ -14,7 +18,6 @@ export const pcb_missing_footprint_error = z
       .literal("pcb_missing_footprint_error")
       .default("pcb_missing_footprint_error"),
     source_component_id: z.string(),
-    message: z.string(),
   })
   .describe("Defines a missing footprint error on the PCB")
 
@@ -28,14 +31,13 @@ type InferredPcbMissingFootprintError = z.infer<
 /**
  * Defines a placement error on the PCB
  */
-export interface PcbMissingFootprintError {
+export interface PcbMissingFootprintError extends BaseCircuitJsonError {
   type: "pcb_missing_footprint_error"
   pcb_missing_footprint_error_id: string
   pcb_group_id?: string
   subcircuit_id?: string
   error_type: "pcb_missing_footprint_error"
   source_component_id: string
-  message: string
 }
 
 /**

--- a/src/pcb/pcb_panelization_placement_error.ts
+++ b/src/pcb/pcb_panelization_placement_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_panelization_placement_error = z
-  .object({
+export const pcb_panelization_placement_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_panelization_placement_error"),
     pcb_panelization_placement_error_id: getZodPrefixedIdWithDefault(
       "pcb_panelization_placement_error",
@@ -11,7 +15,6 @@ export const pcb_panelization_placement_error = z
     error_type: z
       .literal("pcb_panelization_placement_error")
       .default("pcb_panelization_placement_error"),
-    message: z.string(),
     pcb_panel_id: z.string().optional(),
     pcb_board_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
@@ -28,11 +31,10 @@ type InferredPcbPanelizationPlacementError = z.infer<
 /**
  * Defines a panelization placement error on the PCB
  */
-export interface PcbPanelizationPlacementError {
+export interface PcbPanelizationPlacementError extends BaseCircuitJsonError {
   type: "pcb_panelization_placement_error"
   pcb_panelization_placement_error_id: string
   error_type: "pcb_panelization_placement_error"
-  message: string
   pcb_panel_id?: string
   pcb_board_id?: string
   subcircuit_id?: string

--- a/src/pcb/pcb_placement_error.ts
+++ b/src/pcb/pcb_placement_error.ts
@@ -1,13 +1,16 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_placement_error = z
-  .object({
+export const pcb_placement_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_placement_error"),
     pcb_placement_error_id: getZodPrefixedIdWithDefault("pcb_placement_error"),
     error_type: z.literal("pcb_placement_error").default("pcb_placement_error"),
-    message: z.string(),
     subcircuit_id: z.string().optional(),
   })
   .describe("Defines a placement error on the PCB")
@@ -18,11 +21,10 @@ type InferredPcbPlacementError = z.infer<typeof pcb_placement_error>
 /**
  * Defines a placement error on the PCB
  */
-export interface PcbPlacementError {
+export interface PcbPlacementError extends BaseCircuitJsonError {
   type: "pcb_placement_error"
   pcb_placement_error_id: string
   error_type: "pcb_placement_error"
-  message: string
   subcircuit_id?: string
 }
 

--- a/src/pcb/pcb_port_not_connected_error.ts
+++ b/src/pcb/pcb_port_not_connected_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_port_not_connected_error = z
-  .object({
+export const pcb_port_not_connected_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_port_not_connected_error"),
     pcb_port_not_connected_error_id: getZodPrefixedIdWithDefault(
       "pcb_port_not_connected_error",
@@ -11,7 +15,6 @@ export const pcb_port_not_connected_error = z
     error_type: z
       .literal("pcb_port_not_connected_error")
       .default("pcb_port_not_connected_error"),
-    message: z.string(),
     pcb_port_ids: z.array(z.string()),
     pcb_component_ids: z.array(z.string()),
     subcircuit_id: z.string().optional(),
@@ -28,11 +31,10 @@ type InferredPcbPortNotConnectedError = z.infer<
 /**
  * Defines an error when a pcb port is not connected to any trace
  */
-export interface PcbPortNotConnectedError {
+export interface PcbPortNotConnectedError extends BaseCircuitJsonError {
   type: "pcb_port_not_connected_error"
   pcb_port_not_connected_error_id: string
   error_type: "pcb_port_not_connected_error"
-  message: string
   pcb_port_ids: string[]
   pcb_component_ids: string[]
   subcircuit_id?: string

--- a/src/pcb/pcb_port_not_matched_error.ts
+++ b/src/pcb/pcb_port_not_matched_error.ts
@@ -1,15 +1,18 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_port_not_matched_error = z
-  .object({
+export const pcb_port_not_matched_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_port_not_matched_error"),
     pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
     error_type: z
       .literal("pcb_port_not_matched_error")
       .default("pcb_port_not_matched_error"),
-    message: z.string(),
     pcb_component_ids: z.array(z.string()),
     subcircuit_id: z.string().optional(),
   })
@@ -23,11 +26,10 @@ type InferredPcbPortNotMatchedError = z.infer<typeof pcb_port_not_matched_error>
 /**
  * Defines a trace error on the PCB where a port is not matched
  */
-export interface PcbPortNotMatchedError {
+export interface PcbPortNotMatchedError extends BaseCircuitJsonError {
   type: "pcb_port_not_matched_error"
   pcb_error_id: string
   error_type: "pcb_port_not_matched_error"
-  message: string
   pcb_component_ids: string[]
   subcircuit_id?: string
 }

--- a/src/pcb/pcb_trace_error.ts
+++ b/src/pcb/pcb_trace_error.ts
@@ -1,13 +1,16 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_trace_error = z
-  .object({
+export const pcb_trace_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_trace_error"),
     pcb_trace_error_id: getZodPrefixedIdWithDefault("pcb_trace_error"),
     error_type: z.literal("pcb_trace_error").default("pcb_trace_error"),
-    message: z.string(),
     center: point.optional(),
     pcb_trace_id: z.string(),
     source_trace_id: z.string(),
@@ -23,11 +26,10 @@ type InferredPcbTraceError = z.infer<typeof pcb_trace_error>
 /**
  * Defines a trace error on the PCB
  */
-export interface PcbTraceError {
+export interface PcbTraceError extends BaseCircuitJsonError {
   type: "pcb_trace_error"
   pcb_trace_error_id: string
   error_type: "pcb_trace_error"
-  message: string
   center?: Point
   pcb_trace_id: string
   source_trace_id: string

--- a/src/pcb/pcb_trace_missing_error.ts
+++ b/src/pcb/pcb_trace_missing_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_trace_missing_error = z
-  .object({
+export const pcb_trace_missing_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_trace_missing_error"),
     pcb_trace_missing_error_id: getZodPrefixedIdWithDefault(
       "pcb_trace_missing_error",
@@ -11,7 +15,6 @@ export const pcb_trace_missing_error = z
     error_type: z
       .literal("pcb_trace_missing_error")
       .default("pcb_trace_missing_error"),
-    message: z.string(),
     center: point.optional(),
     source_trace_id: z.string(),
     pcb_component_ids: z.array(z.string()),
@@ -28,11 +31,10 @@ type InferredPcbTraceMissingError = z.infer<typeof pcb_trace_missing_error>
 /**
  * Defines an error when a source trace has no corresponding PCB trace
  */
-export interface PcbTraceMissingError {
+export interface PcbTraceMissingError extends BaseCircuitJsonError {
   type: "pcb_trace_missing_error"
   pcb_trace_missing_error_id: string
   error_type: "pcb_trace_missing_error"
-  message: string
   center?: Point
   source_trace_id: string
   pcb_component_ids: string[]

--- a/src/pcb/pcb_via_clearance_error.ts
+++ b/src/pcb/pcb_via_clearance_error.ts
@@ -1,16 +1,19 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { distance, type Distance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const pcb_via_clearance_error = z
-  .object({
+export const pcb_via_clearance_error = base_circuit_json_error
+  .extend({
     type: z.literal("pcb_via_clearance_error"),
     pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
     error_type: z
       .literal("pcb_via_clearance_error")
       .default("pcb_via_clearance_error"),
-    message: z.string(),
     pcb_via_ids: z.array(z.string()).min(2),
     minimum_clearance: distance.optional(),
     actual_clearance: distance.optional(),
@@ -28,11 +31,10 @@ export type PcbViaClearanceErrorInput = z.input<typeof pcb_via_clearance_error>
 type InferredPcbViaClearanceError = z.infer<typeof pcb_via_clearance_error>
 
 /** Error emitted when vias are closer than the allowed clearance */
-export interface PcbViaClearanceError {
+export interface PcbViaClearanceError extends BaseCircuitJsonError {
   type: "pcb_via_clearance_error"
   pcb_error_id: string
   error_type: "pcb_via_clearance_error"
-  message: string
   pcb_via_ids: string[]
   minimum_clearance?: Distance
   actual_clearance?: Distance

--- a/src/schematic/schematic_error.ts
+++ b/src/schematic/schematic_error.ts
@@ -1,23 +1,25 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export interface SchematicError {
+export interface SchematicError extends BaseCircuitJsonError {
   type: "schematic_error"
   schematic_error_id: string
   error_type: "schematic_port_not_found"
-  message: string
   subcircuit_id?: string
 }
 
-export const schematic_error = z
-  .object({
+export const schematic_error = base_circuit_json_error
+  .extend({
     type: z.literal("schematic_error"),
     schematic_error_id: z.string(),
     // eventually each error type should be broken out into a dir of files
     error_type: z
       .literal("schematic_port_not_found")
       .default("schematic_port_not_found"),
-    message: z.string(),
     subcircuit_id: z.string().optional(),
   })
   .describe("Defines a schematic error on the schematic")

--- a/src/schematic/schematic_layout_error.ts
+++ b/src/schematic/schematic_layout_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const schematic_layout_error = z
-  .object({
+export const schematic_layout_error = base_circuit_json_error
+  .extend({
     type: z.literal("schematic_layout_error"),
     schematic_layout_error_id: getZodPrefixedIdWithDefault(
       "schematic_layout_error",
@@ -11,7 +15,6 @@ export const schematic_layout_error = z
     error_type: z
       .literal("schematic_layout_error")
       .default("schematic_layout_error"),
-    message: z.string(),
     source_group_id: z.string(),
     schematic_group_id: z.string(),
     subcircuit_id: z.string().optional(),
@@ -21,11 +24,10 @@ export const schematic_layout_error = z
 export type SchematicLayoutErrorInput = z.input<typeof schematic_layout_error>
 type InferredSchematicLayoutError = z.infer<typeof schematic_layout_error>
 
-export interface SchematicLayoutError {
+export interface SchematicLayoutError extends BaseCircuitJsonError {
   type: "schematic_layout_error"
   schematic_layout_error_id: string
   error_type: "schematic_layout_error"
-  message: string
   source_group_id: string
   schematic_group_id: string
   subcircuit_id?: string

--- a/src/simulation/simulation_unknown_experiment_error.ts
+++ b/src/simulation/simulation_unknown_experiment_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const simulation_unknown_experiment_error = z
-  .object({
+export const simulation_unknown_experiment_error = base_circuit_json_error
+  .extend({
     type: z.literal("simulation_unknown_experiment_error"),
     simulation_unknown_experiment_error_id: getZodPrefixedIdWithDefault(
       "simulation_unknown_experiment_error",
@@ -11,7 +15,6 @@ export const simulation_unknown_experiment_error = z
     error_type: z
       .literal("simulation_unknown_experiment_error")
       .default("simulation_unknown_experiment_error"),
-    message: z.string(),
     simulation_experiment_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
   })
@@ -27,11 +30,10 @@ type InferredSimulationUnknownExperimentError = z.infer<
 /**
  * An unknown error occurred during the simulation experiment.
  */
-export interface SimulationUnknownExperimentError {
+export interface SimulationUnknownExperimentError extends BaseCircuitJsonError {
   type: "simulation_unknown_experiment_error"
   simulation_unknown_experiment_error_id: string
   error_type: "simulation_unknown_experiment_error"
-  message: string
   simulation_experiment_id?: string
   subcircuit_id?: string
 }

--- a/src/source/source_failed_to_create_component_error.ts
+++ b/src/source/source_failed_to_create_component_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const source_failed_to_create_component_error = z
-  .object({
+export const source_failed_to_create_component_error = base_circuit_json_error
+  .extend({
     type: z.literal("source_failed_to_create_component_error"),
     source_failed_to_create_component_error_id: getZodPrefixedIdWithDefault(
       "source_failed_to_create_component_error",
@@ -14,7 +18,6 @@ export const source_failed_to_create_component_error = z
     component_name: z.string().optional(),
     subcircuit_id: z.string().optional(),
     parent_source_component_id: z.string().optional(),
-    message: z.string(),
     pcb_center: z
       .object({
         x: z.number().optional(),
@@ -41,11 +44,11 @@ type InferredSourceFailedToCreateComponentError = z.infer<
  * Error emitted when a component fails to be constructed.
  * Contains details about the failure and prevents the component from being rendered.
  */
-export interface SourceFailedToCreateComponentError {
+export interface SourceFailedToCreateComponentError
+  extends BaseCircuitJsonError {
   type: "source_failed_to_create_component_error"
   source_failed_to_create_component_error_id: string
   error_type: "source_failed_to_create_component_error"
-  message: string
   component_name?: string
   subcircuit_id?: string
   parent_source_component_id?: string

--- a/src/source/source_missing_property_error.ts
+++ b/src/source/source_missing_property_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const source_missing_property_error = z
-  .object({
+export const source_missing_property_error = base_circuit_json_error
+  .extend({
     type: z.literal("source_missing_property_error"),
     source_missing_property_error_id: getZodPrefixedIdWithDefault(
       "source_missing_property_error",
@@ -14,7 +18,6 @@ export const source_missing_property_error = z
     error_type: z
       .literal("source_missing_property_error")
       .default("source_missing_property_error"),
-    message: z.string(),
   })
   .describe("The source code is missing a property")
 
@@ -28,14 +31,13 @@ type InferredSourceMissingPropertyError = z.infer<
 /**
  * The source code is missing a property
  */
-export interface SourceMissingPropertyError {
+export interface SourceMissingPropertyError extends BaseCircuitJsonError {
   type: "source_missing_property_error"
   source_missing_property_error_id: string
   source_component_id: string
   property_name: string
   subcircuit_id?: string
   error_type: "source_missing_property_error"
-  message: string
 }
 
 expectTypesMatch<

--- a/src/source/source_pin_must_be_connected_error.ts
+++ b/src/source/source_pin_must_be_connected_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const source_pin_must_be_connected_error = z
-  .object({
+export const source_pin_must_be_connected_error = base_circuit_json_error
+  .extend({
     type: z.literal("source_pin_must_be_connected_error"),
     source_pin_must_be_connected_error_id: getZodPrefixedIdWithDefault(
       "source_pin_must_be_connected_error",
@@ -11,7 +15,6 @@ export const source_pin_must_be_connected_error = z
     error_type: z
       .literal("source_pin_must_be_connected_error")
       .default("source_pin_must_be_connected_error"),
-    message: z.string(),
     source_component_id: z.string(),
     source_port_id: z.string(),
     subcircuit_id: z.string().optional(),
@@ -30,11 +33,10 @@ type InferredSourcePinMustBeConnectedError = z.infer<
 /**
  * Error emitted when a pin with mustBeConnected attribute is not connected to any trace
  */
-export interface SourcePinMustBeConnectedError {
+export interface SourcePinMustBeConnectedError extends BaseCircuitJsonError {
   type: "source_pin_must_be_connected_error"
   source_pin_must_be_connected_error_id: string
   error_type: "source_pin_must_be_connected_error"
-  message: string
   source_component_id: string
   source_port_id: string
   subcircuit_id?: string

--- a/src/source/source_trace_not_connected_error.ts
+++ b/src/source/source_trace_not_connected_error.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const source_trace_not_connected_error = z
-  .object({
+export const source_trace_not_connected_error = base_circuit_json_error
+  .extend({
     type: z.literal("source_trace_not_connected_error"),
     source_trace_not_connected_error_id: getZodPrefixedIdWithDefault(
       "source_trace_not_connected_error",
@@ -11,7 +15,6 @@ export const source_trace_not_connected_error = z
     error_type: z
       .literal("source_trace_not_connected_error")
       .default("source_trace_not_connected_error"),
-    message: z.string(),
     subcircuit_id: z.string().optional(),
     source_group_id: z.string().optional(),
     source_trace_id: z.string().optional(),
@@ -30,11 +33,10 @@ type InferredSourceTraceNotConnectedError = z.infer<
 /**
  * Occurs when a source trace selector does not match any ports
  */
-export interface SourceTraceNotConnectedError {
+export interface SourceTraceNotConnectedError extends BaseCircuitJsonError {
   type: "source_trace_not_connected_error"
   source_trace_not_connected_error_id: string
   error_type: "source_trace_not_connected_error"
-  message: string
   subcircuit_id?: string
   source_group_id?: string
   source_trace_id?: string

--- a/src/source/unknown_error_finding_part.ts
+++ b/src/source/unknown_error_finding_part.ts
@@ -1,9 +1,13 @@
 import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const unknown_error_finding_part = z
-  .object({
+export const unknown_error_finding_part = base_circuit_json_error
+  .extend({
     type: z.literal("unknown_error_finding_part"),
     unknown_error_finding_part_id: getZodPrefixedIdWithDefault(
       "unknown_error_finding_part",
@@ -11,7 +15,6 @@ export const unknown_error_finding_part = z
     error_type: z
       .literal("unknown_error_finding_part")
       .default("unknown_error_finding_part"),
-    message: z.string(),
     source_component_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
   })
@@ -31,11 +34,10 @@ type InferredUnknownErrorFindingPart = z.infer<
  * This includes cases where the API returns HTML instead of JSON,
  * network failures, or other unexpected responses.
  */
-export interface UnknownErrorFindingPart {
+export interface UnknownErrorFindingPart extends BaseCircuitJsonError {
   type: "unknown_error_finding_part"
   unknown_error_finding_part_id: string
   error_type: "unknown_error_finding_part"
-  message: string
   source_component_id?: string
   subcircuit_id?: string
 }


### PR DESCRIPTION
### Motivation
- Introduce a shared base error schema to centralize common fields (`error_type`, `message`) and add `is_fatal` as a new optional boolean for classifying severity.
- Reduce duplication across error schemas by having existing source, PCB, schematic, and simulation errors extend the shared base type.

### Description
- Add `src/base_circuit_json_error.ts` exporting `base_circuit_json_error` (`error_type`, `message`, and optional `is_fatal`) and the `BaseCircuitJsonError` interface.
- Export the new base error from `src/index.ts` via `export * from "./base_circuit_json_error"`.
- Update multiple error schema files (source, PCB, schematic, simulation) to replace standalone `message`/`error_type` fields with `base_circuit_json_error.extend(...)` and make their TypeScript interfaces extend `BaseCircuitJsonError`.
- Updated Zod schemas to use `base_circuit_json_error` so all error types inherit `message`/`error_type` and the optional `is_fatal` property.

### Testing
- Ran `bunx tsc --noEmit` to type-check the code and it completed successfully.
- Ran `bun run format` (Biome) to format the repository and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a735efe94832e932a06995c1b264f)