### PR TITLE
Add min_trace_width to manufacturing DRC properties

### DIFF
--- a/src/pcb/properties/manufacturing_drc_properties.ts
+++ b/src/pcb/properties/manufacturing_drc_properties.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import { length, type Length } from "src/units"
 
 export const manufacturing_drc_properties = z.object({
+  min_track_width: length.optional(),
   min_via_to_via_spacing: length.optional(),
   min_trace_to_pad_spacing: length.optional(),
   min_pad_to_pad_spacing: length.optional(),
@@ -10,6 +11,7 @@ export const manufacturing_drc_properties = z.object({
 })
 
 export interface ManufacturingDrcProperties {
+  min_track_width?: Length
   min_via_to_via_spacing?: Length
   min_trace_to_pad_spacing?: Length
   min_pad_to_pad_spacing?: Length

--- a/src/pcb/properties/manufacturing_drc_properties.ts
+++ b/src/pcb/properties/manufacturing_drc_properties.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 import { length, type Length } from "src/units"
 
 export const manufacturing_drc_properties = z.object({
-  min_track_width: length.optional(),
+  min_trace_width: length.optional(),
   min_via_to_via_spacing: length.optional(),
   min_trace_to_pad_spacing: length.optional(),
   min_pad_to_pad_spacing: length.optional(),
@@ -11,7 +11,7 @@ export const manufacturing_drc_properties = z.object({
 })
 
 export interface ManufacturingDrcProperties {
-  min_track_width?: Length
+  min_trace_width?: Length
   min_via_to_via_spacing?: Length
   min_trace_to_pad_spacing?: Length
   min_pad_to_pad_spacing?: Length

--- a/tests/pcb_board.test.ts
+++ b/tests/pcb_board.test.ts
@@ -117,7 +117,7 @@ test("pcb_board with manufacturing drc properties", () => {
   const board = pcb_board.parse({
     type: "pcb_board",
     center: { x: 0, y: 0 },
-    min_track_width: "0.12mm",
+    min_trace_width: "0.12mm",
     min_via_to_via_spacing: "0.2mm",
     min_trace_to_pad_spacing: "0.15mm",
     min_pad_to_pad_spacing: "0.18mm",
@@ -125,7 +125,7 @@ test("pcb_board with manufacturing drc properties", () => {
     min_via_pad_diameter: "0.45mm",
   })
 
-  expect(board.min_track_width).toBe(0.12)
+  expect(board.min_trace_width).toBe(0.12)
   expect(board.min_via_to_via_spacing).toBe(0.2)
   expect(board.min_trace_to_pad_spacing).toBe(0.15)
   expect(board.min_pad_to_pad_spacing).toBe(0.18)

--- a/tests/pcb_board.test.ts
+++ b/tests/pcb_board.test.ts
@@ -117,6 +117,7 @@ test("pcb_board with manufacturing drc properties", () => {
   const board = pcb_board.parse({
     type: "pcb_board",
     center: { x: 0, y: 0 },
+    min_track_width: "0.12mm",
     min_via_to_via_spacing: "0.2mm",
     min_trace_to_pad_spacing: "0.15mm",
     min_pad_to_pad_spacing: "0.18mm",
@@ -124,6 +125,7 @@ test("pcb_board with manufacturing drc properties", () => {
     min_via_pad_diameter: "0.45mm",
   })
 
+  expect(board.min_track_width).toBe(0.12)
   expect(board.min_via_to_via_spacing).toBe(0.2)
   expect(board.min_trace_to_pad_spacing).toBe(0.15)
   expect(board.min_pad_to_pad_spacing).toBe(0.18)


### PR DESCRIPTION
### Motivation
- Allow `pcb_board` inputs to specify a minimum track width as part of the manufacturing DRC properties so it can be parsed and typed.

### Description
- Add `min_track_width: length.optional()` to the `manufacturing_drc_properties` Zod schema, add `min_track_width?: Length` to the `ManufacturingDrcProperties` TypeScript interface, and update the `pcb_board` manufacturing DRC test to parse and assert the value.

### Testing
- Ran `bun test tests/pcb_board.test.ts` and the tests passed (8 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e54c0441148327be16eee927489b03)