### PR TITLE
Make manual via source net IDs optional and non-empty

### DIFF
--- a/src/source/source_manually_placed_via.ts
+++ b/src/source/source_manually_placed_via.ts
@@ -8,7 +8,7 @@ export const source_manually_placed_via = z
     type: z.literal("source_manually_placed_via"),
     source_manually_placed_via_id: z.string(),
     source_group_id: z.string(),
-    source_net_id: z.string(),
+    source_net_id: z.string().min(1).optional(),
     subcircuit_id: z.string().optional(),
     source_trace_id: z.string().optional(),
   })
@@ -28,7 +28,7 @@ export interface SourceManuallyPlacedVia {
   type: "source_manually_placed_via"
   source_manually_placed_via_id: string
   source_group_id: string
-  source_net_id: string
+  source_net_id?: string
   subcircuit_id?: string
   source_trace_id?: string
 }

--- a/tests/source_manually_placed_via.test.ts
+++ b/tests/source_manually_placed_via.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test"
 import { source_manually_placed_via } from "../src/source/source_manually_placed_via"
 import { any_circuit_element } from "../src/any_circuit_element"
 
-test("source_manually_placed_via parses", () => {
+test("source_manually_placed_via parses an assigned source net", () => {
   const via = source_manually_placed_via.parse({
     type: "source_manually_placed_via",
     source_manually_placed_via_id: "via1",
@@ -15,12 +15,32 @@ test("source_manually_placed_via parses", () => {
   expect(via.source_net_id).toBe("net1")
 })
 
-test("any_circuit_element includes source_manually_placed_via", () => {
+test("source_manually_placed_via omits an unassigned source net", () => {
+  const via = source_manually_placed_via.parse({
+    type: "source_manually_placed_via",
+    source_manually_placed_via_id: "via1",
+    source_group_id: "group1",
+  })
+
+  expect(via.source_net_id).toBeUndefined()
+})
+
+test("source_manually_placed_via rejects an empty source net id", () => {
+  const result = source_manually_placed_via.safeParse({
+    type: "source_manually_placed_via",
+    source_manually_placed_via_id: "via1",
+    source_group_id: "group1",
+    source_net_id: "",
+  })
+
+  expect(result.success).toBe(false)
+})
+
+test("any_circuit_element includes a manually placed via without a source net", () => {
   const parsed = any_circuit_element.parse({
     type: "source_manually_placed_via",
     source_manually_placed_via_id: "via1",
     source_group_id: "group1",
-    source_net_id: "net1",
     x: "0mm",
     y: "0mm",
     layers: ["top", "bottom"],


### PR DESCRIPTION
## Summary

- make `source_manually_placed_via.source_net_id` optional
- reject an explicitly empty `source_net_id`
- cover assigned, omitted, and invalid empty-string cases through the direct schema and `any_circuit_element`

## Root cause

The field was required even before a manually placed via had been assigned to a source net. Producers therefore had to serialize `source_net_id: ""`, using an empty string as a sentinel instead of omitting an unavailable relationship.

With this change, omission represents an unassigned net and any present ID must be non-empty. A follow-up to tscircuit/core#2965 can stop writing empty source-net IDs once this schema version releases.

## Testing

- `bun test` — 275 passing
- `bun run build`
- `git diff --check`

Part of tscircuit/tscircuit#4205.
