### PR TITLE
fix: declare format-si-unit and zod as runtime dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,8 +1,13 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "circuit-json",
+      "dependencies": {
+        "format-si-unit": "^0.0.7",
+        "zod": "3",
+      },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.30.1",
         "@biomejs/biome": "^1.9.4",
@@ -12,13 +17,11 @@
         "@typescript-eslint/parser": "^8.18.1",
         "@typescript-eslint/typescript-estree": "^8.18.1",
         "esbuild": "^0.20.2",
-        "format-si-unit": "^0.0.7",
         "prettier": "^3.4.2",
         "ts-expect": "^1.3.0",
         "ts-node": "^10.9.2",
         "tsup": "^8.3.0",
         "typescript": "^5.7.2",
-        "zod": "3",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -12,13 +12,11 @@
     "@typescript-eslint/parser": "^8.18.1",
     "@typescript-eslint/typescript-estree": "^8.18.1",
     "esbuild": "^0.20.2",
-    "format-si-unit": "^0.0.7",
     "prettier": "^3.4.2",
     "ts-expect": "^1.3.0",
     "ts-node": "^10.9.2",
     "tsup": "^8.3.0",
-    "typescript": "^5.7.2",
-    "zod": "3"
+    "typescript": "^5.7.2"
   },
   "description": "Definitions for the tscircuit intermediary JSON format",
   "files": [
@@ -33,5 +31,9 @@
     "generate-docs": "bun scripts/generate-readme-docs.ts && prettier --no-semi -w README.md",
     "lint:zod": "bun run scripts/zod-lint.ts",
     "check-snake-case": "bun run scripts/check-snake-case.ts"
+  },
+  "dependencies": {
+    "format-si-unit": "^0.0.7",
+    "zod": "3"
   }
 }


### PR DESCRIPTION
## Problem

A clean install of `circuit-json` alone cannot be imported:

    Cannot find package 'format-si-unit' from '.../circuit-json/dist/index.mjs'

The published `dist/index.mjs` externally imports exactly two packages — `format-si-unit` and `zod` — and `package.json` declares no dependencies at all (both are devDependencies only). Consumers survive only when another package hoists these; strict/isolated layouts (pnpm) break regardless.

Verified on `circuit-json@0.0.443`: clean dir, `bun add circuit-json`, `import * as cj from "circuit-json"` → the error above.

## Fix

Declare `format-si-unit` and `zod` in `dependencies` (moved out of devDependencies), lockfile synced.
