### PR TITLE
Add dash length and gap support to schematic line and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2562,6 +2562,8 @@ interface SchematicLine {
   stroke_width?: number | null
   color: string
   is_dashed: boolean
+  dash_length?: number
+  dash_gap?: number
   subcircuit_id?: string
 }
 ```
@@ -2620,6 +2622,8 @@ interface SchematicPath {
   schematic_component_id: string
   fill_color?: "red" | "blue"
   is_filled?: boolean
+  dash_length?: number
+  dash_gap?: number
   points: Point[]
   subcircuit_id?: string
 }

--- a/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
+++ b/docs/SCHEMATIC_COMPONENT_OVERVIEW.md
@@ -55,6 +55,8 @@ interface SchematicLine {
   stroke_width: number
   color: string
   is_dashed: boolean
+  dash_length?: number
+  dash_gap?: number
   subcircuit_id?: string
 }
 
@@ -154,6 +156,8 @@ interface SchematicPath {
   schematic_component_id: string
   fill_color?: "red" | "blue"
   is_filled?: boolean
+  dash_length?: number
+  dash_gap?: number
   points: Array<{ x: number; y: number }>
 }
 

--- a/src/schematic/schematic_line.ts
+++ b/src/schematic/schematic_line.ts
@@ -1,7 +1,7 @@
-import { z } from "zod"
-import { distance } from "../units"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+import { distance } from "../units"
 
 /** Draws a styled line on the schematic */
 export interface SchematicLine {
@@ -16,6 +16,8 @@ export interface SchematicLine {
   stroke_width?: number | null
   color: string
   is_dashed: boolean
+  dash_length?: number
+  dash_gap?: number
   subcircuit_id?: string
 }
 
@@ -32,6 +34,8 @@ export const schematic_line = z
     stroke_width: distance.nullable().optional(),
     color: z.string().default("#000000"),
     is_dashed: z.boolean().default(false),
+    dash_length: distance.optional(),
+    dash_gap: distance.optional(),
     subcircuit_id: z.string().optional(),
   })
   .describe("Draws a styled line on the schematic")

--- a/src/schematic/schematic_path.ts
+++ b/src/schematic/schematic_path.ts
@@ -1,8 +1,8 @@
-import { z } from "zod"
-import { point, type Point } from "../common/point"
-import { distance } from "../units"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+import { type Point, point } from "../common/point"
+import { distance } from "../units"
 
 export interface SchematicPath {
   type: "schematic_path"
@@ -13,6 +13,8 @@ export interface SchematicPath {
   is_filled?: boolean
   stroke_width?: number | null
   stroke_color?: string
+  dash_length?: number
+  dash_gap?: number
   points: Point[]
   subcircuit_id?: string
 }
@@ -26,6 +28,8 @@ export const schematic_path = z.object({
   is_filled: z.boolean().optional(),
   stroke_width: distance.nullable().optional(),
   stroke_color: z.string().optional(),
+  dash_length: distance.optional(),
+  dash_gap: distance.optional(),
   points: z.array(point),
   subcircuit_id: z.string().optional(),
 })

--- a/tests/schematic_shapes.test.ts
+++ b/tests/schematic_shapes.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "bun:test"
-import { schematic_line } from "../src/schematic/schematic_line"
-import { schematic_rect } from "../src/schematic/schematic_rect"
-import { schematic_circle } from "../src/schematic/schematic_circle"
 import { schematic_arc } from "../src/schematic/schematic_arc"
+import { schematic_circle } from "../src/schematic/schematic_circle"
+import { schematic_line } from "../src/schematic/schematic_line"
+import { schematic_path } from "../src/schematic/schematic_path"
+import { schematic_rect } from "../src/schematic/schematic_rect"
 
 test("schematic_line defaults stroke width and color", () => {
   const line = schematic_line.parse({
@@ -17,6 +18,39 @@ test("schematic_line defaults stroke width and color", () => {
   expect(line.schematic_line_id).toMatch(/^schematic_line_/)
   expect(line.color).toBe("#000000")
   expect(line.is_dashed).toBe(false)
+  expect(line).not.toHaveProperty("dash_length")
+  expect(line).not.toHaveProperty("dash_gap")
+})
+
+test("schematic_line accepts dash distance parameters", () => {
+  const line = schematic_line.parse({
+    type: "schematic_line",
+    x1: 0,
+    y1: 0,
+    x2: 1,
+    y2: 1,
+    is_dashed: true,
+    dash_length: "2mm",
+    dash_gap: "1mm",
+  })
+
+  expect(line.dash_length).toBe(2)
+  expect(line.dash_gap).toBe(1)
+})
+
+test("schematic_path accepts dash distance parameters", () => {
+  const path = schematic_path.parse({
+    type: "schematic_path",
+    points: [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+    ],
+    dash_length: "2mm",
+    dash_gap: "1mm",
+  })
+
+  expect(path.dash_length).toBe(2)
+  expect(path.dash_gap).toBe(1)
 })
 
 test("schematic_rect assigns defaults", () => {


### PR DESCRIPTION
## Summary
- Added optional `dash_length` and `dash_gap` distance fields to `schematic_line` and `schematic_path`
- Updated the generated schematic docs and README schema excerpts to match the new fields
- Added tests covering default absence and distance parsing for both shapes

## Testing
- `bun test`
- `bunx tsc --noEmit`
- `bun run scripts/zod-lint.ts`
- `git diff --check`