### PR TITLE
Add component-inside-silkscreen warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbBoard](#pcbboard)
     - [PcbBreakoutPoint](#pcbbreakoutpoint)
     - [PcbComponent](#pcbcomponent)
+    - [PcbComponentInsideSilkscreenWarning](#pcbcomponentinsidesilkscreenwarning)
     - [PcbComponentInvalidLayerError](#pcbcomponentinvalidlayererror)
     - [PcbComponentNotOnBoardEdgeError](#pcbcomponentnotonboardedgeerror)
     - [PcbComponentOutsideBoardError](#pcbcomponentoutsideboarderror)
@@ -1391,6 +1392,26 @@ interface PcbBreakoutPoint {
 ```typescript
 interface PcbComponentMetadata {
   kicad_footprint?: KicadFootprintMetadata
+}
+```
+
+### PcbComponentInsideSilkscreenWarning
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_component_inside_silkscreen_warning.ts)
+
+Warning emitted when a PCB component is placed inside another component's silkscreen bounds
+
+```typescript
+/** Warning emitted when a PCB component is placed inside another component's silkscreen bounds */
+interface PcbComponentInsideSilkscreenWarning {
+  type: "pcb_component_inside_silkscreen_warning"
+  pcb_component_inside_silkscreen_warning_id: string
+  warning_type: "pcb_component_inside_silkscreen_warning"
+  message: string
+  /** Placed component first, component owning the enclosing silkscreen second */
+  pcb_component_ids: [string, string]
+  pcb_board_id?: string
+  subcircuit_id?: string
 }
 ```
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -64,6 +64,7 @@ export const any_circuit_element = z.union([
   pcb.circuit_json_footprint_load_error,
   pcb.pcb_manual_edit_conflict_warning,
   pcb.pcb_connector_not_in_accessible_orientation_warning,
+  pcb.pcb_component_inside_silkscreen_warning,
   pcb.supplier_footprint_mismatch_warning,
   pcb.pcb_plated_hole,
   pcb.pcb_keepout,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -58,6 +58,7 @@ export * from "./pcb_group"
 export * from "./pcb_autorouting_error"
 export * from "./pcb_manual_edit_conflict_warning"
 export * from "./pcb_connector_not_in_accessible_orientation_warning"
+export * from "./pcb_component_inside_silkscreen_warning"
 export * from "./supplier_footprint_mismatch_warning"
 export * from "./pcb_breakout_point"
 export * from "./pcb_ground_plane"
@@ -102,6 +103,7 @@ import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
 import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
 import type { PcbConnectorNotInAccessibleOrientationWarning } from "./pcb_connector_not_in_accessible_orientation_warning"
+import type { PcbComponentInsideSilkscreenWarning } from "./pcb_component_inside_silkscreen_warning"
 import type { SupplierFootprintMismatchWarning } from "./supplier_footprint_mismatch_warning"
 import type { PcbTraceHint } from "./pcb_trace_hint"
 import type { PcbSilkscreenLine } from "./pcb_silkscreen_line"
@@ -160,6 +162,7 @@ export type PcbCircuitElement =
   | CircuitJsonFootprintLoadError
   | PcbManualEditConflictWarning
   | PcbConnectorNotInAccessibleOrientationWarning
+  | PcbComponentInsideSilkscreenWarning
   | SupplierFootprintMismatchWarning
   | PcbPortNotMatchedError
   | PcbPortNotConnectedError

--- a/src/pcb/pcb_component_inside_silkscreen_warning.ts
+++ b/src/pcb/pcb_component_inside_silkscreen_warning.ts
@@ -1,0 +1,49 @@
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+
+export const pcb_component_inside_silkscreen_warning = z
+  .object({
+    type: z.literal("pcb_component_inside_silkscreen_warning"),
+    pcb_component_inside_silkscreen_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_component_inside_silkscreen_warning",
+    ),
+    warning_type: z
+      .literal("pcb_component_inside_silkscreen_warning")
+      .default("pcb_component_inside_silkscreen_warning"),
+    message: z.string(),
+    /**
+     * Ordered pair containing the placed component first and the component
+     * whose silkscreen bounds contain it second.
+     */
+    pcb_component_ids: z.tuple([z.string(), z.string()]),
+    pcb_board_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Warning emitted when a PCB component is placed inside the silkscreen bounds of another PCB component",
+  )
+
+export type PcbComponentInsideSilkscreenWarningInput = z.input<
+  typeof pcb_component_inside_silkscreen_warning
+>
+type InferredPcbComponentInsideSilkscreenWarning = z.infer<
+  typeof pcb_component_inside_silkscreen_warning
+>
+
+/** Warning emitted when a PCB component is placed inside another component's silkscreen bounds */
+export interface PcbComponentInsideSilkscreenWarning {
+  type: "pcb_component_inside_silkscreen_warning"
+  pcb_component_inside_silkscreen_warning_id: string
+  warning_type: "pcb_component_inside_silkscreen_warning"
+  message: string
+  /** Placed component first, component owning the enclosing silkscreen second */
+  pcb_component_ids: [string, string]
+  pcb_board_id?: string
+  subcircuit_id?: string
+}
+
+expectTypesMatch<
+  PcbComponentInsideSilkscreenWarning,
+  InferredPcbComponentInsideSilkscreenWarning
+>(true)

--- a/tests/pcb-component-inside-silkscreen-warning.test.ts
+++ b/tests/pcb-component-inside-silkscreen-warning.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { pcb_component_inside_silkscreen_warning } from "../src/pcb/pcb_component_inside_silkscreen_warning"
+
+const warningInput = {
+  type: "pcb_component_inside_silkscreen_warning" as const,
+  message: "PCB component R1 is inside the silkscreen bounds of U1",
+  pcb_component_ids: ["pcb_component_r1", "pcb_component_u1"] as [
+    string,
+    string,
+  ],
+  pcb_board_id: "pcb_board_0",
+  subcircuit_id: "subcircuit_0",
+}
+
+test("pcb_component_inside_silkscreen_warning parses", () => {
+  const warning = pcb_component_inside_silkscreen_warning.parse(warningInput)
+
+  expect(warning.pcb_component_inside_silkscreen_warning_id).toStartWith(
+    "pcb_component_inside_silkscreen_warning_",
+  )
+  expect(warning.warning_type).toBe("pcb_component_inside_silkscreen_warning")
+  expect(warning.pcb_component_ids).toEqual([
+    "pcb_component_r1",
+    "pcb_component_u1",
+  ])
+})
+
+test("any_circuit_element includes pcb_component_inside_silkscreen_warning", () => {
+  const parsed = any_circuit_element.parse(warningInput)
+
+  expect(parsed.type).toBe("pcb_component_inside_silkscreen_warning")
+})


### PR DESCRIPTION
AI is placing components inside the silkscreen of other components. Fox ex - the buzzer won't fit if the resistor is placed inside it's silkscreen dimension

<img width="2726" height="1494" alt="image" src="https://github.com/user-attachments/assets/9916d793-336a-4750-b929-23363c05acab" />


## Summary

- add `pcb_component_inside_silkscreen_warning` to Circuit JSON
- represent the containment relationship as an ordered pair of PCB component IDs (placed component first, silkscreen owner second)
- export the warning through the PCB element and universal circuit-element unions
- document and test schema parsing/default ID behavior

## Why

Placement checks need a typed warning when a PCB component is placed inside the silkscreen bounds of another component. Without a Circuit JSON schema for that diagnostic, producers cannot emit it while preserving type-safe downstream parsing.

## Impact

Circuit JSON producers can emit this placement warning, and consumers using `any_circuit_element` or `PcbCircuitElement` can parse it.

## Validation

- `bun test` (289 passing)
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- Biome check on the new schema and test files