### PR TITLE
Add internal circuit schematic port flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3141,6 +3141,8 @@ interface SchematicPort {
   display_pin_label?: string
   subcircuit_id?: string
   is_connected?: boolean
+  is_internal_circuit_port?: boolean
+  is_overlapping_internal_circuit_port?: boolean
   has_input_arrow?: boolean
   has_output_arrow?: boolean
   is_drawn_with_inversion_circle?: boolean

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -17,6 +17,8 @@ export interface SchematicPort {
   display_pin_label?: string
   subcircuit_id?: string
   is_connected?: boolean
+  is_internal_circuit_port?: boolean
+  is_overlapping_internal_circuit_port?: boolean
   has_input_arrow?: boolean
   has_output_arrow?: boolean
   is_drawn_with_inversion_circle?: boolean
@@ -38,6 +40,8 @@ export const schematic_port = z
     display_pin_label: z.string().optional(),
     subcircuit_id: z.string().optional(),
     is_connected: z.boolean().optional(),
+    is_internal_circuit_port: z.boolean().optional(),
+    is_overlapping_internal_circuit_port: z.boolean().optional(),
     has_input_arrow: z.boolean().optional(),
     has_output_arrow: z.boolean().optional(),
     is_drawn_with_inversion_circle: z.boolean().optional(),

--- a/tests/schematic-port.test.ts
+++ b/tests/schematic-port.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { schematic_port } from "src/schematic/schematic_port"
+
+const baseSchematicPort = {
+  type: "schematic_port" as const,
+  source_port_id: "source_port_0",
+  center: { x: 0, y: 0 },
+}
+
+test("schematic ports can identify internal circuit port roles", () => {
+  const internalCircuitPort = schematic_port.parse({
+    ...baseSchematicPort,
+    schematic_port_id: "schematic_port_internal",
+    is_internal_circuit_port: true,
+  })
+  const overlappingPort = schematic_port.parse({
+    ...baseSchematicPort,
+    schematic_port_id: "schematic_port_overlapping",
+    is_overlapping_internal_circuit_port: true,
+  })
+
+  expect(internalCircuitPort.is_internal_circuit_port).toBe(true)
+  expect(overlappingPort.is_overlapping_internal_circuit_port).toBe(true)
+})


### PR DESCRIPTION
## Summary

- add optional `is_internal_circuit_port` and `is_overlapping_internal_circuit_port` fields to `SchematicPort`
- expose both fields through the TypeScript interface and Zod schema
- document the fields and cover both roles with a focused parser test

## Why

Internal-circuit schematics can contain an internal component port and a package-facing port that intentionally share a schematic location. These explicit roles allow Circuit JSON consumers to distinguish that representation without inferring it from geometry. Because both fields are optional, existing Circuit JSON remains valid.

## Validation

- `bun test` — 262 tests passed
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`