### PR TITLE
Add schema for PCB components missing courtyard geometry

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -64,6 +64,7 @@ export const any_circuit_element = z.union([
   pcb.circuit_json_footprint_load_error,
   pcb.pcb_manual_edit_conflict_warning,
   pcb.pcb_connector_not_in_accessible_orientation_warning,
+  pcb.pcb_component_missing_courtyard_warning,
   pcb.supplier_footprint_mismatch_warning,
   pcb.pcb_plated_hole,
   pcb.pcb_keepout,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -59,6 +59,7 @@ export * from "./pcb_group"
 export * from "./pcb_autorouting_error"
 export * from "./pcb_manual_edit_conflict_warning"
 export * from "./pcb_connector_not_in_accessible_orientation_warning"
+export * from "./pcb_component_missing_courtyard_warning"
 export * from "./supplier_footprint_mismatch_warning"
 export * from "./pcb_breakout_point"
 export * from "./pcb_ground_plane"
@@ -104,6 +105,7 @@ import type { PcbMissingFootprintError } from "./pcb_missing_footprint_error"
 import type { ExternalFootprintLoadError } from "./external_footprint_load_error"
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
 import type { PcbConnectorNotInAccessibleOrientationWarning } from "./pcb_connector_not_in_accessible_orientation_warning"
+import type { PcbComponentMissingCourtyardWarning } from "./pcb_component_missing_courtyard_warning"
 import type { SupplierFootprintMismatchWarning } from "./supplier_footprint_mismatch_warning"
 import type { PcbTraceHint } from "./pcb_trace_hint"
 import type { PcbSilkscreenLine } from "./pcb_silkscreen_line"
@@ -163,6 +165,7 @@ export type PcbCircuitElement =
   | CircuitJsonFootprintLoadError
   | PcbManualEditConflictWarning
   | PcbConnectorNotInAccessibleOrientationWarning
+  | PcbComponentMissingCourtyardWarning
   | SupplierFootprintMismatchWarning
   | PcbPortNotMatchedError
   | PcbPortNotConnectedError

--- a/src/pcb/pcb_component_missing_courtyard_warning.ts
+++ b/src/pcb/pcb_component_missing_courtyard_warning.ts
@@ -1,0 +1,43 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_component_missing_courtyard_warning = z
+  .object({
+    type: z.literal("pcb_component_missing_courtyard_warning"),
+    pcb_component_missing_courtyard_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_component_missing_courtyard_warning",
+    ),
+    warning_type: z
+      .literal("pcb_component_missing_courtyard_warning")
+      .default("pcb_component_missing_courtyard_warning"),
+    message: z.string(),
+    pcb_component_id: z.string(),
+    source_component_id: z.string().optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe("Warning emitted when a PCB component has no courtyard geometry")
+
+export type PcbComponentMissingCourtyardWarningInput = z.input<
+  typeof pcb_component_missing_courtyard_warning
+>
+
+type InferredPcbComponentMissingCourtyardWarning = z.infer<
+  typeof pcb_component_missing_courtyard_warning
+>
+
+/** Warning emitted when a PCB component has no courtyard geometry */
+export interface PcbComponentMissingCourtyardWarning {
+  type: "pcb_component_missing_courtyard_warning"
+  pcb_component_missing_courtyard_warning_id: string
+  warning_type: "pcb_component_missing_courtyard_warning"
+  message: string
+  pcb_component_id: string
+  source_component_id?: string
+  subcircuit_id?: string
+}
+
+expectTypesMatch<
+  PcbComponentMissingCourtyardWarning,
+  InferredPcbComponentMissingCourtyardWarning
+>(true)

--- a/tests/pcb_component_missing_courtyard_warning.test.ts
+++ b/tests/pcb_component_missing_courtyard_warning.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "src/any_circuit_element"
+import { pcb_component_missing_courtyard_warning } from "src/pcb/pcb_component_missing_courtyard_warning"
+
+const warningInput = {
+  type: "pcb_component_missing_courtyard_warning" as const,
+  message: "U1 has no courtyard",
+  pcb_component_id: "pcb_component_1",
+  source_component_id: "source_component_1",
+  subcircuit_id: "subcircuit_1",
+}
+
+test("pcb_component_missing_courtyard_warning parses", () => {
+  const warning = pcb_component_missing_courtyard_warning.parse(warningInput)
+
+  expect(warning.pcb_component_missing_courtyard_warning_id).toStartWith(
+    "pcb_component_missing_courtyard_warning",
+  )
+  expect(warning.warning_type).toBe("pcb_component_missing_courtyard_warning")
+  expect(warning.pcb_component_id).toBe("pcb_component_1")
+  expect(warning.source_component_id).toBe("source_component_1")
+  expect(warning.subcircuit_id).toBe("subcircuit_1")
+})
+
+test("any_circuit_element includes pcb_component_missing_courtyard_warning", () => {
+  const warning = any_circuit_element.parse(warningInput)
+
+  expect(warning.type).toBe("pcb_component_missing_courtyard_warning")
+})


### PR DESCRIPTION
## Summary

- add a dedicated `pcb_component_missing_courtyard_warning` schema
- export input and output TypeScript types
- include the warning in `PcbCircuitElement` and `AnyCircuitElement`
- add parser and union regression coverage

## Why

Placement validation needs a schema-backed warning when a PCB component has no courtyard geometry. Without this element in circuit-json, downstream checks cannot emit the warning while preserving circuit-json validation and type safety.

## Developer impact

Consumers can now emit, parse, and narrow missing-courtyard warnings through the standard circuit-json unions.

## Validation

- `bun test` — 298 passed
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`