### PR TITLE
Add resolved component exclusions to PCB keepouts

### DIFF
--- a/src/pcb/pcb_keepout.ts
+++ b/src/pcb/pcb_keepout.ts
@@ -1,7 +1,7 @@
-import { z } from "zod"
-import { point, type Point } from "../common"
-import { distance } from "../units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+import { type Point, point } from "../common"
+import { distance } from "../units"
 
 export const pcb_keepout = z
   .object({
@@ -15,6 +15,7 @@ export const pcb_keepout = z
     pcb_keepout_id: z.string(),
     layers: z.array(z.string()), // Specify layers where the keepout applies
     description: z.string().optional(), // Optional description of the keepout
+    excluded_pcb_component_ids: z.array(z.string()).optional(),
   })
   .or(
     z.object({
@@ -27,6 +28,7 @@ export const pcb_keepout = z
       pcb_keepout_id: z.string(),
       layers: z.array(z.string()), // Specify layers where the keepout applies
       description: z.string().optional(), // Optional description of the keepout
+      excluded_pcb_component_ids: z.array(z.string()).optional(),
     }),
   )
 
@@ -44,6 +46,8 @@ export interface PCBKeepoutRect {
   pcb_keepout_id: string
   layers: string[]
   description?: string
+  /** PCB components excluded from keepout DRC enforcement. */
+  excluded_pcb_component_ids?: string[]
 }
 
 export interface PCBKeepoutCircle {
@@ -56,6 +60,8 @@ export interface PCBKeepoutCircle {
   pcb_keepout_id: string
   layers: string[]
   description?: string
+  /** PCB components excluded from keepout DRC enforcement. */
+  excluded_pcb_component_ids?: string[]
 }
 
 export type PCBKeepout = PCBKeepoutRect | PCBKeepoutCircle

--- a/tests/pcb-keepout.test.ts
+++ b/tests/pcb-keepout.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { type PCBKeepout, pcb_keepout } from "../src/pcb/pcb_keepout"
+
+test.each([
+  {
+    type: "pcb_keepout" as const,
+    shape: "rect" as const,
+    pcb_keepout_id: "keepout_rect",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 5,
+    layers: ["top"],
+    excluded_pcb_component_ids: ["pcb_component_ant1"],
+  },
+  {
+    type: "pcb_keepout" as const,
+    shape: "circle" as const,
+    pcb_keepout_id: "keepout_circle",
+    center: { x: 0, y: 0 },
+    radius: 5,
+    layers: ["top"],
+    excluded_pcb_component_ids: ["pcb_component_ant1"],
+  },
+])("$shape keepout retains excluded PCB component IDs", (input) => {
+  const keepout = pcb_keepout.parse(input)
+  const circuitElement = any_circuit_element.parse(input) as PCBKeepout
+
+  expect(keepout.excluded_pcb_component_ids).toEqual(["pcb_component_ant1"])
+  expect(circuitElement.excluded_pcb_component_ids).toEqual([
+    "pcb_component_ant1",
+  ])
+})


### PR DESCRIPTION
## Summary

- add optional `excluded_pcb_component_ids` to rectangular and circular `pcb_keepout` elements
- expose the field through the corresponding TypeScript interfaces
- verify both the direct keepout schema and `any_circuit_element` preserve the IDs

## Why

Keepout exemptions originate as TSX selectors, but downstream DRC operates on Circuit JSON without access to core's selector engine. Persisting resolved PCB component IDs gives `@tscircuit/checks` and other Circuit JSON consumers a portable, stable representation of the exemption while leaving autorouting behavior unchanged.

## Follow-ups

- tscircuit/checks#176 consumes this field for DRC enforcement
- tscircuit/core#2958 resolves TSX selectors and serializes the IDs

## Validation

- `bun test` — 273 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- Biome check on changed files