### PR TITLE
Make pcb_component anchors optional and add "relative_to_another_component" position_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,13 @@ interface PcbComponent {
   height: Length
   do_not_place?: boolean
   pcb_group_id?: string
-  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  position_mode?:
+    | "packed"
+    | "relative_to_group_anchor"
+    | "relative_to_another_component"
+    | "none"
+  anchor_position?: Point
+  anchor_alignment?: NinePointAnchor
   positioned_relative_to_pcb_group_id?: string
   positioned_relative_to_pcb_board_id?: string
   obstructs_within_bounds: boolean

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -34,7 +34,13 @@ export interface PcbComponent {
   do_not_place?: boolean
   is_allowed_to_be_off_board?: boolean
   pcb_group_id?: string
-  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  position_mode?:
+    | "packed"
+    | "relative_to_group_anchor"
+    | "relative_to_another_component"
+    | "none"
+  anchor_position?: Point
+  anchor_alignment?: NinePointAnchor
   positioned_relative_to_pcb_group_id?: string
   positioned_relative_to_pcb_board_id?: string
   obstructs_within_bounds: boolean

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -3,6 +3,10 @@ import {
   type KicadFootprintMetadata,
   kicadFootprintMetadata,
 } from "src/common/kicadFootprintMetadata"
+import {
+  type NinePointAnchor,
+  ninePointAnchor,
+} from "src/common/NinePointAnchor"
 import { type LayerRef, layer_ref } from "src/pcb/properties/layer_ref"
 import { type Length, type Rotation, length, rotation } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
@@ -39,8 +43,15 @@ export const pcb_component = z
     subcircuit_id: z.string().optional(),
     pcb_group_id: z.string().optional(),
     position_mode: z
-      .enum(["packed", "relative_to_group_anchor", "none"])
+      .enum([
+        "packed",
+        "relative_to_group_anchor",
+        "relative_to_another_component",
+        "none",
+      ])
       .optional(),
+    anchor_position: point.optional(),
+    anchor_alignment: ninePointAnchor.optional(),
     positioned_relative_to_pcb_group_id: z.string().optional(),
     positioned_relative_to_pcb_board_id: z.string().optional(),
     metadata: z
@@ -78,7 +89,13 @@ export interface PcbComponent {
   do_not_place?: boolean
   is_allowed_to_be_off_board?: boolean
   pcb_group_id?: string
-  position_mode?: "packed" | "relative_to_group_anchor" | "none"
+  position_mode?:
+    | "packed"
+    | "relative_to_group_anchor"
+    | "relative_to_another_component"
+    | "none"
+  anchor_position?: Point
+  anchor_alignment?: NinePointAnchor
   positioned_relative_to_pcb_group_id?: string
   positioned_relative_to_pcb_board_id?: string
   metadata?: PcbComponentMetadata

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -12,7 +12,12 @@ const baseComponent = {
   height: 1,
 }
 
-const positionModes = ["packed", "relative_to_group_anchor", "none"] as const
+const positionModes = [
+  "packed",
+  "relative_to_group_anchor",
+  "relative_to_another_component",
+  "none",
+] as const
 
 for (const position_mode of positionModes) {
   test(`pcb_component allows position_mode ${position_mode}`, () => {
@@ -24,6 +29,17 @@ for (const position_mode of positionModes) {
     expect(parsed.position_mode).toBe(position_mode)
   })
 }
+
+test("pcb_component allows optional anchor positioning fields", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    anchor_position: { x: 10, y: 20 },
+    anchor_alignment: "bottom_right",
+  })
+
+  expect(parsed.anchor_position).toEqual({ x: 10, y: 20 })
+  expect(parsed.anchor_alignment).toBe("bottom_right")
+})
 
 test("pcb_component allows positioned_relative_to_pcb_group_id", () => {
   const parsed = pcb_component.parse({


### PR DESCRIPTION
### Motivation
- Allow components to specify optional anchor metadata for more flexible placement and reference other components when positioning by adding `anchor_position` and `anchor_alignment` and a new `position_mode` option.

### Description
- Added `anchor_position: point.optional()` and `anchor_alignment: ninePointAnchor.optional()` to the Zod schema in `src/pcb/pcb_component.ts` and imported `ninePointAnchor` from `src/common/NinePointAnchor`.
- Added `"relative_to_another_component"` to the `position_mode` enum in the Zod schema and to the exported `PcbComponent` TypeScript interface.
- Updated documentation in `README.md` and `docs/PCB_COMPONENT_OVERVIEW.md` to reflect the new optional fields and `position_mode` value.
- Extended `tests/pcb_component_position_mode.test.ts` to include the new `position_mode` value and a test that validates the optional anchor fields parse correctly.

### Testing
- Ran `bun test tests/pcb_component_position_mode.test.ts` which passed (11 tests, 0 failures).
- Ran `bunx tsc --noEmit` to typecheck the project which succeeded with no errors.
- Ran `bun run format` which formatted the repository files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a66836b2e4832e80aa63ea16e47512)