### PR TITLE
Add schematic component unit metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2892,6 +2892,9 @@ interface SchematicComponent {
   schematic_component_id: string
   schematic_sheet_id?: string
   schematic_symbol_id?: string
+  /** Identifies an independently placeable schematic unit of a shared source
+   * component, for example "A" in a dual op-amp shown as U1A. */
+  unit?: string
   pin_spacing?: number
   pin_styles?: Record<
     string,

--- a/src/schematic/schematic_component.ts
+++ b/src/schematic/schematic_component.ts
@@ -42,6 +42,11 @@ export interface SchematicComponent {
   schematic_component_id: string
   schematic_sheet_id?: string
   schematic_symbol_id?: string
+  /**
+   * Identifies an independently placeable schematic unit of a shared source
+   * component, for example "A" in a dual op-amp shown as U1A.
+   */
+  unit?: string
   pin_spacing?: number
   pin_styles?: Record<
     string,
@@ -125,6 +130,7 @@ export const schematic_component = z.object({
   schematic_component_id: z.string(),
   schematic_sheet_id: z.string().optional(),
   schematic_symbol_id: z.string().optional(),
+  unit: z.string().optional(),
   pin_spacing: length.optional(),
   pin_styles: schematic_pin_styles.optional(),
   box_width: length.optional(),

--- a/tests/schematic_component.test.ts
+++ b/tests/schematic_component.test.ts
@@ -31,3 +31,14 @@ test("schematic_component allows schematic_symbol_id", () => {
 
   expect(component.schematic_symbol_id).toBe("schematic_symbol_1")
 })
+
+test("schematic_component allows a shared-component unit", () => {
+  const component = schematic_component.parse({
+    ...baseComponent,
+    source_component_id: "source_component_1",
+    unit: "A",
+  })
+
+  expect(component.source_component_id).toBe("source_component_1")
+  expect(component.unit).toBe("A")
+})


### PR DESCRIPTION
## Summary

- add optional `unit` metadata to `SchematicComponent` and its Zod schema
- document the field in the generated Circuit JSON reference
- add parser coverage for a schematic unit sharing a source component

## Why

A single physical/source component can have multiple independently placeable schematic representations, such as `Q203A` and `Q203B` for a dual MOSFET. The schematic component needs explicit unit metadata while retaining the shared `source_component_id`.

The field is optional, so existing Circuit JSON remains compatible.

## Validation

- `bun test` — 261 passing
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
