### PR TITLE
Add via-in-pad autorouter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1879,7 +1879,7 @@ interface PcbGroup {
   description?: string
   layout_mode?: string
   autorouter_configuration?: {
-    trace_clearance?: Length
+    trace_clearance: Length
     allow_via_in_pad?: boolean
   }
   autorouter_used_string?: string

--- a/README.md
+++ b/README.md
@@ -1879,7 +1879,8 @@ interface PcbGroup {
   description?: string
   layout_mode?: string
   autorouter_configuration?: {
-    trace_clearance: Length
+    trace_clearance?: Length
+    allow_via_in_pad?: boolean
   }
   autorouter_used_string?: string
 }

--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -46,7 +46,7 @@ export const pcb_group = z
     layout_mode: z.string().optional(),
     autorouter_configuration: z
       .object({
-        trace_clearance: length.optional(),
+        trace_clearance: length,
         allow_via_in_pad: z
           .boolean()
           .optional()
@@ -88,7 +88,7 @@ export interface PcbGroup {
   description?: string
   layout_mode?: string
   autorouter_configuration?: {
-    trace_clearance?: Length
+    trace_clearance: Length
     allow_via_in_pad?: boolean
   }
   autorouter_used_string?: string

--- a/src/pcb/pcb_group.ts
+++ b/src/pcb/pcb_group.ts
@@ -46,7 +46,13 @@ export const pcb_group = z
     layout_mode: z.string().optional(),
     autorouter_configuration: z
       .object({
-        trace_clearance: length,
+        trace_clearance: length.optional(),
+        allow_via_in_pad: z
+          .boolean()
+          .optional()
+          .describe(
+            "Allows the autorouter to place vias inside connected pads. Omitted or false keeps via-in-pad routing disabled.",
+          ),
       })
       .optional(),
     autorouter_used_string: z.string().optional(),
@@ -82,7 +88,8 @@ export interface PcbGroup {
   description?: string
   layout_mode?: string
   autorouter_configuration?: {
-    trace_clearance: Length
+    trace_clearance?: Length
+    allow_via_in_pad?: boolean
   }
   autorouter_used_string?: string
 }

--- a/tests/pcb_group_autorouter.test.ts
+++ b/tests/pcb_group_autorouter.test.ts
@@ -16,7 +16,7 @@ test("pcb_group.autorouter_configuration.trace_clearance parses", () => {
   expect(group.autorouter_configuration?.trace_clearance).toBe(0.2)
 })
 
-test("pcb_group.autorouter_configuration.allow_via_in_pad parses independently", () => {
+test("pcb_group.autorouter_configuration.allow_via_in_pad parses", () => {
   const group = pcb_group.parse({
     type: "pcb_group",
     source_group_id: "g1",
@@ -24,11 +24,14 @@ test("pcb_group.autorouter_configuration.allow_via_in_pad parses independently",
     width: 10,
     height: 10,
     pcb_component_ids: [],
-    autorouter_configuration: { allow_via_in_pad: true },
+    autorouter_configuration: {
+      trace_clearance: 0.2,
+      allow_via_in_pad: true,
+    },
   })
 
   expect(group.autorouter_configuration?.allow_via_in_pad).toBe(true)
-  expect(group.autorouter_configuration?.trace_clearance).toBeUndefined()
+  expect(group.autorouter_configuration?.trace_clearance).toBe(0.2)
 })
 
 test("pcb_group.autorouter_used_string is optional", () => {

--- a/tests/pcb_group_autorouter.test.ts
+++ b/tests/pcb_group_autorouter.test.ts
@@ -16,6 +16,21 @@ test("pcb_group.autorouter_configuration.trace_clearance parses", () => {
   expect(group.autorouter_configuration?.trace_clearance).toBe(0.2)
 })
 
+test("pcb_group.autorouter_configuration.allow_via_in_pad parses independently", () => {
+  const group = pcb_group.parse({
+    type: "pcb_group",
+    source_group_id: "g1",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+    pcb_component_ids: [],
+    autorouter_configuration: { allow_via_in_pad: true },
+  })
+
+  expect(group.autorouter_configuration?.allow_via_in_pad).toBe(true)
+  expect(group.autorouter_configuration?.trace_clearance).toBeUndefined()
+})
+
 test("pcb_group.autorouter_used_string is optional", () => {
   const group = pcb_group.parse({
     type: "pcb_group",


### PR DESCRIPTION
## Summary

- add optional `allow_via_in_pad` to `pcb_group.autorouter_configuration`
- add focused schema coverage for the new flag
- regenerate the Circuit JSON README types

## Why

Via-in-pad routing can add fabrication cost, so downstream autorouters need an explicit opt-in that survives Circuit JSON serialization. Omitted or `false` remains disabled; only an explicit `true` will enable the downstream behavior.

This is the Circuit JSON companion to tscircuit/props#759.

## Compatibility

The new field is optional and backward-compatible.

## Validation

- `bun test` — 271 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- changed-file Biome formatting
- `bun run generate-docs`
