### PR TITLE
Add supplier footprint mismatch warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2111,8 +2111,8 @@ interface SupplierFootprintMismatchWarning {
   subcircuit_id?: string
   supplier_name?: SupplierName
   supplier_part_number?: string
-  expected_footprint?: string
-  actual_footprint?: string
+  supplier_footprint_url?: string
+  footprint_copper_intersection_over_union: number
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbSilkscreenRect](#pcbsilkscreenrect)
     - [PcbSilkscreenText](#pcbsilkscreentext)
     - [PcbSolderPaste](#pcbsolderpaste)
+    - [SupplierFootprintMismatchWarning](#supplierfootprintmismatchwarning)
     - [PcbText](#pcbtext)
     - [PcbThermalSpoke](#pcbthermalspoke)
     - [PcbTrace](#pcbtrace)
@@ -2088,6 +2089,30 @@ interface PcbSolderPasteCircle {
   layer: LayerRef
   pcb_component_id?: string
   pcb_smtpad_id?: string
+}
+```
+
+### SupplierFootprintMismatchWarning
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/supplier_footprint_mismatch_warning.ts)
+
+Warning emitted when a supplier part footprint does not match the expected footprint
+
+```typescript
+/** Warning emitted when a supplier part footprint does not match the expected footprint */
+interface SupplierFootprintMismatchWarning {
+  type: "supplier_footprint_mismatch_warning"
+  supplier_footprint_mismatch_warning_id: string
+  warning_type: "supplier_footprint_mismatch_warning"
+  message: string
+  source_component_id: string
+  pcb_component_id?: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  supplier_name?: SupplierName
+  supplier_part_number?: string
+  expected_footprint?: string
+  actual_footprint?: string
 }
 ```
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -60,6 +60,7 @@ export const any_circuit_element = z.union([
   pcb.circuit_json_footprint_load_error,
   pcb.pcb_manual_edit_conflict_warning,
   pcb.pcb_connector_not_in_accessible_orientation_warning,
+  pcb.supplier_footprint_mismatch_warning,
   pcb.pcb_plated_hole,
   pcb.pcb_keepout,
   pcb.pcb_port,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -53,6 +53,7 @@ export * from "./pcb_group"
 export * from "./pcb_autorouting_error"
 export * from "./pcb_manual_edit_conflict_warning"
 export * from "./pcb_connector_not_in_accessible_orientation_warning"
+export * from "./supplier_footprint_mismatch_warning"
 export * from "./pcb_breakout_point"
 export * from "./pcb_ground_plane"
 export * from "./pcb_ground_plane_region"
@@ -93,6 +94,7 @@ import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
 import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
 import type { PcbConnectorNotInAccessibleOrientationWarning } from "./pcb_connector_not_in_accessible_orientation_warning"
+import type { SupplierFootprintMismatchWarning } from "./supplier_footprint_mismatch_warning"
 import type { PcbTraceHint } from "./pcb_trace_hint"
 import type { PcbSilkscreenLine } from "./pcb_silkscreen_line"
 import type { PcbSilkscreenPath } from "./pcb_silkscreen_path"
@@ -147,6 +149,7 @@ export type PcbCircuitElement =
   | CircuitJsonFootprintLoadError
   | PcbManualEditConflictWarning
   | PcbConnectorNotInAccessibleOrientationWarning
+  | SupplierFootprintMismatchWarning
   | PcbPortNotMatchedError
   | PcbPortNotConnectedError
   | PcbVia

--- a/src/pcb/supplier_footprint_mismatch_warning.ts
+++ b/src/pcb/supplier_footprint_mismatch_warning.ts
@@ -22,8 +22,8 @@ export const supplier_footprint_mismatch_warning = z
     subcircuit_id: z.string().optional(),
     supplier_name: supplier_name.optional(),
     supplier_part_number: z.string().optional(),
-    expected_footprint: z.string().optional(),
-    actual_footprint: z.string().optional(),
+    supplier_footprint_url: z.string().optional(),
+    footprint_copper_intersection_over_union: z.number(),
   })
   .describe(
     "Warning emitted when a supplier part footprint does not match the expected footprint",
@@ -50,8 +50,8 @@ export interface SupplierFootprintMismatchWarning {
   subcircuit_id?: string
   supplier_name?: SupplierName
   supplier_part_number?: string
-  expected_footprint?: string
-  actual_footprint?: string
+  supplier_footprint_url?: string
+  footprint_copper_intersection_over_union: number
 }
 
 expectTypesMatch<

--- a/src/pcb/supplier_footprint_mismatch_warning.ts
+++ b/src/pcb/supplier_footprint_mismatch_warning.ts
@@ -1,0 +1,60 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import {
+  supplier_name,
+  type SupplierName,
+} from "src/pcb/properties/supplier_name"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const supplier_footprint_mismatch_warning = z
+  .object({
+    type: z.literal("supplier_footprint_mismatch_warning"),
+    supplier_footprint_mismatch_warning_id: getZodPrefixedIdWithDefault(
+      "supplier_footprint_mismatch_warning",
+    ),
+    warning_type: z
+      .literal("supplier_footprint_mismatch_warning")
+      .default("supplier_footprint_mismatch_warning"),
+    message: z.string(),
+    source_component_id: z.string(),
+    pcb_component_id: z.string().optional(),
+    pcb_group_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+    supplier_name: supplier_name.optional(),
+    supplier_part_number: z.string().optional(),
+    expected_footprint: z.string().optional(),
+    actual_footprint: z.string().optional(),
+  })
+  .describe(
+    "Warning emitted when a supplier part footprint does not match the expected footprint",
+  )
+
+export type SupplierFootprintMismatchWarningInput = z.input<
+  typeof supplier_footprint_mismatch_warning
+>
+type InferredSupplierFootprintMismatchWarning = z.infer<
+  typeof supplier_footprint_mismatch_warning
+>
+
+/**
+ * Warning emitted when a supplier part footprint does not match the expected footprint
+ */
+export interface SupplierFootprintMismatchWarning {
+  type: "supplier_footprint_mismatch_warning"
+  supplier_footprint_mismatch_warning_id: string
+  warning_type: "supplier_footprint_mismatch_warning"
+  message: string
+  source_component_id: string
+  pcb_component_id?: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  supplier_name?: SupplierName
+  supplier_part_number?: string
+  expected_footprint?: string
+  actual_footprint?: string
+}
+
+expectTypesMatch<
+  SupplierFootprintMismatchWarning,
+  InferredSupplierFootprintMismatchWarning
+>(true)

--- a/tests/supplier_footprint_mismatch_warning.test.ts
+++ b/tests/supplier_footprint_mismatch_warning.test.ts
@@ -9,8 +9,8 @@ test("supplier_footprint_mismatch_warning parses", () => {
     source_component_id: "src1",
     supplier_name: "jlcpcb",
     supplier_part_number: "C123",
-    expected_footprint: "0603",
-    actual_footprint: "0402",
+    supplier_footprint_url: "https://example.com/footprints/C123.json",
+    footprint_copper_intersection_over_union: 0.42,
   })
 
   expect(warning.supplier_footprint_mismatch_warning_id).toBeDefined()
@@ -27,6 +27,7 @@ test("any_circuit_element includes supplier_footprint_mismatch_warning", () => {
     type: "supplier_footprint_mismatch_warning",
     message: "supplier footprint does not match expected footprint",
     source_component_id: "src1",
+    footprint_copper_intersection_over_union: 0.42,
   })
 
   expect(parsed.type).toBe("supplier_footprint_mismatch_warning")

--- a/tests/supplier_footprint_mismatch_warning.test.ts
+++ b/tests/supplier_footprint_mismatch_warning.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { supplier_footprint_mismatch_warning } from "../src/pcb/supplier_footprint_mismatch_warning"
+
+test("supplier_footprint_mismatch_warning parses", () => {
+  const warning = supplier_footprint_mismatch_warning.parse({
+    type: "supplier_footprint_mismatch_warning",
+    message: "supplier footprint does not match expected footprint",
+    source_component_id: "src1",
+    supplier_name: "jlcpcb",
+    supplier_part_number: "C123",
+    expected_footprint: "0603",
+    actual_footprint: "0402",
+  })
+
+  expect(warning.supplier_footprint_mismatch_warning_id).toBeDefined()
+  expect(
+    warning.supplier_footprint_mismatch_warning_id.startsWith(
+      "supplier_footprint_mismatch_warning",
+    ),
+  ).toBe(true)
+  expect(warning.warning_type).toBe("supplier_footprint_mismatch_warning")
+})
+
+test("any_circuit_element includes supplier_footprint_mismatch_warning", () => {
+  const parsed = any_circuit_element.parse({
+    type: "supplier_footprint_mismatch_warning",
+    message: "supplier footprint does not match expected footprint",
+    source_component_id: "src1",
+  })
+
+  expect(parsed.type).toBe("supplier_footprint_mismatch_warning")
+})


### PR DESCRIPTION
## Summary
- Add a new `supplier_footprint_mismatch_warning` PCB schema with typed IDs and supplier/footprint context fields.
- Export it through `src/pcb/index.ts` and include it in `any_circuit_element`.
- Add a unit test covering parsing and union membership, and document the type in `README.md`.

## Testing
- `bun test`
- `bun run lint:zod`
- `bun run check-snake-case`