### PR TITLE
feat: add rotated_pill shape variant to pcb_solder_paste

### DIFF
--- a/src/pcb/pcb_solder_paste.ts
+++ b/src/pcb/pcb_solder_paste.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import { distance, type Distance } from "src/units"
+import { distance, type Distance, rotation, type Rotation } from "src/units"
 import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
@@ -63,6 +63,23 @@ const pcb_solder_paste_rotated_rect = z.object({
   pcb_smtpad_id: z.string().optional(),
 })
 
+const pcb_solder_paste_rotated_pill = z.object({
+  type: z.literal("pcb_solder_paste"),
+  shape: z.literal("rotated_pill"),
+  pcb_solder_paste_id: getZodPrefixedIdWithDefault("pcb_solder_paste"),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  x: distance,
+  y: distance,
+  width: z.number(),
+  height: z.number(),
+  radius: z.number(),
+  ccw_rotation: rotation,
+  layer: layer_ref,
+  pcb_component_id: z.string().optional(),
+  pcb_smtpad_id: z.string().optional(),
+})
+
 const pcb_solder_paste_oval = z.object({
   type: z.literal("pcb_solder_paste"),
   shape: z.literal("oval"),
@@ -84,6 +101,7 @@ export const pcb_solder_paste = z
     pcb_solder_paste_rect,
     pcb_solder_paste_pill,
     pcb_solder_paste_rotated_rect,
+    pcb_solder_paste_rotated_pill,
     pcb_solder_paste_oval,
   ])
   .describe("Defines solderpaste on the PCB")
@@ -94,6 +112,9 @@ type InferredPcbSolderPasteRect = z.infer<typeof pcb_solder_paste_rect>
 type InferredPcbSolderPastePill = z.infer<typeof pcb_solder_paste_pill>
 type InferredPcbSolderPasteRotatedRect = z.infer<
   typeof pcb_solder_paste_rotated_rect
+>
+type InferredPcbSolderPasteRotatedPill = z.infer<
+  typeof pcb_solder_paste_rotated_pill
 >
 type InferredPcbSolderPasteOval = z.infer<typeof pcb_solder_paste_oval>
 
@@ -170,6 +191,25 @@ export interface PcbSolderPasteRotatedRect {
 /**
  * Defines solderpaste on the PCB
  */
+export interface PcbSolderPasteRotatedPill {
+  type: "pcb_solder_paste"
+  shape: "rotated_pill"
+  pcb_solder_paste_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  x: Distance
+  y: Distance
+  width: number
+  height: number
+  radius: number
+  ccw_rotation: Rotation
+  layer: LayerRef
+  pcb_component_id?: string
+  pcb_smtpad_id?: string
+}
+/**
+ * Defines solderpaste on the PCB
+ */
 export interface PcbSolderPasteOval {
   type: "pcb_solder_paste"
   shape: "oval"
@@ -190,12 +230,16 @@ export type PcbSolderPaste =
   | PcbSolderPasteRect
   | PcbSolderPastePill
   | PcbSolderPasteRotatedRect
+  | PcbSolderPasteRotatedPill
   | PcbSolderPasteOval
 
 expectTypesMatch<PcbSolderPasteCircle, InferredPcbSolderPasteCircle>(true)
 expectTypesMatch<PcbSolderPasteRect, InferredPcbSolderPasteRect>(true)
 expectTypesMatch<PcbSolderPastePill, InferredPcbSolderPastePill>(true)
 expectTypesMatch<PcbSolderPasteRotatedRect, InferredPcbSolderPasteRotatedRect>(
+  true,
+)
+expectTypesMatch<PcbSolderPasteRotatedPill, InferredPcbSolderPasteRotatedPill>(
   true,
 )
 expectTypesMatch<PcbSolderPasteOval, InferredPcbSolderPasteOval>(true)

--- a/tests/pcb_solder_paste_rotated_pill.test.ts
+++ b/tests/pcb_solder_paste_rotated_pill.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test"
+import { pcb_solder_paste } from "src/pcb/pcb_solder_paste"
+
+test("pcb_solder_paste parses the rotated_pill shape", () => {
+  const paste = pcb_solder_paste.parse({
+    type: "pcb_solder_paste",
+    shape: "rotated_pill",
+    x: 1,
+    y: 2,
+    width: 1.2,
+    height: 0.6,
+    radius: 0.3,
+    ccw_rotation: 45,
+    layer: "top",
+    pcb_component_id: "pcb_component_1",
+    pcb_smtpad_id: "pcb_smtpad_1",
+  })
+
+  if (paste.shape !== "rotated_pill") throw new Error("Expected rotated_pill")
+  expect(paste.pcb_solder_paste_id.startsWith("pcb_solder_paste")).toBe(true)
+  expect(paste.width).toBe(1.2)
+  expect(paste.height).toBe(0.6)
+  expect(paste.radius).toBe(0.3)
+  expect(paste.ccw_rotation).toBe(45)
+  expect(paste.layer).toBe("top")
+})


### PR DESCRIPTION
## What

Adds a `rotated_pill` shape variant to `pcb_solder_paste`, mirroring the existing `pcb_smtpad` `rotated_pill` variant (`width`, `height`, `radius`, `ccw_rotation`).

## Why

`pcb_smtpad` has had a `rotated_pill` variant for a while, but `pcb_solder_paste` only supports circle/rect/pill/rotated_rect/oval — the pill paste variant has no rotation field, so a rotated pill pad cannot get a same-shape paste aperture. This came up in tscircuit/core#2930 (review: the rotated-rect fallback there is a hack); with this variant core can emit a paste aperture that matches the pad outline exactly.

## Tests

- `tests/pcb_solder_paste_rotated_pill.test.ts`: the new variant parses (including `ccw_rotation` and `radius`) and gets a `pcb_solder_paste`-prefixed id.
- Full suite: 271 pass, tsc/zod-lint/check-snake-case clean.
