### PR TITLE
Add source trace IDs to PCB vias

### DIFF
--- a/src/pcb/pcb_via.ts
+++ b/src/pcb/pcb_via.ts
@@ -21,6 +21,7 @@ export const pcb_via = z
     to_layer: layer_ref.optional(),
     layers: z.array(layer_ref),
     pcb_trace_id: z.string().optional(),
+    source_trace_id: z.string().optional(),
     net_is_assignable: z.boolean().optional(),
     net_assigned: z.boolean().optional(),
     is_tented: z.boolean().optional(),
@@ -49,6 +50,7 @@ export interface PcbVia {
   to_layer?: LayerRef
   layers: LayerRef[]
   pcb_trace_id?: string
+  source_trace_id?: string
   net_is_assignable?: boolean
   net_assigned?: boolean
   is_tented?: boolean

--- a/tests/pcb_via.test.ts
+++ b/tests/pcb_via.test.ts
@@ -2,26 +2,30 @@ import { expect, test } from "bun:test"
 import { pcb_via, type PcbVia } from "../src/pcb/pcb_via"
 import { any_circuit_element } from "../src/any_circuit_element"
 
-test("pcb_via allows subcircuit_connectivity_map_key", () => {
+test("pcb_via allows source and subcircuit connectivity references", () => {
   const via = pcb_via.parse({
     type: "pcb_via",
     x: 1,
     y: 2,
     layers: ["top", "bottom"],
     subcircuit_connectivity_map_key: "foo",
+    source_trace_id: "source_trace_1",
   })
 
   expect(via.subcircuit_connectivity_map_key).toBe("foo")
+  expect(via.source_trace_id).toBe("source_trace_1")
 })
 
-test("any_circuit_element includes pcb_via with subcircuit_connectivity_map_key", () => {
+test("any_circuit_element includes pcb_via connectivity references", () => {
   const via = any_circuit_element.parse({
     type: "pcb_via",
     x: 1,
     y: 2,
     layers: ["top", "bottom"],
     subcircuit_connectivity_map_key: "bar",
+    source_trace_id: "source_trace_2",
   }) as PcbVia
 
   expect(via.subcircuit_connectivity_map_key).toBe("bar")
+  expect(via.source_trace_id).toBe("source_trace_2")
 })


### PR DESCRIPTION
## Summary

- add optional `source_trace_id` to the `pcb_via` schema and TypeScript interface
- cover direct schema parsing and `any_circuit_element` parsing
- give manually placed vias a semantic source-connectivity reference without overloading `pcb_trace_id`

## Testing

- `bun test` (273 passing)
- `bun run build`
- `git diff --check`

Part of tscircuit/tscircuit#4205. Unblocks tscircuit/core#2965.
