### PR TITLE
Support 10-layer circuit JSON

### DIFF
--- a/src/common/PcbRenderLayer.ts
+++ b/src/common/PcbRenderLayer.ts
@@ -20,6 +20,8 @@ export type PcbRenderLayer =
   | "inner4_copper"
   | "inner5_copper"
   | "inner6_copper"
+  | "inner7_copper"
+  | "inner8_copper"
   | "edge_cuts"
   | "drill"
 
@@ -42,6 +44,8 @@ export const pcbRenderLayer = z.enum([
   "inner4_copper",
   "inner5_copper",
   "inner6_copper",
+  "inner7_copper",
+  "inner8_copper",
   "edge_cuts",
   "drill",
 ])

--- a/src/pcb/properties/layer_ref.ts
+++ b/src/pcb/properties/layer_ref.ts
@@ -10,6 +10,8 @@ export const all_layers = [
   "inner4",
   "inner5",
   "inner6",
+  "inner7",
+  "inner8",
 ] as const
 
 export const layer_string = z.enum(all_layers)

--- a/tests/pcb_trace_ten_layers.test.ts
+++ b/tests/pcb_trace_ten_layers.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { pcbRenderLayer } from "../src/common/PcbRenderLayer"
+import { pcb_trace } from "../src/pcb/pcb_trace"
+
+test("supports traces and render layers on ten-layer boards", () => {
+  const trace = pcb_trace.parse({
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_ten_layers",
+    route: [
+      {
+        route_type: "wire",
+        x: 0,
+        y: 0,
+        width: 0.1,
+        layer: "inner7",
+      },
+      {
+        route_type: "via",
+        x: 1,
+        y: 0,
+        from_layer: "inner7",
+        to_layer: "inner8",
+      },
+      {
+        route_type: "wire",
+        x: 1,
+        y: 1,
+        width: 0.1,
+        layer: "inner8",
+      },
+    ],
+  })
+
+  expect(trace.route.map((routePoint) => routePoint.route_type)).toEqual([
+    "wire",
+    "via",
+    "wire",
+  ])
+  expect(pcbRenderLayer.parse("inner7_copper")).toBe("inner7_copper")
+  expect(pcbRenderLayer.parse("inner8_copper")).toBe("inner8_copper")
+})


### PR DESCRIPTION
## Summary

- add inner7 and inner8 to the copper layer schema
- add matching inner7_copper and inner8_copper render layers
- validate ten-layer traces, vias, and render-layer names

## Testing

- bun test tests/pcb_trace_ten_layers.test.ts
- bun run build

Companion to tscircuit/tscircuit-autorouter#1648.