### PR TITLE
Add display_tolerance to passive source components

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ interface SourceSimpleCapacitor extends SourceComponentBase {
   capacitance: number
   max_voltage_rating?: number
   display_capacitance?: string
+  display_tolerance?: string
   max_decoupling_trace_length?: number
 }
 ```
@@ -972,6 +973,7 @@ interface SourceSimpleInductor extends SourceComponentBase {
   ftype: "simple_inductor"
   inductance: number
   display_inductance?: string
+  display_tolerance?: string
   max_current_rating?: number
 }
 ```
@@ -1095,6 +1097,7 @@ interface SourceSimpleResistor extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
   display_resistance?: string
+  display_tolerance?: string
 }
 ```
 

--- a/src/source/source_simple_capacitor.ts
+++ b/src/source/source_simple_capacitor.ts
@@ -11,6 +11,7 @@ export const source_simple_capacitor = source_component_base.extend({
   capacitance,
   max_voltage_rating: voltage.optional(),
   display_capacitance: z.string().optional(),
+  display_tolerance: z.string().optional(),
   max_decoupling_trace_length: distance.optional(),
 })
 
@@ -25,6 +26,7 @@ export interface SourceSimpleCapacitor extends SourceComponentBase {
   capacitance: number
   max_voltage_rating?: number
   display_capacitance?: string
+  display_tolerance?: string
   max_decoupling_trace_length?: number
 }
 

--- a/src/source/source_simple_inductor.ts
+++ b/src/source/source_simple_inductor.ts
@@ -10,6 +10,7 @@ export const source_simple_inductor = source_component_base.extend({
   ftype: z.literal("simple_inductor"),
   inductance,
   display_inductance: z.string().optional(),
+  display_tolerance: z.string().optional(),
   max_current_rating: z.number().optional(),
 })
 
@@ -23,6 +24,7 @@ export interface SourceSimpleInductor extends SourceComponentBase {
   ftype: "simple_inductor"
   inductance: number
   display_inductance?: string
+  display_tolerance?: string
   max_current_rating?: number
 }
 

--- a/src/source/source_simple_resistor.ts
+++ b/src/source/source_simple_resistor.ts
@@ -10,6 +10,7 @@ export const source_simple_resistor = source_component_base.extend({
   ftype: z.literal("simple_resistor"),
   resistance,
   display_resistance: z.string().optional(),
+  display_tolerance: z.string().optional(),
 })
 
 export type SourceSimpleResistorInput = z.input<typeof source_simple_resistor>
@@ -22,6 +23,7 @@ export interface SourceSimpleResistor extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
   display_resistance?: string
+  display_tolerance?: string
 }
 
 expectTypesMatch<SourceSimpleResistor, InferredSourceSimpleResistor>(true)

--- a/tests/source_display_tolerance.test.ts
+++ b/tests/source_display_tolerance.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import {
+  source_simple_capacitor,
+  source_simple_inductor,
+  source_simple_resistor,
+} from "../src/source"
+
+test("source_simple_capacitor preserves display_tolerance", () => {
+  const capacitor = source_simple_capacitor.parse({
+    type: "source_component",
+    ftype: "simple_capacitor",
+    source_component_id: "capacitor1",
+    name: "C1",
+    capacitance: "10uF",
+    display_tolerance: "±20%",
+  })
+
+  expect(capacitor.display_tolerance).toBe("±20%")
+})
+
+test("source_simple_resistor preserves display_tolerance", () => {
+  const resistor = source_simple_resistor.parse({
+    type: "source_component",
+    ftype: "simple_resistor",
+    source_component_id: "resistor1",
+    name: "R1",
+    resistance: "1kΩ",
+    display_tolerance: "±1%",
+  })
+
+  expect(resistor.display_tolerance).toBe("±1%")
+})
+
+test("source_simple_inductor preserves display_tolerance", () => {
+  const inductor = source_simple_inductor.parse({
+    type: "source_component",
+    ftype: "simple_inductor",
+    source_component_id: "inductor1",
+    name: "L1",
+    inductance: "10uH",
+    display_tolerance: "±10%",
+  })
+
+  expect(inductor.display_tolerance).toBe("±10%")
+})
+
+test("any_circuit_element preserves display_tolerance", () => {
+  const components = [
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "capacitor1",
+      name: "C1",
+      capacitance: "10uF",
+      display_tolerance: "±20%",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "resistor1",
+      name: "R1",
+      resistance: "1kΩ",
+      display_tolerance: "±1%",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_inductor",
+      source_component_id: "inductor1",
+      name: "L1",
+      inductance: "10uH",
+      display_tolerance: "±10%",
+    },
+  ]
+
+  expect(
+    components.map((component) => {
+      const parsedComponent = any_circuit_element.parse(component)
+      return "display_tolerance" in parsedComponent
+        ? parsedComponent.display_tolerance
+        : undefined
+    }),
+  ).toEqual(["±20%", "±1%", "±10%"])
+})


### PR DESCRIPTION
## Summary

- add optional `display_tolerance` strings to capacitor, resistor, and inductor source schemas
- expose the field on the corresponding TypeScript interfaces and README specification
- verify direct schema parsing and top-level `any_circuit_element` parsing

## Why

Circuit JSON already preserves human-readable component values through fields such as `display_capacitance`, `display_resistance`, and `display_inductance`. This adds the matching display field for tolerance so producers can retain formatted values such as `±1%`.

## Impact

Consumers can read a formatted tolerance from simple capacitors, resistors, and inductors without changing existing numeric component values. The new field is optional, so existing Circuit JSON remains valid.

## Validation

- `bun test` — 290 tests passed
- `bun test tests/source_display_tolerance.test.ts` — 4 tests passed
- `bun run build`
- `bunx tsc --noEmit`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`