### PR TITLE
Add PCB trace-too-long warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2699,7 +2699,8 @@ interface PcbTraceTooLongWarning {
   warning_type: "pcb_trace_too_long_warning"
   message: string
   pcb_trace_id: string
-  source_trace_id: string
+  source_net_id?: string
+  source_trace_id?: string
   actual_trace_length: Distance
   maximum_trace_length: Distance
   subcircuit_id?: string

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbTraceError](#pcbtraceerror)
     - [PcbTraceHint](#pcbtracehint)
     - [PcbTraceMissingError](#pcbtracemissingerror)
+    - [PcbTraceTooLongWarning](#pcbtracetoolongwarning)
     - [PcbTraceWarning](#pcbtracewarning)
     - [PcbVia](#pcbvia)
     - [PcbViaClearanceError](#pcbviaclearanceerror)
@@ -2680,6 +2681,27 @@ interface PcbTraceMissingError extends BaseCircuitJsonError {
   source_trace_id: string
   pcb_component_ids: string[]
   pcb_port_ids: string[]
+  subcircuit_id?: string
+}
+```
+
+### PcbTraceTooLongWarning
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_trace_too_long_warning.ts)
+
+Warning emitted when a PCB trace is longer than its maximum allowed length
+
+```typescript
+/** Warning emitted when a PCB trace is longer than its maximum allowed length */
+interface PcbTraceTooLongWarning {
+  type: "pcb_trace_too_long_warning"
+  pcb_trace_too_long_warning_id: string
+  warning_type: "pcb_trace_too_long_warning"
+  message: string
+  pcb_trace_id: string
+  source_trace_id: string
+  actual_trace_length: Distance
+  maximum_trace_length: Distance
   subcircuit_id?: string
 }
 ```

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -72,6 +72,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_text,
   pcb.pcb_trace,
   pcb.pcb_trace_warning,
+  pcb.pcb_trace_too_long_warning,
   pcb.pcb_via,
   pcb.pcb_smtpad,
   pcb.pcb_solder_paste,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -14,6 +14,7 @@ export * from "./pcb_solder_paste"
 export * from "./pcb_text"
 export * from "./pcb_trace"
 export * from "./pcb_trace_warning"
+export * from "./pcb_trace_too_long_warning"
 export * from "./pcb_trace_error"
 export * from "./pcb_trace_missing_error"
 export * from "./pcb_port_not_matched_error"
@@ -82,6 +83,7 @@ import type { PcbSolderPaste } from "./pcb_solder_paste"
 import type { PcbText } from "./pcb_text"
 import type { PcbTrace } from "./pcb_trace"
 import type { PcbTraceWarning } from "./pcb_trace_warning"
+import type { PcbTraceTooLongWarning } from "./pcb_trace_too_long_warning"
 import type { PcbTraceError } from "./pcb_trace_error"
 import type { PcbTraceMissingError } from "./pcb_trace_missing_error"
 import type { PcbPortNotMatchedError } from "./pcb_port_not_matched_error"
@@ -146,6 +148,7 @@ export type PcbCircuitElement =
   | PcbText
   | PcbTrace
   | PcbTraceWarning
+  | PcbTraceTooLongWarning
   | PcbTraceError
   | PcbTraceMissingError
   | PcbMissingFootprintError

--- a/src/pcb/pcb_trace_too_long_warning.ts
+++ b/src/pcb/pcb_trace_too_long_warning.ts
@@ -14,7 +14,8 @@ export const pcb_trace_too_long_warning = z
       .default("pcb_trace_too_long_warning"),
     message: z.string(),
     pcb_trace_id: z.string(),
-    source_trace_id: z.string(),
+    source_net_id: z.string().optional(),
+    source_trace_id: z.string().optional(),
     actual_trace_length: distance,
     maximum_trace_length: distance,
     subcircuit_id: z.string().optional(),
@@ -35,7 +36,8 @@ export interface PcbTraceTooLongWarning {
   warning_type: "pcb_trace_too_long_warning"
   message: string
   pcb_trace_id: string
-  source_trace_id: string
+  source_net_id?: string
+  source_trace_id?: string
   actual_trace_length: Distance
   maximum_trace_length: Distance
   subcircuit_id?: string

--- a/src/pcb/pcb_trace_too_long_warning.ts
+++ b/src/pcb/pcb_trace_too_long_warning.ts
@@ -1,0 +1,44 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { distance, type Distance } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_trace_too_long_warning = z
+  .object({
+    type: z.literal("pcb_trace_too_long_warning"),
+    pcb_trace_too_long_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_trace_too_long_warning",
+    ),
+    warning_type: z
+      .literal("pcb_trace_too_long_warning")
+      .default("pcb_trace_too_long_warning"),
+    message: z.string(),
+    pcb_trace_id: z.string(),
+    source_trace_id: z.string(),
+    actual_trace_length: distance,
+    maximum_trace_length: distance,
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Warning emitted when a PCB trace is longer than its maximum allowed length",
+  )
+
+export type PcbTraceTooLongWarningInput = z.input<
+  typeof pcb_trace_too_long_warning
+>
+type InferredPcbTraceTooLongWarning = z.infer<typeof pcb_trace_too_long_warning>
+
+/** Warning emitted when a PCB trace is longer than its maximum allowed length */
+export interface PcbTraceTooLongWarning {
+  type: "pcb_trace_too_long_warning"
+  pcb_trace_too_long_warning_id: string
+  warning_type: "pcb_trace_too_long_warning"
+  message: string
+  pcb_trace_id: string
+  source_trace_id: string
+  actual_trace_length: Distance
+  maximum_trace_length: Distance
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbTraceTooLongWarning, InferredPcbTraceTooLongWarning>(true)

--- a/tests/pcb_trace_too_long_warning.test.ts
+++ b/tests/pcb_trace_too_long_warning.test.ts
@@ -11,7 +11,7 @@ const warningInput = {
   maximum_trace_length: 10,
 }
 
-test("pcb_trace_too_long_warning parses", () => {
+test("pcb_trace_too_long_warning parses with a source trace", () => {
   const warning = pcb_trace_too_long_warning.parse(warningInput)
 
   expect(warning.pcb_trace_too_long_warning_id).toStartWith(
@@ -20,6 +20,17 @@ test("pcb_trace_too_long_warning parses", () => {
   expect(warning.warning_type).toBe("pcb_trace_too_long_warning")
   expect(warning.actual_trace_length).toBe(12.5)
   expect(warning.maximum_trace_length).toBe(10)
+})
+
+test("pcb_trace_too_long_warning parses with a source net", () => {
+  const { source_trace_id: _, ...warningWithoutSourceTrace } = warningInput
+  const warning = pcb_trace_too_long_warning.parse({
+    ...warningWithoutSourceTrace,
+    source_net_id: "source_net_0",
+  })
+
+  expect(warning.source_net_id).toBe("source_net_0")
+  expect(warning.source_trace_id).toBeUndefined()
 })
 
 test("any_circuit_element includes pcb_trace_too_long_warning", () => {

--- a/tests/pcb_trace_too_long_warning.test.ts
+++ b/tests/pcb_trace_too_long_warning.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { pcb_trace_too_long_warning } from "../src/pcb/pcb_trace_too_long_warning"
+
+const warningInput = {
+  type: "pcb_trace_too_long_warning" as const,
+  message: "PCB trace is 12.5mm long, exceeding the 10mm maximum",
+  pcb_trace_id: "pcb_trace_0",
+  source_trace_id: "source_trace_0",
+  actual_trace_length: 12.5,
+  maximum_trace_length: 10,
+}
+
+test("pcb_trace_too_long_warning parses", () => {
+  const warning = pcb_trace_too_long_warning.parse(warningInput)
+
+  expect(warning.pcb_trace_too_long_warning_id).toStartWith(
+    "pcb_trace_too_long_warning",
+  )
+  expect(warning.warning_type).toBe("pcb_trace_too_long_warning")
+  expect(warning.actual_trace_length).toBe(12.5)
+  expect(warning.maximum_trace_length).toBe(10)
+})
+
+test("any_circuit_element includes pcb_trace_too_long_warning", () => {
+  const parsed = any_circuit_element.parse(warningInput)
+
+  expect(parsed.type).toBe("pcb_trace_too_long_warning")
+})


### PR DESCRIPTION
## Summary

- add a `pcb_trace_too_long_warning` Circuit JSON element
- expose the measured `actual_trace_length` and configured `maximum_trace_length` alongside PCB/source trace references
- export the warning through the PCB and `any_circuit_element` unions
- document the new schema and cover direct and union parsing

## Validation

- `bun test` (258 pass)
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`