### PR TITLE
Add resistor tolerance to source resistor schema

### DIFF
--- a/src/source/source_simple_resistor.ts
+++ b/src/source/source_simple_resistor.ts
@@ -1,14 +1,20 @@
-import { z } from "zod"
 import {
-  source_component_base,
   type SourceComponentBase,
+  source_component_base,
 } from "src/source/base/source_component_base"
 import { resistance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const source_simple_resistor = source_component_base.extend({
   ftype: z.literal("simple_resistor"),
   resistance,
+  tolerance: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe("Resistance tolerance as a fraction (0 to 1)"),
   display_resistance: z.string().optional(),
 })
 
@@ -21,6 +27,7 @@ type InferredSourceSimpleResistor = z.infer<typeof source_simple_resistor>
 export interface SourceSimpleResistor extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
+  tolerance?: number
   display_resistance?: string
 }
 


### PR DESCRIPTION
Ref https://github.com/tscircuit/core/pull/3097
## Summary

- Add optional `tolerance` to `SourceSimpleResistor`
- Represent tolerance as a fraction between `0` and `1`
- Preserve tolerance through `source_simple_resistor` and `any_circuit_element` parsing
- Add validation and regression tests

## Example

A 5% resistor tolerance is represented as:

```json
{
  "ftype": "simple_resistor",
  "resistance": 1000,
  "tolerance": 0.05
}