### PR TITLE
Add `is_allowed_to_be_off_board` to `pcb_component`

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -32,6 +32,7 @@ export interface PcbComponent {
   width: Length
   height: Length
   do_not_place?: boolean
+  is_allowed_to_be_off_board?: boolean
   pcb_group_id?: string
   position_mode?: "packed" | "relative_to_group_anchor" | "none"
   positioned_relative_to_pcb_group_id?: string

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -27,6 +27,7 @@ export const pcb_component = z
     width: length,
     height: length,
     do_not_place: z.boolean().optional(),
+    is_allowed_to_be_off_board: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     position_mode: z
@@ -62,6 +63,7 @@ export interface PcbComponent {
   width: Length
   height: Length
   do_not_place?: boolean
+  is_allowed_to_be_off_board?: boolean
   pcb_group_id?: string
   position_mode?: "packed" | "relative_to_group_anchor" | "none"
   positioned_relative_to_pcb_group_id?: string

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -54,6 +54,15 @@ test("pcb_component allows display offsets", () => {
   expect(parsed.display_offset_y).toBe("-2mm")
 })
 
+test("pcb_component allows is_allowed_to_be_off_board", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    is_allowed_to_be_off_board: true,
+  })
+
+  expect(parsed.is_allowed_to_be_off_board).toBe(true)
+})
+
 test("pcb_component rejects invalid position_mode", () => {
   expect(() =>
     pcb_component.parse({


### PR DESCRIPTION
### Motivation
- Allow components to indicate they may be placed off the PCB so parsers, types, and docs accept that flag.

### Description
- Add optional `is_allowed_to_be_off_board: z.boolean().optional()` to the `pcb_component` Zod schema in `src/pcb/pcb_component.ts`.
- Add `is_allowed_to_be_off_board?: boolean` to the `PcbComponent` TypeScript interface in `src/pcb/pcb_component.ts`.
- Add a parser test `pcb_component allows is_allowed_to_be_off_board` to `tests/pcb_component_position_mode.test.ts` that asserts the field is accepted.
- Update `docs/PCB_COMPONENT_OVERVIEW.md` to include the new `is_allowed_to_be_off_board` field in the `PcbComponent` overview.

### Testing
- `bun test tests/pcb_component_position_mode.test.ts` passed (all tests in the file succeeded).
- `bunx tsc --noEmit` succeeded (typecheck passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d0d6ae344832ebd416265c5623a99)