### PR TITLE
Add pcb_note_text.is_mirrored to support bottom-layer mirrored text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,6 +1660,8 @@ interface PcbNoteText {
     | "top_right"
     | "bottom_left"
     | "bottom_right"
+  layer: VisibleLayer
+  is_mirrored?: boolean
   color?: string
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2061,7 +2061,7 @@ interface PcbSilkscreenText {
   }
   ccw_rotation?: number
   layer: LayerRef
-  is_mirrored?: boolean
+  is_mirrored_from_top_view?: boolean
   anchor_position: Point
   anchor_alignment: NinePointAnchor
 }

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -378,6 +378,8 @@ export interface PcbNoteText {
     | "top_right"
     | "bottom_left"
     | "bottom_right"
+  layer: VisibleLayer
+  is_mirrored?: boolean
   color?: string
 }
 

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -379,7 +379,7 @@ export interface PcbNoteText {
     | "bottom_left"
     | "bottom_right"
   layer: VisibleLayer
-  is_mirrored?: boolean
+  is_mirrored_from_top_view?: boolean
   color?: string
 }
 

--- a/src/pcb/pcb_note_text.ts
+++ b/src/pcb/pcb_note_text.ts
@@ -20,7 +20,7 @@ export const pcb_note_text = z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
       .default("center"),
     layer: visible_layer.default("top"),
-    is_mirrored: z.boolean().optional(),
+    is_mirrored_from_top_view: z.boolean().optional(),
     color: z.string().optional(),
   })
   .describe("Defines a documentation note in text on the PCB")
@@ -49,7 +49,7 @@ export interface PcbNoteText {
     | "bottom_left"
     | "bottom_right"
   layer: VisibleLayer
-  is_mirrored?: boolean
+  is_mirrored_from_top_view?: boolean
   color?: string
 }
 

--- a/src/pcb/pcb_note_text.ts
+++ b/src/pcb/pcb_note_text.ts
@@ -20,6 +20,7 @@ export const pcb_note_text = z
       .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
       .default("center"),
     layer: visible_layer.default("top"),
+    is_mirrored: z.boolean().optional(),
     color: z.string().optional(),
   })
   .describe("Defines a documentation note in text on the PCB")
@@ -48,6 +49,7 @@ export interface PcbNoteText {
     | "bottom_left"
     | "bottom_right"
   layer: VisibleLayer
+  is_mirrored?: boolean
   color?: string
 }
 

--- a/tests/pcb_note_components.test.ts
+++ b/tests/pcb_note_components.test.ts
@@ -14,6 +14,7 @@ test("pcb note text defaults", () => {
   expect(note.font).toBe("tscircuit2024")
   expect(note.font_size).toBeCloseTo(1)
   expect(note.anchor_position).toEqual({ x: 0, y: 0 })
+  expect(note.is_mirrored).toBeUndefined()
 })
 
 test("pcb note rect defaults", () => {
@@ -88,8 +89,10 @@ test("pcb note text allows optional name and text", () => {
   const note = pcb_note_text.parse({
     type: "pcb_note_text",
     name: "Callout",
+    is_mirrored: true,
   })
 
   expect(note.name).toBe("Callout")
   expect(note.text).toBeUndefined()
+  expect(note.is_mirrored).toBe(true)
 })

--- a/tests/pcb_note_components.test.ts
+++ b/tests/pcb_note_components.test.ts
@@ -14,7 +14,7 @@ test("pcb note text defaults", () => {
   expect(note.font).toBe("tscircuit2024")
   expect(note.font_size).toBeCloseTo(1)
   expect(note.anchor_position).toEqual({ x: 0, y: 0 })
-  expect(note.is_mirrored).toBeUndefined()
+  expect(note.is_mirrored_from_top_view).toBeUndefined()
 })
 
 test("pcb note rect defaults", () => {
@@ -89,10 +89,10 @@ test("pcb note text allows optional name and text", () => {
   const note = pcb_note_text.parse({
     type: "pcb_note_text",
     name: "Callout",
-    is_mirrored: true,
+    is_mirrored_from_top_view: true,
   })
 
   expect(note.name).toBe("Callout")
   expect(note.text).toBeUndefined()
-  expect(note.is_mirrored).toBe(true)
+  expect(note.is_mirrored_from_top_view).toBe(true)
 })


### PR DESCRIPTION
## Summary
- add `is_mirrored?: boolean` to the `PcbNoteText` Zod schema and exported TypeScript interface
- add regression coverage for both the default omitted case and an explicit mirrored note text case
- update the generated docs for `PcbNoteText`

## Why
`PcbNoteText` was missing the mirrored-text flag that already exists on other PCB text primitives. That left downstream renderers without the schema-level signal needed to mirror note text on bottom layers.

This is a small core data-modeling fix that reproduces the gap with a test and fixes it in the same PR, which unblocks `circuit-to-canvas` from rendering bottom-layer note text as mirrored text.

### 3d-viewer currently
<img width="1082" height="748" alt="image" src="https://github.com/user-attachments/assets/643220a8-6703-464c-9558-393ecfd844c9" />

## Impact
- unblocks bottom-layer note text mirroring in `circuit-to-canvas`
- keeps PCB text modeling consistent across note, copper, and silkscreen text
- preserves existing behavior when `is_mirrored` is omitted

## Validation
- `bun test tests/pcb_note_components.test.ts`