### PR TITLE
Add pcb_via_trace_clearance_error schema and tests

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -89,6 +89,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_port_not_matched_error,
   pcb.pcb_port_not_connected_error,
   pcb.pcb_via_clearance_error,
+  pcb.pcb_via_trace_clearance_error,
   pcb.pcb_pad_pad_clearance_error,
   pcb.pcb_pad_trace_clearance_error,
   pcb.pcb_fabrication_note_path,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -62,6 +62,7 @@ export * from "./pcb_component_outside_board_error"
 export * from "./pcb_component_not_on_board_edge_error"
 export * from "./pcb_component_invalid_layer_error"
 export * from "./pcb_via_clearance_error"
+export * from "./pcb_via_trace_clearance_error"
 export * from "./pcb_pad_pad_clearance_error"
 export * from "./pcb_pad_trace_clearance_error"
 export * from "./pcb_courtyard_rect"
@@ -121,6 +122,7 @@ import type { PcbComponentNotOnBoardEdgeError } from "./pcb_component_not_on_boa
 import type { PcbComponentInvalidLayerError } from "./pcb_component_invalid_layer_error"
 import type { CircuitJsonFootprintLoadError } from "./circuit_json_footprint_load_error"
 import type { PcbViaClearanceError } from "./pcb_via_clearance_error"
+import type { PcbViaTraceClearanceError } from "./pcb_via_trace_clearance_error"
 import type { PcbPadPadClearanceError } from "./pcb_pad_pad_clearance_error"
 import type { PcbPadTraceClearanceError } from "./pcb_pad_trace_clearance_error"
 import type { PcbCourtyardRect } from "./pcb_courtyard_rect"
@@ -181,6 +183,7 @@ export type PcbCircuitElement =
   | PcbComponentNotOnBoardEdgeError
   | PcbComponentInvalidLayerError
   | PcbViaClearanceError
+  | PcbViaTraceClearanceError
   | PcbPadPadClearanceError
   | PcbPadTraceClearanceError
   | PcbCourtyardRect

--- a/src/pcb/pcb_via_trace_clearance_error.ts
+++ b/src/pcb/pcb_via_trace_clearance_error.ts
@@ -1,0 +1,60 @@
+import { z } from "zod"
+import {
+  base_circuit_json_error,
+  type BaseCircuitJsonError,
+} from "src/base_circuit_json_error"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { distance, type Distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_via_trace_clearance_error = base_circuit_json_error
+  .extend({
+    type: z.literal("pcb_via_trace_clearance_error"),
+    pcb_via_trace_clearance_error_id: getZodPrefixedIdWithDefault(
+      "pcb_via_trace_clearance_error",
+    ),
+    error_type: z
+      .literal("pcb_via_trace_clearance_error")
+      .default("pcb_via_trace_clearance_error"),
+    pcb_via_id: z.string(),
+    pcb_trace_id: z.string(),
+    minimum_clearance: distance.optional(),
+    actual_clearance: distance.optional(),
+    center: z
+      .object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+      })
+      .optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Error emitted when a via and trace are closer than the allowed clearance",
+  )
+
+export type PcbViaTraceClearanceErrorInput = z.input<
+  typeof pcb_via_trace_clearance_error
+>
+type InferredPcbViaTraceClearanceError = z.infer<
+  typeof pcb_via_trace_clearance_error
+>
+
+/** Error emitted when a via and trace are closer than the allowed clearance */
+export interface PcbViaTraceClearanceError extends BaseCircuitJsonError {
+  type: "pcb_via_trace_clearance_error"
+  pcb_via_trace_clearance_error_id: string
+  error_type: "pcb_via_trace_clearance_error"
+  pcb_via_id: string
+  pcb_trace_id: string
+  minimum_clearance?: Distance
+  actual_clearance?: Distance
+  center?: {
+    x?: number
+    y?: number
+  }
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbViaTraceClearanceError, InferredPcbViaTraceClearanceError>(
+  true,
+)

--- a/tests/pcb_via_trace_clearance_error.test.ts
+++ b/tests/pcb_via_trace_clearance_error.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { pcb_via_trace_clearance_error } from "../src/pcb/pcb_via_trace_clearance_error"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+test("pcb_via_trace_clearance_error parses", () => {
+  const error = pcb_via_trace_clearance_error.parse({
+    type: "pcb_via_trace_clearance_error",
+    message: "via and trace too close",
+    pcb_via_id: "pcb_via_1",
+    pcb_trace_id: "pcb_trace_1",
+    minimum_clearance: "0.2mm",
+    actual_clearance: "0.1mm",
+    center: {
+      x: 4.2,
+      y: 1.5,
+    },
+  })
+
+  expect(error.pcb_via_trace_clearance_error_id).toBeDefined()
+  expect(
+    error.pcb_via_trace_clearance_error_id.startsWith(
+      "pcb_via_trace_clearance_error",
+    ),
+  ).toBe(true)
+  expect(error.minimum_clearance).toBeCloseTo(0.2)
+  expect(error.actual_clearance).toBeCloseTo(0.1)
+  expect(error.center).toEqual({ x: 4.2, y: 1.5 })
+})
+
+test("any_circuit_element includes pcb_via_trace_clearance_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_via_trace_clearance_error",
+    message: "via and trace too close",
+    pcb_via_id: "pcb_via_1",
+    pcb_trace_id: "pcb_trace_1",
+  })
+
+  expect(parsed.type).toBe("pcb_via_trace_clearance_error")
+})


### PR DESCRIPTION
### Motivation
- Provide a dedicated error schema for when a PCB via is too close to a trace, mirroring existing pad/trace and pad/pad clearance error patterns.

### Description
- Add new schema `pcb_via_trace_clearance_error` in `src/pcb/pcb_via_trace_clearance_error.ts` with fields for `pcb_via_id`, `pcb_trace_id`, `minimum_clearance`, `actual_clearance`, `center`, and `subcircuit_id` and type/interface exports.
- Export the new type from `src/pcb/index.ts` and include `PcbViaTraceClearanceError` in the `PcbCircuitElement` union. 
- Include `pcb.pcb_via_trace_clearance_error` in the global `any_circuit_element` union in `src/any_circuit_element.ts` so parser/consumers recognize the new element. 
- Add tests in `tests/pcb_via_trace_clearance_error.test.ts` that validate direct parsing of the schema and that `any_circuit_element` accepts the new type.

### Testing
- Ran `bun test tests/pcb_via_trace_clearance_error.test.ts` which passed (2 tests, 0 fail). 
- Ran `bun run lint:zod` which reported `No linting errors found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e427c6e4c083279426c12667879bba)