### PR TITLE
Add JST connector standards

### DIFF
--- a/src/source/source_simple_connector.ts
+++ b/src/source/source_simple_connector.ts
@@ -5,9 +5,24 @@ import {
 import { z } from "zod"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
+export const source_simple_connector_standards = [
+  "usb_c",
+  "m2",
+  "jst_sh",
+  "jst_gh",
+  "jst_zh",
+  "jst_ph",
+  "jst_xh",
+  "jst_vh",
+] as const
+
+export type SourceSimpleConnectorStandard =
+  (typeof source_simple_connector_standards)[number]
+
 export const source_simple_connector = source_component_base.extend({
   ftype: z.literal("simple_connector"),
-  standard: z.enum(["usb_c", "m2"]).optional(),
+  standard: z.enum(source_simple_connector_standards).optional(),
+  pin_count: z.number().int().positive().optional(),
 })
 
 export type SourceSimpleConnectorInput = z.input<typeof source_simple_connector>
@@ -18,7 +33,10 @@ type InferredSourceSimpleConnector = z.infer<typeof source_simple_connector>
  */
 export interface SourceSimpleConnector extends SourceComponentBase {
   ftype: "simple_connector"
-  standard?: "usb_c" | "m2"
+  /** Connector interface or product family, such as usb_c, m2, or jst_ph */
+  standard?: SourceSimpleConnectorStandard
+  /** Number of electrical circuits in the connector */
+  pin_count?: number
 }
 
 expectTypesMatch<SourceSimpleConnector, InferredSourceSimpleConnector>(true)

--- a/tests/source_simple_connector.test.ts
+++ b/tests/source_simple_connector.test.ts
@@ -36,6 +36,46 @@ test("source_simple_connector parses with m2 standard", () => {
   expect(connector.standard).toBe("m2")
 })
 
+test("source_simple_connector parses JST standards with pin_count", () => {
+  const jstStandards = [
+    "jst_sh",
+    "jst_gh",
+    "jst_zh",
+    "jst_ph",
+    "jst_xh",
+    "jst_vh",
+  ] as const
+
+  for (const standard of jstStandards) {
+    const connector = source_simple_connector.parse({
+      type: "source_component",
+      ftype: "simple_connector",
+      source_component_id: `connector_${standard}`,
+      name: "J1",
+      standard,
+      pin_count: 4,
+    })
+
+    expect(connector.standard).toBe(standard)
+    expect(connector.pin_count).toBe(4)
+  }
+})
+
+test("source_simple_connector rejects invalid pin_count", () => {
+  for (const pin_count of [0, -1, 1.5]) {
+    expect(() =>
+      source_simple_connector.parse({
+        type: "source_component",
+        ftype: "simple_connector",
+        source_component_id: "connector_invalid_pin_count",
+        name: "J1",
+        standard: "jst_ph",
+        pin_count,
+      }),
+    ).toThrow()
+  }
+})
+
 test("source_simple_connector rejects invalid standard", () => {
   expect(() =>
     source_simple_connector.parse({
@@ -54,10 +94,13 @@ test("any_circuit_element includes source_simple_connector", () => {
     ftype: "simple_connector",
     source_component_id: "connector5",
     name: "J5",
-    standard: "usb_c",
+    standard: "jst_ph",
+    pin_count: 2,
   })
   if ("ftype" in parsed && parsed.ftype === "simple_connector") {
     expect(parsed.ftype).toBe("simple_connector")
+    expect(parsed.standard).toBe("jst_ph")
+    expect(parsed.pin_count).toBe(2)
   } else {
     throw new Error("Parsed element not a source_simple_connector")
   }


### PR DESCRIPTION
## Summary

- add JST SH/GH/ZH/PH/XH/VH to the allowed `SourceSimpleConnector.standard` values
- add optional positive-integer `pin_count` to the runtime Zod schema and TypeScript interface
- export the shared `SourceSimpleConnectorStandard` type and standards list
- cover every JST family, invalid pin counts, and `any_circuit_element` parsing

This removes the type/schema gap for the JST connector support in [tscircuit/core#3205](https://github.com/tscircuit/core/pull/3205) and mirrors the connector props added in [tscircuit/props#793](https://github.com/tscircuit/props/pull/793).

## Validation

- `bun test` — 291 passed, 0 failed
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- Biome formatting on the changed files