### PR TITLE
Add source filesystem MD5 hash metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@ interface SourceProjectMetadata {
   name?: string
   software_used_string?: string
   project_url?: string
+  source_filesystem_md5_hash?: string
   created_at?: string // ISO8601 timestamp
 }
 ```

--- a/src/source/source_project_metadata.ts
+++ b/src/source/source_project_metadata.ts
@@ -7,6 +7,7 @@ export interface SourceProjectMetadata {
   name?: string
   software_used_string?: string
   project_url?: string
+  source_filesystem_md5_hash?: string
   created_at?: string // ISO8601 timestamp
 }
 
@@ -15,6 +16,7 @@ export const source_project_metadata = z.object({
   name: z.string().optional(),
   software_used_string: z.string().optional(),
   project_url: z.string().optional(),
+  source_filesystem_md5_hash: z.string().optional(),
   created_at: timestamp.optional(),
 })
 

--- a/tests/source_project_metadata.test.ts
+++ b/tests/source_project_metadata.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { source_project_metadata } from "../src/source/source_project_metadata"
+
+test("source_project_metadata accepts an optional source filesystem MD5 hash", () => {
+  const metadataWithoutHash = source_project_metadata.parse({
+    type: "source_project_metadata",
+  })
+  expect(metadataWithoutHash.source_filesystem_md5_hash).toBeUndefined()
+
+  const metadataWithHash = source_project_metadata.parse({
+    type: "source_project_metadata",
+    source_filesystem_md5_hash: "d41d8cd98f00b204e9800998ecf8427e",
+  })
+  expect(metadataWithHash.source_filesystem_md5_hash).toBe(
+    "d41d8cd98f00b204e9800998ecf8427e",
+  )
+
+  expect(
+    source_project_metadata.safeParse({
+      type: "source_project_metadata",
+      source_filesystem_md5_hash: 123,
+    }).success,
+  ).toBeFalse()
+})


### PR DESCRIPTION
## Summary

- add `source_filesystem_md5_hash` as an optional string on `source_project_metadata`
- expose the field through both the TypeScript interface and Zod schema
- document and test the new metadata field

## Why

Consumers can record a hash of the source filesystem in Circuit JSON and compare it with the current source code. This allows them to determine whether existing Circuit JSON is still valid or needs to be rebuilt.

## Validation

- `bun test` (260 passing)
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`