### PR TITLE
Add same-net and different-net trace-edge clearance DRC properties

### DIFF
--- a/src/pcb/properties/manufacturing_drc_properties.ts
+++ b/src/pcb/properties/manufacturing_drc_properties.ts
@@ -21,8 +21,8 @@ export interface ManufacturingDrcProperties {
   min_plated_hole_drill_edge_to_drill_edge_clearance?: Length
   min_trace_to_pad_edge_clearance?: Length
   min_pad_edge_to_pad_edge_clearance?: Length
-  min_same_net_track_edge_to_track_edge_clearance?: Length
-  min_different_net_track_edge_to_track_edge_clearance?: Length
+  min_same_net_trace_edge_to_trace_edge_clearance?: Length
+  min_different_net_trace_edge_to_trace_edge_clearance?: Length
   min_via_hole_diameter?: Length
   min_via_pad_diameter?: Length
 }

--- a/src/pcb/properties/manufacturing_drc_properties.ts
+++ b/src/pcb/properties/manufacturing_drc_properties.ts
@@ -8,6 +8,8 @@ export const manufacturing_drc_properties = z.object({
   min_plated_hole_drill_edge_to_drill_edge_clearance: length.optional(),
   min_trace_to_pad_edge_clearance: length.optional(),
   min_pad_edge_to_pad_edge_clearance: length.optional(),
+  min_same_net_track_edge_to_track_edge_clearance: length.optional(),
+  min_different_net_track_edge_to_track_edge_clearance: length.optional(),
   min_via_hole_diameter: length.optional(),
   min_via_pad_diameter: length.optional(),
 })
@@ -19,6 +21,8 @@ export interface ManufacturingDrcProperties {
   min_plated_hole_drill_edge_to_drill_edge_clearance?: Length
   min_trace_to_pad_edge_clearance?: Length
   min_pad_edge_to_pad_edge_clearance?: Length
+  min_same_net_track_edge_to_track_edge_clearance?: Length
+  min_different_net_track_edge_to_track_edge_clearance?: Length
   min_via_hole_diameter?: Length
   min_via_pad_diameter?: Length
 }

--- a/src/pcb/properties/manufacturing_drc_properties.ts
+++ b/src/pcb/properties/manufacturing_drc_properties.ts
@@ -8,8 +8,8 @@ export const manufacturing_drc_properties = z.object({
   min_plated_hole_drill_edge_to_drill_edge_clearance: length.optional(),
   min_trace_to_pad_edge_clearance: length.optional(),
   min_pad_edge_to_pad_edge_clearance: length.optional(),
-  min_same_net_track_edge_to_track_edge_clearance: length.optional(),
-  min_different_net_track_edge_to_track_edge_clearance: length.optional(),
+  min_same_net_trace_edge_to_trace_edge_clearance: length.optional(),
+  min_different_net_trace_edge_to_trace_edge_clearance: length.optional(),
   min_via_hole_diameter: length.optional(),
   min_via_pad_diameter: length.optional(),
 })


### PR DESCRIPTION
### Motivation
- Represent minimum track-edge-to-track-edge clearances for same-net and different-net cases in manufacturing DRC properties.

### Description
- Extend `src/pcb/properties/manufacturing_drc_properties.ts` by adding `min_same_net_track_edge_to_track_edge_clearance` and `min_different_net_track_edge_to_track_edge_clearance` as optional `length` fields in the Zod schema and matching optional `Length` fields on the `ManufacturingDrcProperties` interface.

### Testing
- Ran `npm run lint:zod` which completed with no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3c0f626388327a51fec7c8857d763)