### PR TITLE
Add PCB silkscreen graphic schema (BRep + optional image_asset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbPortNotMatchedError](#pcbportnotmatchederror)
     - [PcbRouteHints](#pcbroutehints)
     - [PcbSilkscreenCircle](#pcbsilkscreencircle)
+    - [PcbSilkscreenGraphic](#pcbsilkscreengraphic)
     - [PcbSilkscreenLine](#pcbsilkscreenline)
     - [PcbSilkscreenOval](#pcbsilkscreenoval)
     - [PcbSilkscreenPath](#pcbsilkscreenpath)
@@ -2320,6 +2321,27 @@ interface PcbSilkscreenCircle {
   layer: VisibleLayer
   stroke_width: Length
   is_filled?: boolean
+}
+```
+
+### PcbSilkscreenGraphic
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_silkscreen_graphic.ts)
+
+Defines a BRep silkscreen graphic on the PCB
+
+```typescript
+/** Defines a BRep silkscreen graphic on the PCB */
+interface PcbSilkscreenGraphicBRep {
+  type: "pcb_silkscreen_graphic"
+  pcb_silkscreen_graphic_id: string
+  pcb_component_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  layer: VisibleLayer
+  image_asset?: Asset
+  shape: "brep"
+  brep_shape: BRepShape
 }
 ```
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -84,6 +84,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_silkscreen_rect,
   pcb.pcb_silkscreen_circle,
   pcb.pcb_silkscreen_oval,
+  pcb.pcb_silkscreen_graphic,
   pcb.pcb_trace_error,
   pcb.pcb_trace_missing_error,
   pcb.pcb_placement_error,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -32,6 +32,7 @@ export * from "./pcb_copper_text"
 export * from "./pcb_silkscreen_rect"
 export * from "./pcb_silkscreen_circle"
 export * from "./pcb_silkscreen_oval"
+export * from "./pcb_silkscreen_graphic"
 export * from "./pcb_silkscreen_pill"
 export * from "./pcb_fabrication_note_text"
 export * from "./pcb_fabrication_note_path"
@@ -104,6 +105,7 @@ import type { PcbSilkscreenRect } from "./pcb_silkscreen_rect"
 import type { PcbSilkscreenPill } from "./pcb_silkscreen_pill"
 import type { PcbSilkscreenCircle } from "./pcb_silkscreen_circle"
 import type { PcbSilkscreenOval } from "./pcb_silkscreen_oval"
+import type { PcbSilkscreenGraphic } from "./pcb_silkscreen_graphic"
 import type { PcbCopperText } from "./pcb_copper_text"
 import type { PcbFabricationNoteRect } from "./pcb_fabrication_note_rect"
 import type { PcbFabricationNoteDimension } from "./pcb_fabrication_note_dimension"
@@ -169,6 +171,7 @@ export type PcbCircuitElement =
   | PcbSilkscreenRect
   | PcbSilkscreenCircle
   | PcbSilkscreenOval
+  | PcbSilkscreenGraphic
   | PcbFabricationNoteRect
   | PcbFabricationNoteDimension
   | PcbNoteText

--- a/src/pcb/pcb_silkscreen_graphic.ts
+++ b/src/pcb/pcb_silkscreen_graphic.ts
@@ -1,0 +1,59 @@
+import { z } from "zod"
+import { asset, type Asset, getZodPrefixedIdWithDefault } from "src/common"
+import { visible_layer, type VisibleLayer } from "src/pcb/properties/layer_ref"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import { brep_shape, type BRepShape } from "./properties/brep"
+
+const pcb_silkscreen_graphic_base = z.object({
+  type: z.literal("pcb_silkscreen_graphic"),
+  pcb_silkscreen_graphic_id: getZodPrefixedIdWithDefault(
+    "pcb_silkscreen_graphic",
+  ),
+  pcb_component_id: z.string(),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  layer: visible_layer,
+  image_asset: asset.optional(),
+})
+
+export const pcb_silkscreen_graphic_brep = pcb_silkscreen_graphic_base
+  .extend({
+    shape: z.literal("brep"),
+    brep_shape: brep_shape,
+  })
+  .describe("Defines a BRep silkscreen graphic on the PCB")
+
+export type PcbSilkscreenGraphicBRepInput = z.input<
+  typeof pcb_silkscreen_graphic_brep
+>
+type InferredPcbSilkscreenGraphicBRep = z.infer<
+  typeof pcb_silkscreen_graphic_brep
+>
+
+/**
+ * Defines a BRep silkscreen graphic on the PCB
+ */
+export interface PcbSilkscreenGraphicBRep {
+  type: "pcb_silkscreen_graphic"
+  pcb_silkscreen_graphic_id: string
+  pcb_component_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  layer: VisibleLayer
+  image_asset?: Asset
+  shape: "brep"
+  brep_shape: BRepShape
+}
+expectTypesMatch<PcbSilkscreenGraphicBRep, InferredPcbSilkscreenGraphicBRep>(
+  true,
+)
+
+export const pcb_silkscreen_graphic = z
+  .discriminatedUnion("shape", [pcb_silkscreen_graphic_brep])
+  .describe("Defines a silkscreen graphic on the PCB")
+
+export type PcbSilkscreenGraphicInput = z.input<typeof pcb_silkscreen_graphic>
+export type PcbSilkscreenGraphic = PcbSilkscreenGraphicBRep
+
+type InferredPcbSilkscreenGraphic = z.infer<typeof pcb_silkscreen_graphic>
+expectTypesMatch<PcbSilkscreenGraphic, InferredPcbSilkscreenGraphic>(true)

--- a/tests/pcb_silkscreen_graphic.test.ts
+++ b/tests/pcb_silkscreen_graphic.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { pcb_silkscreen_graphic } from "../src/pcb/pcb_silkscreen_graphic"
+
+test("pcb_silkscreen_graphic brep parses", () => {
+  const graphic = pcb_silkscreen_graphic.parse({
+    type: "pcb_silkscreen_graphic",
+    pcb_component_id: "pcb_component_0",
+    shape: "brep",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: 0, y: 0, bulge: 0.25 },
+          { x: 2, y: 0 },
+          { x: 2, y: 2 },
+          { x: 0, y: 2 },
+        ],
+      },
+    },
+    layer: "top",
+  })
+
+  expect(graphic.shape).toBe("brep")
+  expect(graphic.brep_shape.outer_ring.vertices.length).toBe(4)
+  expect(graphic.brep_shape.inner_rings).toEqual([])
+  expect((graphic as any).pcb_silkscreen_graphic_id).toBeDefined()
+  expect(any_circuit_element.parse(graphic)).toBeDefined()
+})
+
+test("pcb_silkscreen_graphic accepts optional image_asset", () => {
+  const graphic = pcb_silkscreen_graphic.parse({
+    type: "pcb_silkscreen_graphic",
+    pcb_component_id: "pcb_component_0",
+    shape: "brep",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 1, y: 1 },
+        ],
+      },
+    },
+    layer: "bottom",
+    image_asset: {
+      project_relative_path: "assets/logo.png",
+      url: "https://example.com/logo.png",
+      mimetype: "image/png",
+    },
+  })
+
+  expect(graphic.image_asset).toEqual({
+    project_relative_path: "assets/logo.png",
+    url: "https://example.com/logo.png",
+    mimetype: "image/png",
+  })
+  expect(any_circuit_element.parse(graphic)).toBeDefined()
+})


### PR DESCRIPTION
### Motivation
- Introduce a generic silkscreen graphic element that can either reference an image asset or be defined as a BRep, matching the copper pour BRep pattern for arbitrary shapes.

### Description
- Add a new schema/type `pcb_silkscreen_graphic` with `shape: "brep"`, `brep_shape: BRepShape`, `layer: VisibleLayer`, generated id and optional `image_asset` in `src/pcb/pcb_silkscreen_graphic.ts`.
- Export the new schema from `src/pcb/index.ts` and include `PcbSilkscreenGraphic` in the `PcbCircuitElement` union type.
- Include the element in the global parser union by adding `pcb.pcb_silkscreen_graphic` to `src/any_circuit_element.ts`.
- Add tests in `tests/pcb_silkscreen_graphic.test.ts` covering BRep parsing, default inner rings, optional `image_asset`, generated id presence, and `any_circuit_element` compatibility, and regenerate README docs to include the new element.

### Testing
- Ran `bun test tests/pcb_silkscreen_graphic.test.ts` and both tests passed (2 pass, 0 fail).
- Ran `bunx tsc --noEmit` which completed without type errors.
- Ran `bun run generate-docs` and `bun run format` to update documentation and formatting, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2085fa14c0832e979976a11cb11007)