### PR TITLE
Add trace maximum via count schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbTraceHint](#pcbtracehint)
     - [PcbTraceMissingError](#pcbtracemissingerror)
     - [PcbTraceTooLongWarning](#pcbtracetoolongwarning)
+    - [PcbTraceTooManyViasWarning](#pcbtracetoomanyviaswarning)
     - [PcbTraceWarning](#pcbtracewarning)
     - [PcbVia](#pcbvia)
     - [PcbViaClearanceError](#pcbviaclearanceerror)
@@ -1211,6 +1212,7 @@ interface SourceTrace {
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
   max_length?: number
+  max_via_count?: number
   name?: string
   display_name?: string
   min_trace_thickness?: number
@@ -2782,6 +2784,28 @@ interface PcbTraceTooLongWarning {
   source_trace_id?: string
   actual_trace_length: Distance
   maximum_trace_length: Distance
+  subcircuit_id?: string
+}
+```
+
+### PcbTraceTooManyViasWarning
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_trace_too_many_vias_warning.ts)
+
+Warning emitted when a PCB trace has more vias than its maximum allowed count
+
+```typescript
+/** Warning emitted when a PCB trace has more vias than its maximum allowed count */
+interface PcbTraceTooManyViasWarning {
+  type: "pcb_trace_too_many_vias_warning"
+  pcb_trace_too_many_vias_warning_id: string
+  warning_type: "pcb_trace_too_many_vias_warning"
+  message: string
+  pcb_trace_id: string
+  source_net_id?: string
+  source_trace_id?: string
+  actual_via_count: number
+  maximum_via_count: number
   subcircuit_id?: string
 }
 ```

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -73,6 +73,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_trace,
   pcb.pcb_trace_warning,
   pcb.pcb_trace_too_long_warning,
+  pcb.pcb_trace_too_many_vias_warning,
   pcb.pcb_via,
   pcb.pcb_smtpad,
   pcb.pcb_solder_paste,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -17,6 +17,7 @@ export * from "./pcb_text"
 export * from "./pcb_trace"
 export * from "./pcb_trace_warning"
 export * from "./pcb_trace_too_long_warning"
+export * from "./pcb_trace_too_many_vias_warning"
 export * from "./pcb_trace_error"
 export * from "./pcb_trace_missing_error"
 export * from "./pcb_port_not_matched_error"
@@ -87,6 +88,7 @@ import type { PcbText } from "./pcb_text"
 import type { PcbTrace } from "./pcb_trace"
 import type { PcbTraceWarning } from "./pcb_trace_warning"
 import type { PcbTraceTooLongWarning } from "./pcb_trace_too_long_warning"
+import type { PcbTraceTooManyViasWarning } from "./pcb_trace_too_many_vias_warning"
 import type { PcbTraceError } from "./pcb_trace_error"
 import type { PcbTraceMissingError } from "./pcb_trace_missing_error"
 import type { PcbPortNotMatchedError } from "./pcb_port_not_matched_error"
@@ -153,6 +155,7 @@ export type PcbCircuitElement =
   | PcbTrace
   | PcbTraceWarning
   | PcbTraceTooLongWarning
+  | PcbTraceTooManyViasWarning
   | PcbTraceError
   | PcbTraceMissingError
   | PcbMissingFootprintError

--- a/src/pcb/pcb_trace_too_many_vias_warning.ts
+++ b/src/pcb/pcb_trace_too_many_vias_warning.ts
@@ -1,0 +1,50 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_trace_too_many_vias_warning = z
+  .object({
+    type: z.literal("pcb_trace_too_many_vias_warning"),
+    pcb_trace_too_many_vias_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_trace_too_many_vias_warning",
+    ),
+    warning_type: z
+      .literal("pcb_trace_too_many_vias_warning")
+      .default("pcb_trace_too_many_vias_warning"),
+    message: z.string(),
+    pcb_trace_id: z.string(),
+    source_net_id: z.string().optional(),
+    source_trace_id: z.string().optional(),
+    actual_via_count: z.number().int().nonnegative(),
+    maximum_via_count: z.number().int().nonnegative(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Warning emitted when a PCB trace has more vias than its maximum allowed count",
+  )
+
+export type PcbTraceTooManyViasWarningInput = z.input<
+  typeof pcb_trace_too_many_vias_warning
+>
+type InferredPcbTraceTooManyViasWarning = z.infer<
+  typeof pcb_trace_too_many_vias_warning
+>
+
+/** Warning emitted when a PCB trace has more vias than its maximum allowed count */
+export interface PcbTraceTooManyViasWarning {
+  type: "pcb_trace_too_many_vias_warning"
+  pcb_trace_too_many_vias_warning_id: string
+  warning_type: "pcb_trace_too_many_vias_warning"
+  message: string
+  pcb_trace_id: string
+  source_net_id?: string
+  source_trace_id?: string
+  actual_via_count: number
+  maximum_via_count: number
+  subcircuit_id?: string
+}
+
+expectTypesMatch<
+  PcbTraceTooManyViasWarning,
+  InferredPcbTraceTooManyViasWarning
+>(true)

--- a/src/source/source_trace.ts
+++ b/src/source/source_trace.ts
@@ -9,6 +9,7 @@ export interface SourceTrace {
   subcircuit_id?: string
   subcircuit_connectivity_map_key?: string
   max_length?: number
+  max_via_count?: number
   name?: string
   display_name?: string
   min_trace_thickness?: number
@@ -22,6 +23,7 @@ export const source_trace = z.object({
   subcircuit_id: z.string().optional(),
   subcircuit_connectivity_map_key: z.string().optional(),
   max_length: z.number().optional(),
+  max_via_count: z.number().int().nonnegative().optional(),
   name: z.string().optional(),
   min_trace_thickness: z.number().optional(),
   display_name: z.string().optional(),

--- a/tests/pcb_trace_too_many_vias_warning.test.ts
+++ b/tests/pcb_trace_too_many_vias_warning.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "../src/any_circuit_element"
+import { pcb_trace_too_many_vias_warning } from "../src/pcb/pcb_trace_too_many_vias_warning"
+
+const warningInput = {
+  type: "pcb_trace_too_many_vias_warning" as const,
+  message: "PCB trace has 1 via, exceeding the maximum of 0",
+  pcb_trace_id: "pcb_trace_0",
+  source_trace_id: "source_trace_0",
+  actual_via_count: 1,
+  maximum_via_count: 0,
+}
+
+test("pcb_trace_too_many_vias_warning parses with a source trace", () => {
+  const warning = pcb_trace_too_many_vias_warning.parse(warningInput)
+
+  expect(warning.pcb_trace_too_many_vias_warning_id).toStartWith(
+    "pcb_trace_too_many_vias_warning",
+  )
+  expect(warning.warning_type).toBe("pcb_trace_too_many_vias_warning")
+  expect(warning.actual_via_count).toBe(1)
+  expect(warning.maximum_via_count).toBe(0)
+})
+
+test("pcb_trace_too_many_vias_warning parses with a source net", () => {
+  const { source_trace_id: _, ...warningWithoutSourceTrace } = warningInput
+  const warning = pcb_trace_too_many_vias_warning.parse({
+    ...warningWithoutSourceTrace,
+    source_net_id: "source_net_0",
+  })
+
+  expect(warning.source_net_id).toBe("source_net_0")
+  expect(warning.source_trace_id).toBeUndefined()
+})
+
+test("any_circuit_element includes pcb_trace_too_many_vias_warning", () => {
+  const parsed = any_circuit_element.parse(warningInput)
+
+  expect(parsed.type).toBe("pcb_trace_too_many_vias_warning")
+})

--- a/tests/source_trace_max_via_count.test.ts
+++ b/tests/source_trace_max_via_count.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { source_trace } from "../src/source/source_trace"
+
+const sourceTraceInput = {
+  type: "source_trace" as const,
+  source_trace_id: "source_trace_0",
+  connected_source_port_ids: ["source_port_0", "source_port_1"],
+  connected_source_net_ids: [],
+}
+
+test("source_trace accepts a nonnegative maximum via count", () => {
+  const trace = source_trace.parse({
+    ...sourceTraceInput,
+    max_via_count: 0,
+  })
+
+  expect(trace.max_via_count).toBe(0)
+})
+
+test("source_trace rejects a negative maximum via count", () => {
+  expect(() =>
+    source_trace.parse({
+      ...sourceTraceInput,
+      max_via_count: -1,
+    }),
+  ).toThrow()
+})


### PR DESCRIPTION
## What changed

- add optional `max_via_count` to the `source_trace` schema and TypeScript interface
- add the typed `pcb_trace_too_many_vias_warning` element with actual and maximum via counts
- export the warning through the PCB barrel, `PcbCircuitElement`, and `any_circuit_element`
- document both additions and add schema parsing coverage

## Why

`@tscircuit/props` already accepts `maxViaCount` on traces, but Circuit JSON had no field for preserving that constraint and no structured warning for reporting a routed trace that violates it. These schema additions allow `core` to emit the constraint and `checks` to report violations, including zero-via crystal routes.

## Validation

- `bun test` — 296 tests passed
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`
