### PR TITLE
Add manufacturing DRC properties to pcb_board schema

### DIFF
--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -3,6 +3,7 @@ export * from "./properties/layer_ref"
 export * from "./properties/pcb_route_hints"
 export * from "./properties/supplier_name"
 export * from "./properties/route_hint_point"
+export * from "./properties/manufacturing_drc_properties"
 
 export * from "./pcb_component"
 export * from "./pcb_hole"

--- a/src/pcb/pcb_board.ts
+++ b/src/pcb/pcb_board.ts
@@ -8,6 +8,10 @@ import {
 } from "src/common"
 import { length, type Length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import {
+  manufacturing_drc_properties,
+  type ManufacturingDrcProperties,
+} from "src/pcb/properties/manufacturing_drc_properties"
 
 export const pcb_board = z
   .object({
@@ -42,12 +46,13 @@ export const pcb_board = z
     anchor_alignment: ninePointAnchor.optional(),
     position_mode: z.enum(["relative_to_panel_anchor", "none"]).optional(),
   })
+  .merge(manufacturing_drc_properties)
   .describe("Defines the board outline of the PCB")
 
 /**
  * Defines the board outline of the PCB
  */
-export interface PcbBoard {
+export interface PcbBoard extends ManufacturingDrcProperties {
   type: "pcb_board"
   pcb_board_id: string
   pcb_panel_id?: string

--- a/src/pcb/pcb_pad_pad_clearance_error.ts
+++ b/src/pcb/pcb_pad_pad_clearance_error.ts
@@ -32,7 +32,9 @@ export const pcb_pad_pad_clearance_error = base_circuit_json_error
 export type PcbPadPadClearanceErrorInput = z.input<
   typeof pcb_pad_pad_clearance_error
 >
-type InferredPcbPadPadClearanceError = z.infer<typeof pcb_pad_pad_clearance_error>
+type InferredPcbPadPadClearanceError = z.infer<
+  typeof pcb_pad_pad_clearance_error
+>
 
 /** Error emitted when pads are closer than the allowed clearance */
 export interface PcbPadPadClearanceError extends BaseCircuitJsonError {

--- a/src/pcb/pcb_pad_trace_clearance_error.ts
+++ b/src/pcb/pcb_pad_trace_clearance_error.ts
@@ -28,7 +28,9 @@ export const pcb_pad_trace_clearance_error = base_circuit_json_error
       .optional(),
     subcircuit_id: z.string().optional(),
   })
-  .describe("Error emitted when a pad and trace are closer than allowed clearance")
+  .describe(
+    "Error emitted when a pad and trace are closer than allowed clearance",
+  )
 
 export type PcbPadTraceClearanceErrorInput = z.input<
   typeof pcb_pad_trace_clearance_error

--- a/src/pcb/properties/manufacturing_drc_properties.ts
+++ b/src/pcb/properties/manufacturing_drc_properties.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+import { length, type Length } from "src/units"
+
+export const manufacturing_drc_properties = z.object({
+  min_via_to_via_spacing: length.optional(),
+  min_trace_to_pad_spacing: length.optional(),
+  min_pad_to_pad_spacing: length.optional(),
+  min_via_hole_diameter: length.optional(),
+  min_via_pad_diameter: length.optional(),
+})
+
+export interface ManufacturingDrcProperties {
+  min_via_to_via_spacing?: Length
+  min_trace_to_pad_spacing?: Length
+  min_pad_to_pad_spacing?: Length
+  min_via_hole_diameter?: Length
+  min_via_pad_diameter?: Length
+}

--- a/tests/pcb_board.test.ts
+++ b/tests/pcb_board.test.ts
@@ -112,3 +112,21 @@ test("pcb_board with anchor properties", () => {
   expect(board.display_offset_x).toBe("10mm")
   expect(board.display_offset_y).toBe("10mm")
 })
+
+test("pcb_board with manufacturing drc properties", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    center: { x: 0, y: 0 },
+    min_via_to_via_spacing: "0.2mm",
+    min_trace_to_pad_spacing: "0.15mm",
+    min_pad_to_pad_spacing: "0.18mm",
+    min_via_hole_diameter: "0.25mm",
+    min_via_pad_diameter: "0.45mm",
+  })
+
+  expect(board.min_via_to_via_spacing).toBe(0.2)
+  expect(board.min_trace_to_pad_spacing).toBe(0.15)
+  expect(board.min_pad_to_pad_spacing).toBe(0.18)
+  expect(board.min_via_hole_diameter).toBe(0.25)
+  expect(board.min_via_pad_diameter).toBe(0.45)
+})


### PR DESCRIPTION
### Motivation
- Provide a reusable set of manufacturing DRC properties for PCBs so board-level manufacturing constraints can be expressed and validated consistently.

### Description
- Add `src/pcb/properties/manufacturing_drc_properties.ts` defining `manufacturing_drc_properties` with optional fields `min_via_to_via_spacing`, `min_trace_to_pad_spacing`, `min_pad_to_pad_spacing`, `min_via_hole_diameter`, and `min_via_pad_diameter` using the existing `length` schema.
- Merge `manufacturing_drc_properties` into the `pcb_board` Zod schema via `.merge(...)` and extend the `PcbBoard` TypeScript interface with `ManufacturingDrcProperties`.
- Re-export the new properties module from `src/pcb/index.ts` so it is available from the PCB barrel file.
- Add a unit test in `tests/pcb_board.test.ts` that parses a `pcb_board` with all new manufacturing DRC fields and asserts converted numeric values.

### Testing
- Ran `bun test tests/pcb_board.test.ts` and the test file passed (8 tests, 0 failures). 
- Ran `bunx tsc --noEmit` for type checking and it completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3f82f42e4832e9c318f07437de40f)