### PR TITLE
Add optional cable_insertion_center to pcb_component

### DIFF
--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -54,6 +54,7 @@ export const pcb_component = z
     anchor_alignment: ninePointAnchor.optional(),
     positioned_relative_to_pcb_group_id: z.string().optional(),
     positioned_relative_to_pcb_board_id: z.string().optional(),
+    cable_insertion_center: point.optional(),
     metadata: z
       .object({
         kicad_footprint: kicadFootprintMetadata.optional(),
@@ -98,6 +99,7 @@ export interface PcbComponent {
   anchor_alignment?: NinePointAnchor
   positioned_relative_to_pcb_group_id?: string
   positioned_relative_to_pcb_board_id?: string
+  cable_insertion_center?: Point
   metadata?: PcbComponentMetadata
   obstructs_within_bounds: boolean
 }

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -59,6 +59,15 @@ test("pcb_component allows positioned_relative_to_pcb_board_id", () => {
   expect(parsed.positioned_relative_to_pcb_board_id).toBe("pcb_board_1")
 })
 
+test("pcb_component allows cable_insertion_center", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    cable_insertion_center: { x: 5, y: -3 },
+  })
+
+  expect(parsed.cable_insertion_center).toEqual({ x: 5, y: -3 })
+})
+
 test("pcb_component allows display offsets", () => {
   const parsed = pcb_component.parse({
     ...baseComponent,


### PR DESCRIPTION
### Motivation
- Allow PCB components to optionally include a coordinate for cable insertion centers so connectors/cables can be described on the component record.

### Description
- Added `cable_insertion_center: point.optional()` to the `pcb_component` Zod schema and `cable_insertion_center?: Point` to the `PcbComponent` TypeScript interface, and added a unit test that verifies parsing and preservation of the field.

### Testing
- Ran `bun test tests/pcb_component_position_mode.test.ts` which passed (12 tests, 0 failures).
- Ran `bunx tsc --noEmit` for type checking which succeeded.
- Ran `bun run format` to apply project formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8e9bf5cec832e848c94cdb1b62269)