### PR TITLE
feat: parse schematic text font sizes

### DIFF
--- a/src/schematic/schematic_text.ts
+++ b/src/schematic/schematic_text.ts
@@ -1,10 +1,10 @@
-import { z } from "zod"
-import { distance } from "../units"
-import { expectTypesMatch } from "src/utils/expect-types-match"
-import { ninePointAnchor } from "src/common/NinePointAnchor"
-import type { NinePointAnchor } from "src/common/NinePointAnchor"
 import type { FivePointAnchor } from "src/common/FivePointAnchor"
 import { fivePointAnchor } from "src/common/FivePointAnchor"
+import { ninePointAnchor } from "src/common/NinePointAnchor"
+import type { NinePointAnchor } from "src/common/NinePointAnchor"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+import { distance } from "../units"
 
 export interface SchematicText {
   type: "schematic_text"
@@ -29,7 +29,7 @@ export const schematic_text = z.object({
   schematic_symbol_id: z.string().optional(),
   schematic_text_id: z.string(),
   text: z.string(),
-  font_size: z.number().default(0.18),
+  font_size: distance.default("0.18mm"),
   position: z.object({
     x: distance,
     y: distance,

--- a/tests/schematic-text.test.ts
+++ b/tests/schematic-text.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { schematic_text } from "../src/schematic/schematic_text"
+
+test("schematic_text accepts font size distance strings", () => {
+  const text = schematic_text.parse({
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_1",
+    text: "R1",
+    font_size: "0.4mm",
+    position: { x: 0, y: 0 },
+  })
+
+  expect(text.font_size).toBeCloseTo(0.4)
+})
+
+test("schematic_text defaults font size", () => {
+  const text = schematic_text.parse({
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_1",
+    text: "R1",
+    position: { x: 0, y: 0 },
+  })
+
+  expect(text.font_size).toBeCloseTo(0.18)
+})


### PR DESCRIPTION
Fixes #11

## Summary
- Parse `schematic_text.font_size` with the shared distance parser.
- Preserve the existing `0.18mm` default output value.
- Add regression tests for distance string font sizes and the default.

## Verification
- `bun test tests\schematic-text.test.ts`
- `bun x biome check src\schematic\schematic_text.ts tests\schematic-text.test.ts`
- `bun run build`
- `git diff --check`