### PR TITLE
Add schematic_symbol support and allow schematic_component to reference it

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -109,6 +109,7 @@ export const any_circuit_element = z.union([
   sch.schematic_circle,
   sch.schematic_arc,
   sch.schematic_component,
+  sch.schematic_symbol,
   sch.schematic_port,
   sch.schematic_trace,
   sch.schematic_path,

--- a/src/schematic/index.ts
+++ b/src/schematic/index.ts
@@ -1,6 +1,7 @@
 export * from "./schematic_box"
 export * from "./schematic_path"
 export * from "./schematic_component"
+export * from "./schematic_symbol"
 export * from "./schematic_line"
 export * from "./schematic_rect"
 export * from "./schematic_circle"

--- a/src/schematic/schematic_component.ts
+++ b/src/schematic/schematic_component.ts
@@ -40,6 +40,7 @@ export interface SchematicComponent {
   center: Point
   source_component_id?: string
   schematic_component_id: string
+  schematic_symbol_id?: string
   pin_spacing?: number
   pin_styles?: Record<
     string,
@@ -121,6 +122,7 @@ export const schematic_component = z.object({
   center: point,
   source_component_id: z.string().optional(),
   schematic_component_id: z.string(),
+  schematic_symbol_id: z.string().optional(),
   pin_spacing: length.optional(),
   pin_styles: schematic_pin_styles.optional(),
   box_width: length.optional(),

--- a/src/schematic/schematic_symbol.ts
+++ b/src/schematic/schematic_symbol.ts
@@ -1,0 +1,23 @@
+import { z } from "zod"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export interface SchematicSymbol {
+  type: "schematic_symbol"
+  schematic_symbol_id: string
+  name?: string
+}
+
+export const schematic_symbol = z
+  .object({
+    type: z.literal("schematic_symbol"),
+    schematic_symbol_id: z.string(),
+    name: z.string().optional(),
+  })
+  .describe(
+    "Defines a named schematic symbol that can be referenced by components.",
+  )
+
+export type SchematicSymbolInput = z.input<typeof schematic_symbol>
+type InferredSchematicSymbol = z.infer<typeof schematic_symbol>
+
+expectTypesMatch<SchematicSymbol, InferredSchematicSymbol>(true)

--- a/tests/schematic_component.test.ts
+++ b/tests/schematic_component.test.ts
@@ -22,3 +22,12 @@ test("schematic_component allows disabling box with pins", () => {
 
   expect(component.is_box_with_pins).toBe(false)
 })
+
+test("schematic_component allows schematic_symbol_id", () => {
+  const component = schematic_component.parse({
+    ...baseComponent,
+    schematic_symbol_id: "schematic_symbol_1",
+  })
+
+  expect(component.schematic_symbol_id).toBe("schematic_symbol_1")
+})

--- a/tests/schematic_symbol.test.ts
+++ b/tests/schematic_symbol.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { schematic_symbol } from "../src/schematic/schematic_symbol"
+
+test("schematic_symbol accepts optional name", () => {
+  const symbol = schematic_symbol.parse({
+    type: "schematic_symbol",
+    schematic_symbol_id: "sym_1",
+    name: "opamp",
+  })
+
+  expect(symbol.name).toBe("opamp")
+})
+
+test("schematic_symbol does not require name", () => {
+  const symbol = schematic_symbol.parse({
+    type: "schematic_symbol",
+    schematic_symbol_id: "sym_2",
+  })
+
+  expect(symbol.name).toBeUndefined()
+})


### PR DESCRIPTION
### Motivation
- Introduce a first-class `schematic_symbol` element so schematic components can reference named symbols via an ID.
- Allow `schematic_component` to optionally reference a `schematic_symbol` using `schematic_symbol_id` to support symbol reuse and lookup.

### Description
- Added a new `src/schematic/schematic_symbol.ts` Zod schema and TypeScript type for the `schematic_symbol` element with `schematic_symbol_id: string` and optional `name?: string`.
- Exported `schematic_symbol` from `src/schematic/index.ts` and included it in the global `any_circuit_element` union in `src/any_circuit_element.ts`.
- Added an optional `schematic_symbol_id?: string` field to the `SchematicComponent` interface and Zod schema in `src/schematic/schematic_component.ts`.
- Added tests `tests/schematic_symbol.test.ts` and extended `tests/schematic_component.test.ts` to cover parsing the new symbol type and the optional `schematic_symbol_id` on components.

### Testing
- Ran `bun test tests/schematic_component.test.ts` and all tests in that file passed.
- Ran `bun test tests/schematic_symbol.test.ts` and all tests in that file passed.
- Ran `bunx tsc --noEmit` for type checking and it completed successfully.
- Ran `bun run format` to apply formatting changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697bb3ea551c832e86348a0ca0b60e69)