### PR TITLE
Add I2C/SPI/UART configuration and capability flags to source_port

### DIFF
--- a/src/source/source_port.ts
+++ b/src/source/source_port.ts
@@ -13,6 +13,22 @@ export const source_port = z.object({
   subcircuit_id: z.string().optional(),
   subcircuit_connectivity_map_key: z.string().optional(),
   must_be_connected: z.boolean().optional(),
+  is_configured_for_i2c_sda: z.boolean().optional(),
+  is_configured_for_i2c_scl: z.boolean().optional(),
+  is_configured_for_spi_mosi: z.boolean().optional(),
+  is_configured_for_spi_miso: z.boolean().optional(),
+  is_configured_for_spi_sck: z.boolean().optional(),
+  is_configured_for_spi_cs: z.boolean().optional(),
+  is_configured_for_uart_tx: z.boolean().optional(),
+  is_configured_for_uart_rx: z.boolean().optional(),
+  supports_i2c_sda: z.boolean().optional(),
+  supports_i2c_scl: z.boolean().optional(),
+  supports_spi_mosi: z.boolean().optional(),
+  supports_spi_miso: z.boolean().optional(),
+  supports_spi_sck: z.boolean().optional(),
+  supports_spi_cs: z.boolean().optional(),
+  supports_uart_tx: z.boolean().optional(),
+  supports_uart_rx: z.boolean().optional(),
 })
 
 export type SourcePortInput = z.input<typeof source_port>
@@ -33,6 +49,22 @@ export interface SourcePort {
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
   must_be_connected?: boolean
+  is_configured_for_i2c_sda?: boolean
+  is_configured_for_i2c_scl?: boolean
+  is_configured_for_spi_mosi?: boolean
+  is_configured_for_spi_miso?: boolean
+  is_configured_for_spi_sck?: boolean
+  is_configured_for_spi_cs?: boolean
+  is_configured_for_uart_tx?: boolean
+  is_configured_for_uart_rx?: boolean
+  supports_i2c_sda?: boolean
+  supports_i2c_scl?: boolean
+  supports_spi_mosi?: boolean
+  supports_spi_miso?: boolean
+  supports_spi_sck?: boolean
+  supports_spi_cs?: boolean
+  supports_uart_tx?: boolean
+  supports_uart_rx?: boolean
 }
 
 expectTypesMatch<SourcePort, InferredSourcePort>(true)

--- a/tests/source_port.test.ts
+++ b/tests/source_port.test.ts
@@ -21,3 +21,44 @@ test("source_port parses without most_frequently_referenced_by_name", () => {
 
   expect(parsed.most_frequently_referenced_by_name).toBeUndefined()
 })
+
+test("source_port parses configuration and support protocol flags", () => {
+  const parsed = source_port.parse({
+    type: "source_port",
+    name: "IO1",
+    source_port_id: "source_port_3",
+    is_configured_for_i2c_sda: true,
+    is_configured_for_i2c_scl: false,
+    is_configured_for_spi_mosi: true,
+    is_configured_for_spi_miso: false,
+    is_configured_for_spi_sck: true,
+    is_configured_for_spi_cs: false,
+    is_configured_for_uart_tx: true,
+    is_configured_for_uart_rx: false,
+    supports_i2c_sda: true,
+    supports_i2c_scl: true,
+    supports_spi_mosi: true,
+    supports_spi_miso: true,
+    supports_spi_sck: true,
+    supports_spi_cs: true,
+    supports_uart_tx: true,
+    supports_uart_rx: true,
+  })
+
+  expect(parsed.is_configured_for_i2c_sda).toBe(true)
+  expect(parsed.is_configured_for_i2c_scl).toBe(false)
+  expect(parsed.is_configured_for_spi_mosi).toBe(true)
+  expect(parsed.is_configured_for_spi_miso).toBe(false)
+  expect(parsed.is_configured_for_spi_sck).toBe(true)
+  expect(parsed.is_configured_for_spi_cs).toBe(false)
+  expect(parsed.is_configured_for_uart_tx).toBe(true)
+  expect(parsed.is_configured_for_uart_rx).toBe(false)
+  expect(parsed.supports_i2c_sda).toBe(true)
+  expect(parsed.supports_i2c_scl).toBe(true)
+  expect(parsed.supports_spi_mosi).toBe(true)
+  expect(parsed.supports_spi_miso).toBe(true)
+  expect(parsed.supports_spi_sck).toBe(true)
+  expect(parsed.supports_spi_cs).toBe(true)
+  expect(parsed.supports_uart_tx).toBe(true)
+  expect(parsed.supports_uart_rx).toBe(true)
+})


### PR DESCRIPTION
### Motivation
- Expose per-port configuration and capability metadata for common serial protocols so tools can reason about pin roles and supported functions.

### Description
- Extend the `source_port` Zod schema with optional `is_configured_for_*` flags for I2C, SPI, and UART and corresponding `supports_*` capability flags.
- Update the exported `SourcePort` TypeScript interface to include the new `is_configured_for_*` and `supports_*` fields and keep it aligned with the inferred Zod type via `expectTypesMatch`.
- Add a unit test `tests/source_port.test.ts` that parses a `source_port` containing all new flags and asserts each value is preserved by the schema.

### Testing
- Ran `bun test tests/source_port.test.ts` and the new/updated tests passed (3 tests, 0 failures). 
- Ran `bunx tsc --noEmit` for type checking and it completed successfully. 
- Ran `bun run format` to apply formatting with no outstanding issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69993b8aa02c832e9e7620c2b7d83081)