### PR TITLE
Add ccw rotation to pcb note text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,7 @@ interface PcbNoteText {
   font: "tscircuit2024"
   font_size: Length
   text?: string
+  ccw_rotation?: number
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/README.md
+++ b/README.md
@@ -1652,7 +1652,7 @@ interface PcbNoteText {
   font: "tscircuit2024"
   font_size: Length
   text?: string
-  ccw_rotation?: number
+  ccw_rotation?: Rotation
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -371,7 +371,7 @@ export interface PcbNoteText {
   font: "tscircuit2024"
   font_size: Length
   text?: string
-  ccw_rotation?: number
+  ccw_rotation?: Rotation
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -371,6 +371,7 @@ export interface PcbNoteText {
   font: "tscircuit2024"
   font_size: Length
   text?: string
+  ccw_rotation?: number
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/src/pcb/pcb_note_text.ts
+++ b/src/pcb/pcb_note_text.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
 import { visible_layer, type VisibleLayer } from "src/pcb/properties/layer_ref"
-import { distance, type Length } from "src/units"
+import { distance, rotation, type Length, type Rotation } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export const pcb_note_text = z
@@ -15,7 +15,7 @@ export const pcb_note_text = z
     font: z.literal("tscircuit2024").default("tscircuit2024"),
     font_size: distance.default("1mm"),
     text: z.string().optional(),
-    ccw_rotation: z.number().optional(),
+    ccw_rotation: rotation.optional(),
     anchor_position: point.default({ x: 0, y: 0 }),
     anchor_alignment: z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
@@ -41,7 +41,7 @@ export interface PcbNoteText {
   font: "tscircuit2024"
   font_size: Length
   text?: string
-  ccw_rotation?: number
+  ccw_rotation?: Rotation
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/src/pcb/pcb_note_text.ts
+++ b/src/pcb/pcb_note_text.ts
@@ -15,6 +15,7 @@ export const pcb_note_text = z
     font: z.literal("tscircuit2024").default("tscircuit2024"),
     font_size: distance.default("1mm"),
     text: z.string().optional(),
+    ccw_rotation: z.number().optional(),
     anchor_position: point.default({ x: 0, y: 0 }),
     anchor_alignment: z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
@@ -40,6 +41,7 @@ export interface PcbNoteText {
   font: "tscircuit2024"
   font_size: Length
   text?: string
+  ccw_rotation?: number
   anchor_position: Point
   anchor_alignment:
     | "center"

--- a/tests/pcb_note_components.test.ts
+++ b/tests/pcb_note_components.test.ts
@@ -93,3 +93,13 @@ test("pcb note text allows optional name and text", () => {
   expect(note.name).toBe("Callout")
   expect(note.text).toBeUndefined()
 })
+
+test("pcb note text allows optional ccw rotation", () => {
+  const note = pcb_note_text.parse({
+    type: "pcb_note_text",
+    text: "Rotate me",
+    ccw_rotation: 45,
+  })
+
+  expect(note.ccw_rotation).toBe(45)
+})

--- a/tests/pcb_note_components.test.ts
+++ b/tests/pcb_note_components.test.ts
@@ -103,3 +103,13 @@ test("pcb note text allows optional ccw rotation", () => {
 
   expect(note.ccw_rotation).toBe(45)
 })
+
+test("pcb note text allows unit-suffixed ccw rotation", () => {
+  const note = pcb_note_text.parse({
+    type: "pcb_note_text",
+    text: "Rotate me too",
+    ccw_rotation: "0.5rad",
+  })
+
+  expect(note.ccw_rotation).toBeCloseTo((0.5 * 180) / Math.PI)
+})


### PR DESCRIPTION
## What changed
- added optional `ccw_rotation` support to `PcbNoteText` in the zod schema and exported TypeScript interface
- added a focused test covering note text rotation parsing
- updated generated docs to include the new field

## Why
`PcbNoteText` was missing the optional rotation field that related PCB text shapes already support, which made note text inconsistent with the rest of the PCB text surface.

## Impact
Users can now provide `ccw_rotation` on `pcb_note_text` elements without type or schema mismatches.

## Validation
- `bun test tests/pcb_note_components.test.ts`
- `npm run build`
