### PR TITLE
Add PcbCourtyardPill definition and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbCourtyardCircle](#pcbcourtyardcircle)
     - [PcbCourtyardOutline](#pcbcourtyardoutline)
     - [PcbCourtyardOverlapError](#pcbcourtyardoverlaperror)
+    - [PcbCourtyardPill](#pcbcourtyardpill)
     - [PcbCourtyardPolygon](#pcbcourtyardpolygon)
     - [PcbCourtyardRect](#pcbcourtyardrect)
     - [PcbCutout](#pcbcutout)
@@ -1485,6 +1486,29 @@ interface PcbCourtyardOverlapError extends BaseCircuitJsonError {
   pcb_error_id: string
   error_type: "pcb_courtyard_overlap_error"
   pcb_component_ids: [string, string]
+}
+```
+
+### PcbCourtyardPill
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_courtyard_pill.ts)
+
+Defines a courtyard pill on the PCB
+
+```typescript
+/** Defines a courtyard pill on the PCB */
+interface PcbCourtyardPill {
+  type: "pcb_courtyard_pill"
+  pcb_courtyard_pill_id: string
+  pcb_component_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  center: Point
+  width: Length
+  height: Length
+  radius: Length
+  layer: VisibleLayer
+  color?: string
 }
 ```
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -119,6 +119,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_courtyard_outline,
   pcb.pcb_courtyard_polygon,
   pcb.pcb_courtyard_circle,
+  pcb.pcb_courtyard_pill,
   sch.schematic_box,
   sch.schematic_text,
   sch.schematic_line,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -70,6 +70,7 @@ export * from "./pcb_courtyard_rect"
 export * from "./pcb_courtyard_outline"
 export * from "./pcb_courtyard_polygon"
 export * from "./pcb_courtyard_circle"
+export * from "./pcb_courtyard_pill"
 
 import type { PcbComponent } from "./pcb_component"
 import type { PcbHole } from "./pcb_hole"
@@ -131,6 +132,7 @@ import type { PcbCourtyardRect } from "./pcb_courtyard_rect"
 import type { PcbCourtyardOutline } from "./pcb_courtyard_outline"
 import type { PcbCourtyardPolygon } from "./pcb_courtyard_polygon"
 import type { PcbCourtyardCircle } from "./pcb_courtyard_circle"
+import type { PcbCourtyardPill } from "./pcb_courtyard_pill"
 
 export type PcbCircuitElement =
   | PcbComponent
@@ -193,3 +195,4 @@ export type PcbCircuitElement =
   | PcbCourtyardOutline
   | PcbCourtyardPolygon
   | PcbCourtyardCircle
+  | PcbCourtyardPill

--- a/src/pcb/pcb_courtyard_pill.ts
+++ b/src/pcb/pcb_courtyard_pill.ts
@@ -1,0 +1,43 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault, point, type Point } from "src/common"
+import { visible_layer, type VisibleLayer } from "src/pcb/properties/layer_ref"
+import { length, type Length } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_courtyard_pill = z
+  .object({
+    type: z.literal("pcb_courtyard_pill"),
+    pcb_courtyard_pill_id: getZodPrefixedIdWithDefault("pcb_courtyard_pill"),
+    pcb_component_id: z.string(),
+    pcb_group_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+    center: point,
+    width: length,
+    height: length,
+    radius: length,
+    layer: visible_layer,
+    color: z.string().optional(),
+  })
+  .describe("Defines a courtyard pill on the PCB")
+
+export type PcbCourtyardPillInput = z.input<typeof pcb_courtyard_pill>
+type InferredPcbCourtyardPill = z.infer<typeof pcb_courtyard_pill>
+
+/**
+ * Defines a courtyard pill on the PCB
+ */
+export interface PcbCourtyardPill {
+  type: "pcb_courtyard_pill"
+  pcb_courtyard_pill_id: string
+  pcb_component_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  center: Point
+  width: Length
+  height: Length
+  radius: Length
+  layer: VisibleLayer
+  color?: string
+}
+
+expectTypesMatch<PcbCourtyardPill, InferredPcbCourtyardPill>(true)

--- a/tests/pcb_courtyard.test.ts
+++ b/tests/pcb_courtyard.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import { pcb_courtyard_rect } from "../src/pcb/pcb_courtyard_rect"
 import { pcb_courtyard_outline } from "../src/pcb/pcb_courtyard_outline"
 import { pcb_courtyard_polygon } from "../src/pcb/pcb_courtyard_polygon"
+import { pcb_courtyard_pill } from "../src/pcb/pcb_courtyard_pill"
 
 test("parse courtyard rect", () => {
   const rect = pcb_courtyard_rect.parse({
@@ -54,4 +55,22 @@ test("parse courtyard polygon", () => {
   expect(polygon).not.toHaveProperty("stroke_width")
   expect(polygon).not.toHaveProperty("has_stroke")
   expect(polygon).not.toHaveProperty("is_stroke_dashed")
+})
+
+test("parse courtyard pill", () => {
+  const pill = pcb_courtyard_pill.parse({
+    type: "pcb_courtyard_pill",
+    pcb_component_id: "pcb_component_4",
+    center: { x: 2, y: 3 },
+    width: 4,
+    height: 1.5,
+    radius: 0.75,
+    layer: "bottom",
+  })
+
+  expect(pill.layer).toBe("bottom")
+  expect(pill.center).toEqual({ x: 2, y: 3 })
+  expect(pill.width).toBe(4)
+  expect(pill.height).toBe(1.5)
+  expect(pill.radius).toBe(0.75)
 })


### PR DESCRIPTION
This pull request adds support for a new PCB courtyard shape called "Pill" (`PcbCourtyardPill`) which is alredy present in `props` repo. It introduces the schema, type definitions, documentation, and tests for this new shape, and integrates it into the existing PCB data model and exports.

**New PCB Courtyard Shape: Pill**

* Added a new schema and type definition for `PcbCourtyardPill`, representing a pill-shaped courtyard on a PCB, including properties such as `center`, `width`, `height`, `radius`, `layer`, and optional `color` (`src/pcb/pcb_courtyard_pill.ts`).
* Updated the PCB element type union and exports to include `PcbCourtyardPill`, ensuring it is recognized as a valid PCB element throughout the codebase (`src/pcb/index.ts`, `src/any_circuit_element.ts`). [[1]](diffhunk://#diff-3022bee8c52a8b47d5aaf08d7d943adbf9687980d9146d2a62ab07abdaaa138cR73) [[2]](diffhunk://#diff-3022bee8c52a8b47d5aaf08d7d943adbf9687980d9146d2a62ab07abdaaa138cR135) [[3]](diffhunk://#diff-3022bee8c52a8b47d5aaf08d7d943adbf9687980d9146d2a62ab07abdaaa138cR198) [[4]](diffhunk://#diff-e9b8dd38a2227129c7ad89d805c91b5c8a403568d20681fb621143adb580f792R122)
* Added documentation for `PcbCourtyardPill` in the `README.md`, detailing its properties and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1492-R1514)

**Testing**

* Introduced a unit test for parsing the new `pcb_courtyard_pill` schema, verifying correct parsing and property values (`tests/pcb_courtyard.test.ts`). [[1]](diffhunk://#diff-7f2fb52ce186846550f3c4e769bb41c040072dd39d934a47c8b926cf08456851R5) [[2]](diffhunk://#diff-7f2fb52ce186846550f3c4e769bb41c040072dd39d934a47c8b926cf08456851R59-R76)