### PR TITLE
Add via-in-pad allowance to pcb_board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,7 @@ interface PcbBoard extends ManufacturingDrcProperties {
   is_subcircuit?: boolean
   subcircuit_id?: string
   is_mounted_to_carrier_board?: boolean
+  is_via_in_pad_allowed?: boolean
   width?: Length
   height?: Length
   display_offset_x?: string

--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -672,6 +672,7 @@ export interface PcbBreakoutPoint {
 export interface PcbBoard {
   type: "pcb_board"
   pcb_board_id: string
+  is_via_in_pad_allowed?: boolean
   width: Length
   height: Length
   thickness: Length

--- a/src/pcb/pcb_board.ts
+++ b/src/pcb/pcb_board.ts
@@ -22,6 +22,7 @@ export const pcb_board = z
     is_subcircuit: z.boolean().optional(),
     subcircuit_id: z.string().optional(),
     is_mounted_to_carrier_board: z.boolean().optional(),
+    is_via_in_pad_allowed: z.boolean().optional(),
     width: length.optional(),
     height: length.optional(),
     center: point,
@@ -62,6 +63,7 @@ export interface PcbBoard extends ManufacturingDrcProperties {
   is_subcircuit?: boolean
   subcircuit_id?: string
   is_mounted_to_carrier_board?: boolean
+  is_via_in_pad_allowed?: boolean
   width?: Length
   height?: Length
   display_offset_x?: string

--- a/tests/pcb_board.test.ts
+++ b/tests/pcb_board.test.ts
@@ -92,6 +92,18 @@ test("pcb_board shape property is optional", () => {
   expect(board.shape).toBeUndefined()
 })
 
+test("pcb_board allows vias in pads to be explicitly allowed", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    width: "10mm",
+    height: "20mm",
+    center: { x: 0, y: 0 },
+    is_via_in_pad_allowed: true,
+  })
+
+  expect(board.is_via_in_pad_allowed).toBe(true)
+})
+
 test("pcb_board with solder mask and silkscreen colors", () => {
   const board = pcb_board.parse({
     type: "pcb_board",


### PR DESCRIPTION
## Summary

- add an optional `is_via_in_pad_allowed` boolean to the `pcb_board` Zod schema
- expose the field on the `PcbBoard` TypeScript interface
- document the field and cover parser behavior with a focused test

## Why

A follow-up check in `tscircuit/checks` will flag vias placed inside pads. Boards that intentionally use via-in-pad need an explicit circuit-json opt-out so that check can distinguish allowed designs from violations.

The property is optional, so existing circuit JSON remains valid. Consumers can treat only `true` as allowing via-in-pad.

## Validation

- `bun test tests/pcb_board.test.ts`
- `bun test` (279 passing)
- `bunx tsc --noEmit`
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`
- `git diff --check`