### PR TITLE
Add pcb_trace_warning support for explicit trace thickness mismatches

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -66,6 +66,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_net,
   pcb.pcb_text,
   pcb.pcb_trace,
+  pcb.pcb_trace_warning,
   pcb.pcb_via,
   pcb.pcb_smtpad,
   pcb.pcb_solder_paste,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -12,6 +12,7 @@ export * from "./pcb_smtpad"
 export * from "./pcb_solder_paste"
 export * from "./pcb_text"
 export * from "./pcb_trace"
+export * from "./pcb_trace_warning"
 export * from "./pcb_trace_error"
 export * from "./pcb_trace_missing_error"
 export * from "./pcb_port_not_matched_error"
@@ -73,6 +74,7 @@ import type { PcbSmtPad } from "./pcb_smtpad"
 import type { PcbSolderPaste } from "./pcb_solder_paste"
 import type { PcbText } from "./pcb_text"
 import type { PcbTrace } from "./pcb_trace"
+import type { PcbTraceWarning } from "./pcb_trace_warning"
 import type { PcbTraceError } from "./pcb_trace_error"
 import type { PcbTraceMissingError } from "./pcb_trace_missing_error"
 import type { PcbPortNotMatchedError } from "./pcb_port_not_matched_error"
@@ -130,6 +132,7 @@ export type PcbCircuitElement =
   | PcbSolderPaste
   | PcbText
   | PcbTrace
+  | PcbTraceWarning
   | PcbTraceError
   | PcbTraceMissingError
   | PcbMissingFootprintError

--- a/src/pcb/pcb_trace_warning.ts
+++ b/src/pcb/pcb_trace_warning.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_trace_warning = z
+  .object({
+    type: z.literal("pcb_trace_warning"),
+    pcb_trace_warning_id: getZodPrefixedIdWithDefault("pcb_trace_warning"),
+    warning_type: z.literal("pcb_trace_warning").default("pcb_trace_warning"),
+    message: z.string(),
+    center: point.optional(),
+    pcb_trace_id: z.string(),
+    source_trace_id: z.string(),
+    pcb_component_ids: z.array(z.string()),
+    pcb_port_ids: z.array(z.string()),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Defines a trace warning on the PCB")
+
+export type PcbTraceWarningInput = z.input<typeof pcb_trace_warning>
+type InferredPcbTraceWarning = z.infer<typeof pcb_trace_warning>
+
+/**
+ * Defines a trace warning on the PCB
+ */
+export interface PcbTraceWarning {
+  type: "pcb_trace_warning"
+  pcb_trace_warning_id: string
+  warning_type: "pcb_trace_warning"
+  message: string
+  center?: Point
+  pcb_trace_id: string
+  source_trace_id: string
+  pcb_component_ids: string[]
+  pcb_port_ids: string[]
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbTraceWarning, InferredPcbTraceWarning>(true)


### PR DESCRIPTION
This change adds pcb_trace_warning to circuit-json so trace-thickness mismatch warnings can be represented in the shared spec and consumed by downstream tooling. The warning is now wired through the PCB exports and the generic circuit element union.