### PR TITLE
Add solder paste margin to SMT pads

### DIFF
--- a/src/pcb/pcb_smtpad.ts
+++ b/src/pcb/pcb_smtpad.ts
@@ -19,6 +19,7 @@ const pcb_smtpad_circle = z.object({
   pcb_port_id: z.string().optional(),
   is_covered_with_solder_mask: z.boolean().optional(),
   soldermask_margin: z.number().optional(),
+  solderpaste_margin: z.number().optional(),
 })
 
 const pcb_smtpad_rect = z.object({
@@ -43,6 +44,7 @@ const pcb_smtpad_rect = z.object({
   soldermask_margin_top: z.number().optional(),
   soldermask_margin_right: z.number().optional(),
   soldermask_margin_bottom: z.number().optional(),
+  solderpaste_margin: z.number().optional(),
 })
 
 const pcb_smtpad_rotated_rect = z.object({
@@ -68,6 +70,7 @@ const pcb_smtpad_rotated_rect = z.object({
   soldermask_margin_top: z.number().optional(),
   soldermask_margin_right: z.number().optional(),
   soldermask_margin_bottom: z.number().optional(),
+  solderpaste_margin: z.number().optional(),
 })
 
 export const pcb_smtpad_pill = z.object({
@@ -87,6 +90,7 @@ export const pcb_smtpad_pill = z.object({
   pcb_port_id: z.string().optional(),
   is_covered_with_solder_mask: z.boolean().optional(),
   soldermask_margin: z.number().optional(),
+  solderpaste_margin: z.number().optional(),
 })
 const pcb_smtpad_rotated_pill = z.object({
   type: z.literal("pcb_smtpad"),
@@ -106,6 +110,7 @@ const pcb_smtpad_rotated_pill = z.object({
   pcb_port_id: z.string().optional(),
   is_covered_with_solder_mask: z.boolean().optional(),
   soldermask_margin: z.number().optional(),
+  solderpaste_margin: z.number().optional(),
 })
 
 const pcb_smtpad_polygon = z.object({
@@ -121,6 +126,7 @@ const pcb_smtpad_polygon = z.object({
   pcb_port_id: z.string().optional(),
   is_covered_with_solder_mask: z.boolean().optional(),
   soldermask_margin: z.number().optional(),
+  solderpaste_margin: z.number().optional(),
 })
 
 export const pcb_smtpad = z
@@ -160,6 +166,7 @@ export interface PcbSmtPadCircle {
   pcb_port_id?: string
   is_covered_with_solder_mask?: boolean
   soldermask_margin?: number
+  solderpaste_margin?: number
 }
 
 /**
@@ -187,6 +194,7 @@ export interface PcbSmtPadRect {
   soldermask_margin_top?: number
   soldermask_margin_right?: number
   soldermask_margin_bottom?: number
+  solderpaste_margin?: number
 }
 
 /**
@@ -215,6 +223,7 @@ export interface PcbSmtPadRotatedRect {
   soldermask_margin_top?: number
   soldermask_margin_right?: number
   soldermask_margin_bottom?: number
+  solderpaste_margin?: number
 }
 /**
  * Defines a pill-shaped SMT pad on the PCB (rounded rectangle).
@@ -236,6 +245,7 @@ export interface PcbSmtPadPill {
   pcb_port_id?: string
   is_covered_with_solder_mask?: boolean
   soldermask_margin?: number
+  solderpaste_margin?: number
 }
 
 /**
@@ -259,6 +269,7 @@ export interface PcbSmtPadRotatedPill {
   pcb_port_id?: string
   is_covered_with_solder_mask?: boolean
   soldermask_margin?: number
+  solderpaste_margin?: number
 }
 
 /**
@@ -277,6 +288,7 @@ export interface PcbSmtPadPolygon {
   pcb_port_id?: string
   is_covered_with_solder_mask?: boolean
   soldermask_margin?: number
+  solderpaste_margin?: number
 }
 
 export type PcbSmtPad =

--- a/tests/pcb-smtpad-solderpaste-margin.test.ts
+++ b/tests/pcb-smtpad-solderpaste-margin.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { pcb_smtpad } from "../src/pcb/pcb_smtpad"
+
+const pads = [
+  { shape: "circle", radius: 0.5 },
+  { shape: "rect", width: 1, height: 2 },
+  { shape: "rotated_rect", width: 1, height: 2, ccw_rotation: 45 },
+  { shape: "pill", width: 2, height: 1, radius: 0.5 },
+  {
+    shape: "rotated_pill",
+    width: 2,
+    height: 1,
+    radius: 0.5,
+    ccw_rotation: 45,
+  },
+  {
+    shape: "polygon",
+    points: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+    ],
+  },
+] as const
+
+test("all SMT pad shapes parse solderpaste_margin", () => {
+  for (const pad of pads) {
+    const parsed = pcb_smtpad.parse({
+      type: "pcb_smtpad",
+      x: 0,
+      y: 0,
+      layer: "top",
+      solderpaste_margin: -0.05,
+      ...pad,
+    })
+
+    expect(parsed.solderpaste_margin).toBe(-0.05)
+  }
+})


### PR DESCRIPTION
## What changed

- Add optional `solderpaste_margin` to every `pcb_smtpad` shape schema and exported TypeScript interface.
- Add a regression test covering circle, rect, rotated rect, pill, rotated pill, and polygon pads.

## Why

The source-level `solderPasteMargin` prop and its aperture behavior are already available through tscircuit/props#767 and tscircuit/core#2945, but Circuit JSON could not represent the originating per-pad margin. This adds the missing schema field while following the existing `soldermask_margin` naming convention.

Positive values can represent aperture expansion and negative values contraction; the field remains optional, so existing Circuit JSON is unchanged.

## Checks

- `bun test` (280 pass)
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- Biome format/lint on changed files