### PR TITLE
Add semantic pin 1 locations to PCB components

### DIFF
--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -1,6 +1,7 @@
 export * from "./properties/brep"
 export * from "./properties/insertion_direction"
 export * from "./properties/layer_ref"
+export * from "./properties/pcb_pin1_location"
 export * from "./properties/pcb_route_hints"
 export * from "./properties/supplier_name"
 export * from "./properties/route_hint_point"

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -12,6 +12,14 @@ import {
   insertion_direction,
 } from "src/pcb/properties/insertion_direction"
 import { type LayerRef, layer_ref } from "src/pcb/properties/layer_ref"
+import {
+  type PcbPin1Location,
+  pcb_pin1_location,
+} from "src/pcb/properties/pcb_pin1_location"
+import {
+  type SupplierName,
+  supplier_name,
+} from "src/pcb/properties/supplier_name"
 import { type Length, type Rotation, length, rotation } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 import { z } from "zod"
@@ -60,6 +68,17 @@ export const pcb_component = z
     positioned_relative_to_pcb_board_id: z.string().optional(),
     cable_insertion_center: point.optional(),
     insertion_direction: insertion_direction.optional(),
+    pin1_location: pcb_pin1_location
+      .optional()
+      .describe(
+        "Location of pin 1 on the unrotated, top-view component footprint",
+      ),
+    supplier_pin1_location_map: z
+      .record(supplier_name, pcb_pin1_location)
+      .optional()
+      .describe(
+        "Pin 1 location for each supplier's unrotated, top-view footprint",
+      ),
     metadata: z
       .object({
         kicad_footprint: kicadFootprintMetadata.optional(),
@@ -106,6 +125,8 @@ export interface PcbComponent {
   positioned_relative_to_pcb_board_id?: string
   cable_insertion_center?: Point
   insertion_direction?: InsertionDirection
+  pin1_location?: PcbPin1Location
+  supplier_pin1_location_map?: Partial<Record<SupplierName, PcbPin1Location>>
   metadata?: PcbComponentMetadata
   obstructs_within_bounds: boolean
 }

--- a/src/pcb/pcb_component.ts
+++ b/src/pcb/pcb_component.ts
@@ -28,6 +28,10 @@ export interface PcbComponentMetadata {
   kicad_footprint?: KicadFootprintMetadata
 }
 
+export type SupplierPin1LocationMap = Partial<
+  Record<SupplierName, PcbPin1Location>
+>
+
 export const pcb_component = z
   .object({
     type: z.literal("pcb_component"),
@@ -126,7 +130,7 @@ export interface PcbComponent {
   cable_insertion_center?: Point
   insertion_direction?: InsertionDirection
   pin1_location?: PcbPin1Location
-  supplier_pin1_location_map?: Partial<Record<SupplierName, PcbPin1Location>>
+  supplier_pin1_location_map?: SupplierPin1LocationMap
   metadata?: PcbComponentMetadata
   obstructs_within_bounds: boolean
 }

--- a/src/pcb/properties/pcb_pin1_location.ts
+++ b/src/pcb/properties/pcb_pin1_location.ts
@@ -1,0 +1,30 @@
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+
+/**
+ * Describes where pin 1 is located on an unrotated, top-view PCB footprint.
+ */
+export const pcb_pin1_location = z.enum([
+  "leftside_top",
+  "leftside_bottom",
+  "rightside_top",
+  "rightside_bottom",
+  "topside_left",
+  "topside_right",
+  "bottomside_left",
+  "bottomside_right",
+])
+
+type InferredPcbPin1Location = z.infer<typeof pcb_pin1_location>
+
+export type PcbPin1Location =
+  | "leftside_top"
+  | "leftside_bottom"
+  | "rightside_top"
+  | "rightside_bottom"
+  | "topside_left"
+  | "topside_right"
+  | "bottomside_left"
+  | "bottomside_right"
+
+expectTypesMatch<PcbPin1Location, InferredPcbPin1Location>(true)

--- a/src/pcb/properties/pcb_pin1_location.ts
+++ b/src/pcb/properties/pcb_pin1_location.ts
@@ -28,3 +28,42 @@ export type PcbPin1Location =
   | "bottomside_right"
 
 expectTypesMatch<PcbPin1Location, InferredPcbPin1Location>(true)
+
+export type PcbPin1LocationRotation = 0 | 90 | 180 | 270
+
+const pin1LocationRotationCycles: readonly (readonly PcbPin1Location[])[] = [
+  [
+    "leftside_top",
+    "bottomside_left",
+    "rightside_bottom",
+    "topside_right",
+  ],
+  [
+    "leftside_bottom",
+    "bottomside_right",
+    "rightside_top",
+    "topside_left",
+  ],
+]
+
+/**
+ * Returns the counter-clockwise rotation that maps one pin 1 location to
+ * another, or null when the locations differ by reflection rather than
+ * rotation.
+ */
+export const getRotationBetweenPcbPin1Locations = (
+  from: PcbPin1Location,
+  to: PcbPin1Location,
+): PcbPin1LocationRotation | null => {
+  for (const cycle of pin1LocationRotationCycles) {
+    const fromIndex = cycle.indexOf(from)
+    const toIndex = cycle.indexOf(to)
+
+    if (fromIndex !== -1 && toIndex !== -1) {
+      return (((toIndex - fromIndex + cycle.length) % cycle.length) *
+        90) as PcbPin1LocationRotation
+    }
+  }
+
+  return null
+}

--- a/tests/pcb_component_position_mode.test.ts
+++ b/tests/pcb_component_position_mode.test.ts
@@ -175,6 +175,39 @@ test("pcb_component allows optional metadata.kicad_footprint", () => {
   expect(parsed.metadata?.kicad_footprint?.attributes?.smd).toBe(true)
 })
 
+test("pcb_component allows semantic pin 1 locations", () => {
+  const parsed = pcb_component.parse({
+    ...baseComponent,
+    pin1_location: "leftside_top",
+    supplier_pin1_location_map: {
+      jlcpcb: "topside_left",
+      pcbway: "rightside_bottom",
+    },
+  })
+
+  expect(parsed.pin1_location).toBe("leftside_top")
+  expect(parsed.supplier_pin1_location_map).toEqual({
+    jlcpcb: "topside_left",
+    pcbway: "rightside_bottom",
+  })
+})
+
+test("pcb_component rejects invalid semantic pin 1 locations", () => {
+  expect(() =>
+    pcb_component.parse({
+      ...baseComponent,
+      pin1_location: "top_left",
+    }),
+  ).toThrowError()
+
+  expect(() =>
+    pcb_component.parse({
+      ...baseComponent,
+      supplier_pin1_location_map: { jlcpcb: "top_left" },
+    }),
+  ).toThrowError()
+})
+
 test("pcb_component rejects invalid position_mode", () => {
   expect(() =>
     pcb_component.parse({

--- a/tests/pcb_pin1_location.test.ts
+++ b/tests/pcb_pin1_location.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import {
+  type PcbPin1Location,
+  getRotationBetweenPcbPin1Locations,
+} from "src/pcb/properties/pcb_pin1_location"
+
+const rotationCycles = [
+  [
+    "leftside_top",
+    "bottomside_left",
+    "rightside_bottom",
+    "topside_right",
+  ],
+  [
+    "leftside_bottom",
+    "bottomside_right",
+    "rightside_top",
+    "topside_left",
+  ],
+] as const satisfies readonly (readonly PcbPin1Location[])[]
+
+test("maps every rotation-compatible pin 1 location pair", () => {
+  for (const cycle of rotationCycles) {
+    for (let fromIndex = 0; fromIndex < cycle.length; fromIndex++) {
+      for (let toIndex = 0; toIndex < cycle.length; toIndex++) {
+        const expectedRotation =
+          ((toIndex - fromIndex + cycle.length) % cycle.length) * 90
+
+        expect(
+          getRotationBetweenPcbPin1Locations(
+            cycle[fromIndex],
+            cycle[toIndex],
+          ),
+        ).toBe(expectedRotation)
+      }
+    }
+  }
+})
+
+test("returns null when pin 1 locations differ by reflection", () => {
+  for (const from of rotationCycles[0]) {
+    for (const to of rotationCycles[1]) {
+      expect(getRotationBetweenPcbPin1Locations(from, to)).toBeNull()
+      expect(getRotationBetweenPcbPin1Locations(to, from)).toBeNull()
+    }
+  }
+})

--- a/tests/pcb_pin1_location.test.ts
+++ b/tests/pcb_pin1_location.test.ts
@@ -19,17 +19,21 @@ const rotationCycles = [
   ],
 ] as const satisfies readonly (readonly PcbPin1Location[])[]
 
+const quarterTurnRotations = [0, 90, 180, 270] as const
+
 test("maps every rotation-compatible pin 1 location pair", () => {
   for (const cycle of rotationCycles) {
     for (let fromIndex = 0; fromIndex < cycle.length; fromIndex++) {
       for (let toIndex = 0; toIndex < cycle.length; toIndex++) {
         const expectedRotation =
-          ((toIndex - fromIndex + cycle.length) % cycle.length) * 90
+          quarterTurnRotations[
+            (toIndex - fromIndex + cycle.length) % cycle.length
+          ]!
 
         expect(
           getRotationBetweenPcbPin1Locations(
-            cycle[fromIndex],
-            cycle[toIndex],
+            cycle[fromIndex]!,
+            cycle[toIndex]!,
           ),
         ).toBe(expectedRotation)
       }


### PR DESCRIPTION
## Summary

- add the shared `PcbPin1Location` semantic orientation type
- add `pcb_component.pin1_location` for the rendered footprint
- add `pcb_component.supplier_pin1_location_map` keyed by supplier so multiple assembly providers can coexist
- add `getRotationBetweenPcbPin1Locations` for deriving transient quarter-turn corrections while rejecting reflected topology
- validate and export the new fields, supplier map type, and helper

Both values describe unrotated, top-view footprints. Rotation offsets remain derived export data and are not persisted.

## Testing

- `bun test`
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`
