### PR TITLE
add source trace id to schematic_text

### DIFF
--- a/src/schematic/schematic_text.ts
+++ b/src/schematic/schematic_text.ts
@@ -12,6 +12,13 @@ export interface SchematicText {
   schematic_component_id?: string
   schematic_symbol_id?: string
   schematic_text_id: string
+  /**
+   * Set when the text annotates a trace rather than a component, as an inline
+   * net label does - the net name drawn alongside a point-to-point wire instead
+   * of as an anchored `schematic_net_label`. Lets consumers tell such a label
+   * apart from free-standing text and resolve the net it belongs to.
+   */
+  source_trace_id?: string
   text: string
   font_size: number
   position: {
@@ -30,6 +37,7 @@ export const schematic_text = z.object({
   schematic_component_id: z.string().optional(),
   schematic_symbol_id: z.string().optional(),
   schematic_text_id: z.string(),
+  source_trace_id: z.string().optional(),
   text: z.string(),
   font_size: z.number().default(0.18),
   position: z.object({

--- a/tests/schematic_text.test.ts
+++ b/tests/schematic_text.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import {
+  type SchematicText,
+  schematic_text,
+} from "../src/schematic/schematic_text"
+
+test("schematic_text.source_trace_id defaults to undefined", () => {
+  const text = schematic_text.parse({
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_1",
+    text: "hello",
+    position: { x: 0, y: 0 },
+  })
+
+  expect(text.source_trace_id).toBeUndefined()
+})
+
+test("schematic_text allows source_trace_id", () => {
+  const text = schematic_text.parse({
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_1",
+    source_trace_id: "source_trace_1",
+    text: "USER_LED_ANODE",
+    position: { x: 0, y: 0 },
+    rotation: -90,
+  })
+
+  expect(text.source_trace_id).toBe("source_trace_1")
+})
+
+test("any_circuit_element includes schematic_text with source_trace_id", () => {
+  const text = any_circuit_element.parse({
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_2",
+    source_trace_id: "source_trace_2",
+    text: "SPI_SCK",
+    position: { x: 1, y: 2 },
+  }) as SchematicText
+
+  expect(text.source_trace_id).toBe("source_trace_2")
+})


### PR DESCRIPTION
Adds an optional `source_trace_id` to `schematic_text`, mirroring the field `schematic_net_label` already carries.

## Why

I'm adding **inline net labels** to [core](https://github.com/tscircuit/core) and [schematic-trace-solver](https://github.com/tscircuit/schematic-trace-solver): a net name drawn parallel to the wire it belongs to — above a horizontal trace, or to the left of a vertical one reading bottom-to-top — instead of a tag anchored to the end of the trace. It keeps the visual line between two pins unbroken on point-to-point signals like `USER_LED_ANODE`.

Because an inline label is rotated, it can't be a `schematic_net_label` — that element is always axis-aligned, with an `anchor_side` and a tag symbol. So it's emitted as a `schematic_text` with `anchor: "center"` and `rotation` of `0` or `-90`.

That leaves two gaps:

- the label is indistinguishable from free-standing text such as a reference designator, and
- consumers have no way to resolve which net it names.

`source_trace_id` closes both. It's what core naturally has on hand — the label is derived from a specific `source_trace` while building the solver input — and it's more reliably available than `source_net_id` here, since a trace labeled via `schDisplayLabel` has no `source_net` at all.

## Verified against a real consumer

Core populates it and it round-trips:

```
inline label source_trace_id: source_trace_0
resolves to source_trace: source_trace_0  ports: 2
refdes text ("U1") source_trace_id: undefined
```

The full core suite (1345 tests) passes with the field populated.

## Notes

- Purely additive and optional — no existing producer or consumer changes behavior.
- `bun test` (287 pass), `bunx tsc --noEmit`, `lint:zod`, and `check-snake-case` are all clean.
- I did **not** regenerate `README.md`. It's stale on `main` for unrelated reasons (`PcbPin1Location`, `pcb_via` source ids, `source_manually_placed_via`), so regenerating pulls in drift that isn't mine — and the closest precedent, #672, didn't touch it either. Happy to include it if you'd rather.
- I considered adding `source_net_id` alongside, for symmetry with `schematic_net_label`. I left it out because it isn't populatable in this case, but say the word if you want both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)