### PR TITLE
Declare format-si-unit as a peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,9 @@
         "typescript": "^5.7.2",
         "zod": "3",
       },
+      "peerDependencies": {
+        "format-si-unit": "*",
+      },
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "typescript": "^5.7.2",
     "zod": "3"
   },
+  "peerDependencies": {
+    "format-si-unit": "*"
+  },
   "description": "Definitions for the tscircuit intermediary JSON format",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- declare format-si-unit as a runtime peer with a wildcard version
- retain format-si-unit ^0.0.7 as a development dependency for local builds and tests
- update the Bun workspace lock metadata

This fixes clean consumers of circuit-json 0.0.434 and newer failing to resolve the runtime format-si-unit import. It unblocks tscircuit/props#739.

## Testing

- bun test: 261 passed
- bunx tsc --noEmit
- bun run build
- bun run lint:zod
- bun run check-snake-case
- bunx biome format .
- packed-package install in a clean Bun 1.3.14 container; Bun automatically installed format-si-unit from the peer declaration and the Circuit JSON unit parser loaded successfully