### PR TITLE
feat(pcb_component): add relational_constraints for hierarchical auto-placement

### DIFF
--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -75,6 +75,31 @@ export const pcb_component = z
       .describe(
         "Does this component take up all the space within its bounds on a layer. This is generally true except for when separated pin headers are being represented by a single component (in which case, chips can be placed between the pin headers) or for tall modules where chips fit underneath",
       ),
+    relational_constraints: z
+      .object({
+        anchor_to: z
+          .string()
+          .optional()
+          .describe(
+            "The name of another component that this component should be placed near (soft constraint for auto-placement engines)",
+          ),
+        max_distance: z
+          .number()
+          .optional()
+          .describe(
+            "Maximum allowable Euclidean distance in mm between this component's center and the anchor_to component's center",
+          ),
+        keep_near: z
+          .string()
+          .optional()
+          .describe(
+            "Hint for auto-placement engines to keep this component in the same tile/cluster as the named component",
+          ),
+      })
+      .optional()
+      .describe(
+        "Soft placement relationships between this component and others, used by auto-placement engines",
+      ),
   })
   .describe("Defines a component on the PCB")
 
@@ -117,6 +142,23 @@ export interface PcbComponent {
     | "from_back"
   metadata?: PcbComponentMetadata
   obstructs_within_bounds: boolean
+  relational_constraints?: {
+    /**
+     * The name of another component that this component should be placed near.
+     * Soft constraint for auto-placement engines.
+     */
+    anchor_to?: string
+    /**
+     * Maximum allowable Euclidean distance in mm between this component's
+     * center and the anchor_to component's center.
+     */
+    max_distance?: number
+    /**
+     * Hint for auto-placement engines to keep this component in the same
+     * tile or cluster as the named component.
+     */
+    keep_near?: string
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `relational_constraints` field to `pcb_component` to express **soft proximity relationships** between components. This is useful for hierarchical and tile-based auto-placement pipelines.

## Motivation

When building auto-placement engines for dense mixed-signal boards (e.g. RTLS trackers with nRF9151, nPM1300, nRF5340, BQ51013B co-located on a 50×82mm 2-layer PCB), you need a way to encode "this decoupling cap must stay within 8mm of its IC" without hard-coding absolute XY coordinates.

The existing `position_mode` / `anchor_position` / `anchor_alignment` fields cover **deterministic relative placement** (component A at exact offset from component B). `relational_constraints` covers the complementary **soft constraint** case — telling a physics-based or greedy placement engine what the *goal* is, while letting the engine decide the exact position.

## Fields Added

```ts
relational_constraints?: {
  // Name of the target component to stay near (soft constraint)
  anchor_to?: string
  // Maximum allowed Euclidean distance in mm between centers
  max_distance?: number
  // Grouping hint for tile/cluster assignment
  keep_near?: string
}
```

All fields are **optional**. The constraints are advisory — they are intended to be consumed by placement engines, not enforced by Zod validation.

## Example Usage

```json
{
  "type": "pcb_component",
  "pcb_component_id": "pcb_component_C_DEC2",
  "source_component_id": "...",
  "center": { "x": -18.3, "y": -28.1 },
  "width": 1.6, "height": 0.8,
  "layer": "top", "rotation": 0,
  "obstructs_within_bounds": true,
  "relational_constraints": {
    "anchor_to": "U1_NRF9151",
    "max_distance": 8,
    "keep_near": "T1_RF"
  }
}
```

## Changes

- `src/pcb/pcb_component.ts`: adds `relational_constraints` to both the Zod schema and the `PcbComponent` TypeScript interface
- Build and `expectTypesMatch` pass cleanly (`tsc --noEmit` exit 0)

## Testing

The `expectTypesMatch<PcbComponent, InferredPcbComponent>(true)` structural check at the bottom of the file ensures the interface and Zod-inferred type stay in sync — this already validates the new field.