### PR TITLE
Add source net IDs to PCB vias

### DIFF
--- a/src/pcb/pcb_via.ts
+++ b/src/pcb/pcb_via.ts
@@ -22,6 +22,7 @@ export const pcb_via = z
     layers: z.array(layer_ref),
     pcb_trace_id: z.string().optional(),
     source_trace_id: z.string().optional(),
+    source_net_id: z.string().min(1).optional(),
     net_is_assignable: z.boolean().optional(),
     net_assigned: z.boolean().optional(),
     is_tented: z.boolean().optional(),
@@ -51,6 +52,7 @@ export interface PcbVia {
   layers: LayerRef[]
   pcb_trace_id?: string
   source_trace_id?: string
+  source_net_id?: string
   net_is_assignable?: boolean
   net_assigned?: boolean
   is_tented?: boolean

--- a/tests/pcb_via.test.ts
+++ b/tests/pcb_via.test.ts
@@ -10,10 +10,12 @@ test("pcb_via allows source and subcircuit connectivity references", () => {
     layers: ["top", "bottom"],
     subcircuit_connectivity_map_key: "foo",
     source_trace_id: "source_trace_1",
+    source_net_id: "source_net_1",
   })
 
   expect(via.subcircuit_connectivity_map_key).toBe("foo")
   expect(via.source_trace_id).toBe("source_trace_1")
+  expect(via.source_net_id).toBe("source_net_1")
 })
 
 test("any_circuit_element includes pcb_via connectivity references", () => {
@@ -24,8 +26,22 @@ test("any_circuit_element includes pcb_via connectivity references", () => {
     layers: ["top", "bottom"],
     subcircuit_connectivity_map_key: "bar",
     source_trace_id: "source_trace_2",
+    source_net_id: "source_net_2",
   }) as PcbVia
 
   expect(via.subcircuit_connectivity_map_key).toBe("bar")
   expect(via.source_trace_id).toBe("source_trace_2")
+  expect(via.source_net_id).toBe("source_net_2")
+})
+
+test("pcb_via rejects an empty source net id", () => {
+  expect(() =>
+    pcb_via.parse({
+      type: "pcb_via",
+      x: 1,
+      y: 2,
+      layers: ["top", "bottom"],
+      source_net_id: "",
+    }),
+  ).toThrow()
 })


### PR DESCRIPTION
## Summary

- add optional non-empty source_net_id to pcb_via
- expose it on the PcbVia interface
- verify direct parsing through pcb_via and any_circuit_element
- reject empty source net IDs

This gives net-assigned PCB vias a direct, correctly typed logical-net relationship without overloading pcb_trace_id or creating a synthetic source trace.

Part of tscircuit/tscircuit#4205.

## Validation

- bun test tests/pcb_via.test.ts
- bun run build
- bun run lint:zod
- bun run check-snake-case
- git diff --check
