### PR TITLE
Add pcb_board.is_mounted_to_carrier_board and pcb_board.carrier_pcb_board_id

### DIFF
--- a/src/pcb/pcb_board.ts
+++ b/src/pcb/pcb_board.ts
@@ -14,8 +14,10 @@ export const pcb_board = z
     type: z.literal("pcb_board"),
     pcb_board_id: getZodPrefixedIdWithDefault("pcb_board"),
     pcb_panel_id: z.string().optional(),
+    carrier_pcb_board_id: z.string().optional(),
     is_subcircuit: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
+    is_mounted_to_carrier_board: z.boolean().optional(),
     width: length.optional(),
     height: length.optional(),
     center: point,
@@ -49,8 +51,10 @@ export interface PcbBoard {
   type: "pcb_board"
   pcb_board_id: string
   pcb_panel_id?: string
+  carrier_pcb_board_id?: string
   is_subcircuit?: boolean
   subcircuit_id?: string
+  is_mounted_to_carrier_board?: boolean
   width?: Length
   height?: Length
   display_offset_x?: string


### PR DESCRIPTION
### Motivation
- Make the mount flag name explicit that it refers to mounting to a carrier PCB so the field is unambiguous when a board references a carrier.

### Description
- Rename the Zod schema and TypeScript property in `src/pcb/pcb_board.ts` from `is_mounted` to `is_mounted_to_carrier_board` and keep `carrier_pcb_board_id` as an optional carrier reference.

### Testing
- Ran type checking with `bunx tsc --noEmit` and code formatting with `bun run format`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698535af9458832e931f43d1bcdd781d)