### PR TITLE
Add voltage to simple batteries

### DIFF
--- a/src/source/source_simple_battery.ts
+++ b/src/source/source_simple_battery.ts
@@ -3,12 +3,13 @@ import {
   source_component_base,
   type SourceComponentBase,
 } from "src/source/base/source_component_base"
-import { battery_capacity } from "src/units"
+import { battery_capacity, voltage } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export const source_simple_battery = source_component_base.extend({
   ftype: z.literal("simple_battery"),
   capacity: battery_capacity,
+  voltage: voltage.optional(),
 })
 
 export type SourceSimpleBatteryInput = z.input<typeof source_simple_battery>
@@ -20,6 +21,7 @@ type InferredSourceSimpleBattery = z.infer<typeof source_simple_battery>
 export interface SourceSimpleBattery extends SourceComponentBase {
   ftype: "simple_battery"
   capacity: number
+  voltage?: number
 }
 
 expectTypesMatch<SourceSimpleBattery, InferredSourceSimpleBattery>(true)

--- a/tests/source_simple_battery.test.ts
+++ b/tests/source_simple_battery.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { source_simple_battery } from "../src/source/source_simple_battery"
+
+test("source_simple_battery parses voltage", () => {
+  const battery = source_simple_battery.parse({
+    type: "source_component",
+    ftype: "simple_battery",
+    source_component_id: "B1",
+    name: "B1",
+    capacity: 2200,
+    voltage: 3.7,
+  })
+
+  expect(battery.voltage).toBe(3.7)
+})


### PR DESCRIPTION
## Summary

- Add optional `voltage` to the `source_simple_battery` schema and `SourceSimpleBattery` type.
- Add a regression test covering battery voltage parsing.

## Root cause

`@tscircuit/props` already accepts `battery.voltage`, but the circuit-json battery source schema did not declare the corresponding field. This prevented core from representing the accepted prop in typed source-component JSON.

## Validation

- `bun test tests/source_simple_battery.test.ts`
- `bunx tsc --noEmit`
- `bun run build`