### PR TITLE
Add keep_upright to pcb_silkscreen_text

### DIFF
--- a/src/pcb/pcb_silkscreen_text.ts
+++ b/src/pcb/pcb_silkscreen_text.ts
@@ -36,6 +36,7 @@ export const pcb_silkscreen_text = z
     ccw_rotation: z.number().optional(),
     layer: layer_ref,
     is_mirrored: z.boolean().default(false).optional(),
+    keep_upright: z.boolean().default(false).optional(),
     anchor_position: point.default({ x: 0, y: 0 }),
     anchor_alignment: ninePointAnchor.default("center"),
   })
@@ -66,6 +67,12 @@ export interface PcbSilkscreenText {
   ccw_rotation?: number
   layer: LayerRef
   is_mirrored?: boolean
+  /**
+   * When true, a renderer should keep the text readable ("keep upright",
+   * like KiCad) by flipping any ccw_rotation that would render it upside-down,
+   * rather than drawing the raw rotation. Defaults to false.
+   */
+  keep_upright?: boolean
   anchor_position: Point
   anchor_alignment: NinePointAnchor
 }

--- a/tests/pcb_silkscreen_text.test.ts
+++ b/tests/pcb_silkscreen_text.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test"
+import { pcb_silkscreen_text } from "../src/pcb/pcb_silkscreen_text"
+
+test("pcb_silkscreen_text carries an optional keep_upright flag", () => {
+  const base = {
+    type: "pcb_silkscreen_text" as const,
+    pcb_component_id: "pcb_component_0",
+    text: "R1",
+    layer: "top" as const,
+    ccw_rotation: 180,
+  }
+
+  const withFlag = pcb_silkscreen_text.parse({ ...base, keep_upright: true })
+  expect(withFlag.keep_upright).toBe(true)
+
+  // Absent behaves like the sibling is_mirrored flag: undefined (falsy), so a
+  // renderer honors the raw ccw_rotation unless keep_upright is explicitly set.
+  const withoutFlag = pcb_silkscreen_text.parse(base)
+  expect(withoutFlag.keep_upright).toBeUndefined()
+})


### PR DESCRIPTION
Adds an optional `keep_upright?: boolean` to `pcb_silkscreen_text` (mirrors the existing `is_mirrored` flag — optional, off by default).

It lets a renderer keep reference-designator text readable when a component is rotated (flip any `ccw_rotation` that would render it upside-down, like KiCad's "keep upright"), while text without the flag still honors its raw `ccw_rotation`. This is the property @imrishabh18 asked for in tscircuit/circuit-to-canvas#251 — the renderer will gate its keep-upright behavior on this flag, and `@tscircuit/core` will set it on auto-generated refdes.

Added to both the zod schema and the interface (`expectTypesMatch` keeps them in sync) plus a small parse test.