### PR TITLE
feat: add hidden edge rendering hint to CAD components

### DIFF
--- a/src/cad/cad_component.ts
+++ b/src/cad/cad_component.ts
@@ -53,6 +53,7 @@ export const cad_component = z
     model_jscad: z.any().optional(),
     show_as_translucent_model: z.boolean().optional(),
     show_as_bounding_box: z.boolean().optional(),
+    show_hidden_edges: z.boolean().optional(),
     anchor_alignment: z
       .enum(["center", "center_of_component_on_board_surface"] as const)
       .optional()
@@ -98,6 +99,7 @@ export interface CadComponent {
   model_jscad?: any
   show_as_translucent_model?: boolean
   show_as_bounding_box?: boolean
+  show_hidden_edges?: boolean
   anchor_alignment: CadComponentAnchorAlignment
 }
 

--- a/tests/cad_component_model_fields.test.ts
+++ b/tests/cad_component_model_fields.test.ts
@@ -44,3 +44,16 @@ test("cad_component accepts show_as_bounding_box", () => {
 
   expect(component.show_as_bounding_box).toBe(true)
 })
+
+test("cad_component accepts show_hidden_edges", () => {
+  const component = cad_component.parse({
+    type: "cad_component",
+    cad_component_id: "cad-hidden-edges",
+    pcb_component_id: "pcb-hidden-edges",
+    source_component_id: "src-hidden-edges",
+    position: { x: 0, y: 0, z: 0 },
+    show_hidden_edges: true,
+  })
+
+  expect(component.show_hidden_edges).toBe(true)
+})


### PR DESCRIPTION
## Summary

- add optional `show_hidden_edges` to the `cad_component` schema
- expose the field on the typed `CadComponent` interface
- test schema parsing for the new rendering hint

## Why

This gives end-user component props a typed Circuit JSON path for carrying hidden-edge intent to 3D exporters and viewers.

## Impact

The field is optional and backward compatible. Consumers that do not support it can safely ignore it.

## Checks

- `bun test tests/cad_component_model_fields.test.ts`
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`