### PR TITLE
Add corner radius support to schematic rectangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -3067,6 +3067,7 @@ interface SchematicRect {
   height: number
   rotation: number
   stroke_width?: number | null
+  corner_radius?: number
   color: string
   is_filled: boolean
   fill_color?: string

--- a/src/schematic/schematic_rect.ts
+++ b/src/schematic/schematic_rect.ts
@@ -15,6 +15,7 @@ export interface SchematicRect {
   height: number
   rotation: number
   stroke_width?: number | null
+  corner_radius?: number
   color: string
   is_filled: boolean
   fill_color?: string
@@ -33,6 +34,7 @@ export const schematic_rect = z
     height: distance,
     rotation: rotation.default(0),
     stroke_width: distance.nullable().optional(),
+    corner_radius: distance.optional(),
     color: z.string().default("#000000"),
     is_filled: z.boolean().default(false),
     fill_color: z.string().optional(),

--- a/tests/schematic_shapes.test.ts
+++ b/tests/schematic_shapes.test.ts
@@ -68,6 +68,19 @@ test("schematic_rect assigns defaults", () => {
   expect(rect.is_dashed).toBe(false)
 })
 
+test("schematic_rect accepts corner radius", () => {
+  const rect = schematic_rect.parse({
+    type: "schematic_rect",
+    schematic_component_id: "comp_1",
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 2,
+    corner_radius: "0.25mm",
+  })
+
+  expect(rect.corner_radius).toBe(0.25)
+})
+
 test("schematic_circle assigns defaults", () => {
   const circle = schematic_circle.parse({
     type: "schematic_circle",


### PR DESCRIPTION
## Summary

Add optional `corner_radius` support to `schematic_rect` so schematic rectangles can carry rounded-corner metadata through parsing and the public type surface.

## Why

Other rect-like primitives in the schema already support rounded-corner metadata, and schematic rectangles needed the same field for consistent modeling.

## What changed

- Added `corner_radius?: number` to `SchematicRect`
- Added `corner_radius` to the `schematic_rect` Zod schema as a distance field
- Added a parser test that verifies unit-style input like `0.25mm` is accepted and converted
- Updated the published README type excerpt

## Validation

- `bun test tests/schematic_shapes.test.ts`
