### PR TITLE
add resistor tolerance to Circuit JSON

### DIFF
--- a/src/source/source_simple_resistor.ts
+++ b/src/source/source_simple_resistor.ts
@@ -9,6 +9,7 @@ import { expectTypesMatch } from "src/utils/expect-types-match"
 export const source_simple_resistor = source_component_base.extend({
   ftype: z.literal("simple_resistor"),
   resistance,
+  tolerance: z.number().optional(),
   display_resistance: z.string().optional(),
 })
 
@@ -21,6 +22,7 @@ type InferredSourceSimpleResistor = z.infer<typeof source_simple_resistor>
 export interface SourceSimpleResistor extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
+  tolerance?: number
   display_resistance?: string
 }
 

--- a/tests/source_simple_resistor.test.ts
+++ b/tests/source_simple_resistor.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { source_simple_resistor } from "../src/source/source_simple_resistor"
+
+test("source_simple_resistor parses tolerance", () => {
+  const resistor = source_simple_resistor.parse({
+    type: "source_component",
+    ftype: "simple_resistor",
+    source_component_id: "R1",
+    name: "R1",
+    resistance: 10_000,
+    tolerance: 0.05,
+  })
+
+  expect(resistor.tolerance).toBe(0.05)
+})
+
+test("any_circuit_element includes tolerance for simple resistors", () => {
+  const parsed = any_circuit_element.parse({
+    type: "source_component",
+    ftype: "simple_resistor",
+    source_component_id: "R1",
+    name: "R1",
+    resistance: 10_000,
+    tolerance: 0.05,
+  })
+
+  if ("ftype" in parsed && parsed.ftype === "simple_resistor") {
+    expect(parsed.tolerance).toBe(0.05)
+  } else {
+    throw new Error("Parsed element was not a simple resistor")
+  }
+})


### PR DESCRIPTION
## What changed

Add optional `tolerance` support to `SourceSimpleResistor` in Circuit JSON.

The value is normalized as a fraction, so a 5% resistor is represented as `0.05`.

## Why

The resistor component props already accepts tolerance, and `core` now serializes it. This schema change makes the field officially supported by Circuit JSON validation and TypeScript types.

## Validation

- `bun test tests/source_simple_resistor.test.ts`
- `bunx tsc --noEmit`

Submitted from `rushabhcodes/circuit-json` branch `fix-resistor-tolerance-schema`.