### PR TITLE
Add pad clearance error circuit-json elements

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -1,9 +1,9 @@
 import { z } from "zod"
+import * as cad from "./cad"
 import * as pcb from "./pcb"
 import * as sch from "./schematic"
-import * as src from "./source"
-import * as cad from "./cad"
 import * as sim from "./simulation"
+import * as src from "./source"
 import {
   expectStringUnionsMatch,
   expectTypesMatch,
@@ -200,8 +200,6 @@ expectStringUnionsMatch<
   | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
   | "pcb_courtyard_overlap_error DOES NOT HAVE AN pcb_courtyard_overlap_error_id PROPERTY"
   | "pcb_via_clearance_error DOES NOT HAVE AN pcb_via_clearance_error_id PROPERTY"
-  | "pcb_pad_pad_clearance_error DOES NOT HAVE AN pcb_pad_pad_clearance_error_id PROPERTY"
-  | "pcb_pad_trace_clearance_error DOES NOT HAVE AN pcb_pad_trace_clearance_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"
   | "schematic_box DOES NOT HAVE AN schematic_box_id PROPERTY"
 >(true)

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -89,6 +89,8 @@ export const any_circuit_element = z.union([
   pcb.pcb_port_not_matched_error,
   pcb.pcb_port_not_connected_error,
   pcb.pcb_via_clearance_error,
+  pcb.pcb_pad_pad_clearance_error,
+  pcb.pcb_pad_trace_clearance_error,
   pcb.pcb_fabrication_note_path,
   pcb.pcb_fabrication_note_text,
   pcb.pcb_fabrication_note_rect,
@@ -198,6 +200,8 @@ expectStringUnionsMatch<
   | "pcb_footprint_overlap_error DOES NOT HAVE AN pcb_footprint_overlap_error_id PROPERTY"
   | "pcb_courtyard_overlap_error DOES NOT HAVE AN pcb_courtyard_overlap_error_id PROPERTY"
   | "pcb_via_clearance_error DOES NOT HAVE AN pcb_via_clearance_error_id PROPERTY"
+  | "pcb_pad_pad_clearance_error DOES NOT HAVE AN pcb_pad_pad_clearance_error_id PROPERTY"
+  | "pcb_pad_trace_clearance_error DOES NOT HAVE AN pcb_pad_trace_clearance_error_id PROPERTY"
   | "schematic_debug_object DOES NOT HAVE AN schematic_debug_object_id PROPERTY"
   | "schematic_box DOES NOT HAVE AN schematic_box_id PROPERTY"
 >(true)

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -61,6 +61,8 @@ export * from "./pcb_component_outside_board_error"
 export * from "./pcb_component_not_on_board_edge_error"
 export * from "./pcb_component_invalid_layer_error"
 export * from "./pcb_via_clearance_error"
+export * from "./pcb_pad_pad_clearance_error"
+export * from "./pcb_pad_trace_clearance_error"
 export * from "./pcb_courtyard_rect"
 export * from "./pcb_courtyard_outline"
 export * from "./pcb_courtyard_polygon"
@@ -118,6 +120,8 @@ import type { PcbComponentNotOnBoardEdgeError } from "./pcb_component_not_on_boa
 import type { PcbComponentInvalidLayerError } from "./pcb_component_invalid_layer_error"
 import type { CircuitJsonFootprintLoadError } from "./circuit_json_footprint_load_error"
 import type { PcbViaClearanceError } from "./pcb_via_clearance_error"
+import type { PcbPadPadClearanceError } from "./pcb_pad_pad_clearance_error"
+import type { PcbPadTraceClearanceError } from "./pcb_pad_trace_clearance_error"
 import type { PcbCourtyardRect } from "./pcb_courtyard_rect"
 import type { PcbCourtyardOutline } from "./pcb_courtyard_outline"
 import type { PcbCourtyardPolygon } from "./pcb_courtyard_polygon"
@@ -176,6 +180,8 @@ export type PcbCircuitElement =
   | PcbComponentNotOnBoardEdgeError
   | PcbComponentInvalidLayerError
   | PcbViaClearanceError
+  | PcbPadPadClearanceError
+  | PcbPadTraceClearanceError
   | PcbCourtyardRect
   | PcbCourtyardOutline
   | PcbCourtyardPolygon

--- a/src/pcb/pcb_pad_pad_clearance_error.ts
+++ b/src/pcb/pcb_pad_pad_clearance_error.ts
@@ -10,14 +10,16 @@ import { expectTypesMatch } from "src/utils/expect-types-match"
 export const pcb_pad_pad_clearance_error = base_circuit_json_error
   .extend({
     type: z.literal("pcb_pad_pad_clearance_error"),
-    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    pcb_pad_pad_clearance_error_id: getZodPrefixedIdWithDefault(
+      "pcb_pad_pad_clearance_error",
+    ),
     error_type: z
       .literal("pcb_pad_pad_clearance_error")
       .default("pcb_pad_pad_clearance_error"),
     pcb_pad_ids: z.array(z.string()).min(2),
     minimum_clearance: distance.optional(),
     actual_clearance: distance.optional(),
-    pcb_center: z
+    center: z
       .object({
         x: z.number().optional(),
         y: z.number().optional(),
@@ -35,12 +37,12 @@ type InferredPcbPadPadClearanceError = z.infer<typeof pcb_pad_pad_clearance_erro
 /** Error emitted when pads are closer than the allowed clearance */
 export interface PcbPadPadClearanceError extends BaseCircuitJsonError {
   type: "pcb_pad_pad_clearance_error"
-  pcb_error_id: string
+  pcb_pad_pad_clearance_error_id: string
   error_type: "pcb_pad_pad_clearance_error"
   pcb_pad_ids: string[]
   minimum_clearance?: Distance
   actual_clearance?: Distance
-  pcb_center?: {
+  center?: {
     x?: number
     y?: number
   }

--- a/src/pcb/pcb_pad_pad_clearance_error.ts
+++ b/src/pcb/pcb_pad_pad_clearance_error.ts
@@ -1,0 +1,50 @@
+import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { distance, type Distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_pad_pad_clearance_error = base_circuit_json_error
+  .extend({
+    type: z.literal("pcb_pad_pad_clearance_error"),
+    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    error_type: z
+      .literal("pcb_pad_pad_clearance_error")
+      .default("pcb_pad_pad_clearance_error"),
+    pcb_pad_ids: z.array(z.string()).min(2),
+    minimum_clearance: distance.optional(),
+    actual_clearance: distance.optional(),
+    pcb_center: z
+      .object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+      })
+      .optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Error emitted when pads are closer than the allowed clearance")
+
+export type PcbPadPadClearanceErrorInput = z.input<
+  typeof pcb_pad_pad_clearance_error
+>
+type InferredPcbPadPadClearanceError = z.infer<typeof pcb_pad_pad_clearance_error>
+
+/** Error emitted when pads are closer than the allowed clearance */
+export interface PcbPadPadClearanceError extends BaseCircuitJsonError {
+  type: "pcb_pad_pad_clearance_error"
+  pcb_error_id: string
+  error_type: "pcb_pad_pad_clearance_error"
+  pcb_pad_ids: string[]
+  minimum_clearance?: Distance
+  actual_clearance?: Distance
+  pcb_center?: {
+    x?: number
+    y?: number
+  }
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbPadPadClearanceError, InferredPcbPadPadClearanceError>(true)

--- a/src/pcb/pcb_pad_trace_clearance_error.ts
+++ b/src/pcb/pcb_pad_trace_clearance_error.ts
@@ -10,7 +10,9 @@ import { expectTypesMatch } from "src/utils/expect-types-match"
 export const pcb_pad_trace_clearance_error = base_circuit_json_error
   .extend({
     type: z.literal("pcb_pad_trace_clearance_error"),
-    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    pcb_pad_trace_clearance_error_id: getZodPrefixedIdWithDefault(
+      "pcb_pad_trace_clearance_error",
+    ),
     error_type: z
       .literal("pcb_pad_trace_clearance_error")
       .default("pcb_pad_trace_clearance_error"),
@@ -18,7 +20,7 @@ export const pcb_pad_trace_clearance_error = base_circuit_json_error
     pcb_trace_id: z.string(),
     minimum_clearance: distance.optional(),
     actual_clearance: distance.optional(),
-    pcb_center: z
+    center: z
       .object({
         x: z.number().optional(),
         y: z.number().optional(),
@@ -38,13 +40,13 @@ type InferredPcbPadTraceClearanceError = z.infer<
 /** Error emitted when a pad and trace are closer than allowed clearance */
 export interface PcbPadTraceClearanceError extends BaseCircuitJsonError {
   type: "pcb_pad_trace_clearance_error"
-  pcb_error_id: string
+  pcb_pad_trace_clearance_error_id: string
   error_type: "pcb_pad_trace_clearance_error"
   pcb_pad_id: string
   pcb_trace_id: string
   minimum_clearance?: Distance
   actual_clearance?: Distance
-  pcb_center?: {
+  center?: {
     x?: number
     y?: number
   }

--- a/src/pcb/pcb_pad_trace_clearance_error.ts
+++ b/src/pcb/pcb_pad_trace_clearance_error.ts
@@ -1,0 +1,56 @@
+import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { distance, type Distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_pad_trace_clearance_error = base_circuit_json_error
+  .extend({
+    type: z.literal("pcb_pad_trace_clearance_error"),
+    pcb_error_id: getZodPrefixedIdWithDefault("pcb_error"),
+    error_type: z
+      .literal("pcb_pad_trace_clearance_error")
+      .default("pcb_pad_trace_clearance_error"),
+    pcb_pad_id: z.string(),
+    pcb_trace_id: z.string(),
+    minimum_clearance: distance.optional(),
+    actual_clearance: distance.optional(),
+    pcb_center: z
+      .object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+      })
+      .optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Error emitted when a pad and trace are closer than allowed clearance")
+
+export type PcbPadTraceClearanceErrorInput = z.input<
+  typeof pcb_pad_trace_clearance_error
+>
+type InferredPcbPadTraceClearanceError = z.infer<
+  typeof pcb_pad_trace_clearance_error
+>
+
+/** Error emitted when a pad and trace are closer than allowed clearance */
+export interface PcbPadTraceClearanceError extends BaseCircuitJsonError {
+  type: "pcb_pad_trace_clearance_error"
+  pcb_error_id: string
+  error_type: "pcb_pad_trace_clearance_error"
+  pcb_pad_id: string
+  pcb_trace_id: string
+  minimum_clearance?: Distance
+  actual_clearance?: Distance
+  pcb_center?: {
+    x?: number
+    y?: number
+  }
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbPadTraceClearanceError, InferredPcbPadTraceClearanceError>(
+  true,
+)

--- a/tests/pcb_pad_pad_clearance_error.test.ts
+++ b/tests/pcb_pad_pad_clearance_error.test.ts
@@ -9,17 +9,21 @@ test("pcb_pad_pad_clearance_error parses", () => {
     pcb_pad_ids: ["pcb_smtpad_1", "pcb_smtpad_2"],
     minimum_clearance: "0.2mm",
     actual_clearance: "0.1mm",
-    pcb_center: {
+    center: {
       x: 8.1,
       y: -2.3,
     },
   })
 
-  expect(error.pcb_error_id).toBeDefined()
-  expect(error.pcb_error_id.startsWith("pcb_error")).toBe(true)
+  expect(error.pcb_pad_pad_clearance_error_id).toBeDefined()
+  expect(
+    error.pcb_pad_pad_clearance_error_id.startsWith(
+      "pcb_pad_pad_clearance_error",
+    ),
+  ).toBe(true)
   expect(error.minimum_clearance).toBeCloseTo(0.2)
   expect(error.actual_clearance).toBeCloseTo(0.1)
-  expect(error.pcb_center).toEqual({ x: 8.1, y: -2.3 })
+  expect(error.center).toEqual({ x: 8.1, y: -2.3 })
 })
 
 test("any_circuit_element includes pcb_pad_pad_clearance_error", () => {

--- a/tests/pcb_pad_pad_clearance_error.test.ts
+++ b/tests/pcb_pad_pad_clearance_error.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { pcb_pad_pad_clearance_error } from "../src/pcb/pcb_pad_pad_clearance_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_pad_pad_clearance_error parses", () => {
+  const error = pcb_pad_pad_clearance_error.parse({
+    type: "pcb_pad_pad_clearance_error",
+    message: "pads too close",
+    pcb_pad_ids: ["pcb_smtpad_1", "pcb_smtpad_2"],
+    minimum_clearance: "0.2mm",
+    actual_clearance: "0.1mm",
+    pcb_center: {
+      x: 8.1,
+      y: -2.3,
+    },
+  })
+
+  expect(error.pcb_error_id).toBeDefined()
+  expect(error.pcb_error_id.startsWith("pcb_error")).toBe(true)
+  expect(error.minimum_clearance).toBeCloseTo(0.2)
+  expect(error.actual_clearance).toBeCloseTo(0.1)
+  expect(error.pcb_center).toEqual({ x: 8.1, y: -2.3 })
+})
+
+test("any_circuit_element includes pcb_pad_pad_clearance_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_pad_pad_clearance_error",
+    message: "pads too close",
+    pcb_pad_ids: ["pcb_smtpad_1", "pcb_smtpad_2"],
+  })
+
+  expect(parsed.type).toBe("pcb_pad_pad_clearance_error")
+})

--- a/tests/pcb_pad_trace_clearance_error.test.ts
+++ b/tests/pcb_pad_trace_clearance_error.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { pcb_pad_trace_clearance_error } from "../src/pcb/pcb_pad_trace_clearance_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_pad_trace_clearance_error parses", () => {
+  const error = pcb_pad_trace_clearance_error.parse({
+    type: "pcb_pad_trace_clearance_error",
+    message: "pad and trace too close",
+    pcb_pad_id: "pcb_smtpad_1",
+    pcb_trace_id: "pcb_trace_1",
+    minimum_clearance: "0.2mm",
+    actual_clearance: "0.1mm",
+    pcb_center: {
+      x: 4.2,
+      y: 1.5,
+    },
+  })
+
+  expect(error.pcb_error_id).toBeDefined()
+  expect(error.pcb_error_id.startsWith("pcb_error")).toBe(true)
+  expect(error.minimum_clearance).toBeCloseTo(0.2)
+  expect(error.actual_clearance).toBeCloseTo(0.1)
+  expect(error.pcb_center).toEqual({ x: 4.2, y: 1.5 })
+})
+
+test("any_circuit_element includes pcb_pad_trace_clearance_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_pad_trace_clearance_error",
+    message: "pad and trace too close",
+    pcb_pad_id: "pcb_smtpad_1",
+    pcb_trace_id: "pcb_trace_1",
+  })
+
+  expect(parsed.type).toBe("pcb_pad_trace_clearance_error")
+})

--- a/tests/pcb_pad_trace_clearance_error.test.ts
+++ b/tests/pcb_pad_trace_clearance_error.test.ts
@@ -10,17 +10,21 @@ test("pcb_pad_trace_clearance_error parses", () => {
     pcb_trace_id: "pcb_trace_1",
     minimum_clearance: "0.2mm",
     actual_clearance: "0.1mm",
-    pcb_center: {
+    center: {
       x: 4.2,
       y: 1.5,
     },
   })
 
-  expect(error.pcb_error_id).toBeDefined()
-  expect(error.pcb_error_id.startsWith("pcb_error")).toBe(true)
+  expect(error.pcb_pad_trace_clearance_error_id).toBeDefined()
+  expect(
+    error.pcb_pad_trace_clearance_error_id.startsWith(
+      "pcb_pad_trace_clearance_error",
+    ),
+  ).toBe(true)
   expect(error.minimum_clearance).toBeCloseTo(0.2)
   expect(error.actual_clearance).toBeCloseTo(0.1)
-  expect(error.pcb_center).toEqual({ x: 4.2, y: 1.5 })
+  expect(error.center).toEqual({ x: 4.2, y: 1.5 })
 })
 
 test("any_circuit_element includes pcb_pad_trace_clearance_error", () => {


### PR DESCRIPTION
### Motivation
- Add explicit error elements to represent pad-to-pad and pad-to-trace clearance violations modeled after the existing `pcb_via_clearance_error` shape so these cases can be validated and included in the union types.

### Description
- Added `src/pcb/pcb_pad_pad_clearance_error.ts` implementing a Zod schema and TypeScript interface for `pcb_pad_pad_clearance_error` with `pcb_pad_ids`, clearance distances, optional `pcb_center`, `subcircuit_id`, and `pcb_error_id`.
- Added `src/pcb/pcb_pad_trace_clearance_error.ts` implementing a Zod schema and TypeScript interface for `pcb_pad_trace_clearance_error` with `pcb_pad_id`, `pcb_trace_id`, clearance distances, optional `pcb_center`, `subcircuit_id`, and `pcb_error_id`.
- Exported both new elements from `src/pcb/index.ts` and added their types to the `PcbCircuitElement` union.
- Updated `src/any_circuit_element.ts` to include both new elements in the union and added them to the missing-id exception list, and added focused tests in `tests/pcb_pad_pad_clearance_error.test.ts` and `tests/pcb_pad_trace_clearance_error.test.ts`.

### Testing
- Ran the targeted tests with `bun test tests/pcb_via_clearance_error.test.ts tests/pcb_pad_pad_clearance_error.test.ts tests/pcb_pad_trace_clearance_error.test.ts`, which completed with `6 pass` and `0 fail`.
- Built the package with `bun run build`, which completed successfully (ESM and DTS artifacts generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3bbc0533c83279cfcd74813509405)