### PR TITLE
Remove corner_radius property from  PcbFabricationNoteRect, and PcbNoteRect interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1575,7 +1575,6 @@ interface PcbCutoutRect {
   width: Length
   height: Length
   rotation?: Rotation
-  corner_radius?: Length
 }
 ```
 
@@ -1650,7 +1649,6 @@ interface PcbFabricationNoteRect {
   height: Length
   layer: VisibleLayer
   stroke_width: Length
-  corner_radius?: Length
   is_filled?: boolean
   has_stroke?: boolean
   is_stroke_dashed?: boolean
@@ -1961,7 +1959,6 @@ interface PcbNoteRect {
   height: Length
   layer: VisibleLayer
   stroke_width: Length
-  corner_radius?: Length
   is_filled?: boolean
   has_stroke?: boolean
   is_stroke_dashed?: boolean

--- a/src/pcb/pcb_fabrication_note_rect.ts
+++ b/src/pcb/pcb_fabrication_note_rect.ts
@@ -18,7 +18,6 @@ export const pcb_fabrication_note_rect = z
     height: length,
     layer: visible_layer,
     stroke_width: length.default("0.1mm"),
-    corner_radius: length.optional(),
     is_filled: z.boolean().optional(),
     has_stroke: z.boolean().optional(),
     is_stroke_dashed: z.boolean().optional(),
@@ -45,7 +44,6 @@ export interface PcbFabricationNoteRect {
   height: Length
   layer: VisibleLayer
   stroke_width: Length
-  corner_radius?: Length
   is_filled?: boolean
   has_stroke?: boolean
   is_stroke_dashed?: boolean

--- a/src/pcb/pcb_note_rect.ts
+++ b/src/pcb/pcb_note_rect.ts
@@ -18,7 +18,6 @@ export const pcb_note_rect = z
     height: length,
     layer: visible_layer.default("top"),
     stroke_width: length.default("0.1mm"),
-    corner_radius: length.optional(),
     is_filled: z.boolean().optional(),
     has_stroke: z.boolean().optional(),
     is_stroke_dashed: z.boolean().optional(),
@@ -45,7 +44,6 @@ export interface PcbNoteRect {
   height: Length
   layer: VisibleLayer
   stroke_width: Length
-  corner_radius?: Length
   is_filled?: boolean
   has_stroke?: boolean
   is_stroke_dashed?: boolean


### PR DESCRIPTION
This pull request removes the optional `corner_radius` property from several rectangle-related interfaces and schemas in both the codebase and documentation. This change simplifies the data structures for PCB note and fabrication rectangles by eliminating support for rounded corners.

**Rectangle property simplification:**

* Removed the optional `corner_radius` property from the `PcbNoteRect` and `PcbFabricationNoteRect` interfaces and their corresponding zod schemas in `src/pcb/pcb_note_rect.ts` and `src/pcb/pcb_fabrication_note_rect.ts`. [[1]](diffhunk://#diff-18caf81b52b2d748d58544e0ba30397db9d87588bb911286cfcff846e59fc776L21) [[2]](diffhunk://#diff-18caf81b52b2d748d58544e0ba30397db9d87588bb911286cfcff846e59fc776L48) [[3]](diffhunk://#diff-194780c5df7c264f4fa05161dc74d3ca731477cd2b1eac376dd4c208b1005eb0L21) [[4]](diffhunk://#diff-194780c5df7c264f4fa05161dc74d3ca731477cd2b1eac376dd4c208b1005eb0L48)
* Updated the `README.md` documentation to reflect the removal of the `corner_radius` property from the `PcbNoteRect` and `PcbFabricationNoteRect` interface definitions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1578) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1653) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1964)