### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -7,6 +7,11 @@ on:
       - '!version-bumps/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPOS: "" # comma-separated list, e.g. "eval,tscircuit,docs"
   UPSTREAM_PACKAGES_TO_UPDATE: "" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/protos"
@@ -20,16 +25,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release --no-push-main
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
       - name: Get package version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "circuit-json",
   "version": "0.0.469",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/circuit-json.git"
+  },
   "author": "",
   "main": "dist/index.mjs",
   "devDependencies": {


### PR DESCRIPTION
## Summary

- grant GitHub Actions OIDC permission for npm trusted publishing
- remove the legacy npm token from the release step
- use Node 24 with actions/setup-node v6
- add explicit repository metadata where missing

## Validation

- parsed the release workflow as YAML
- parsed package.json
- ran git diff --check
- confirmed the release workflow no longer references NPM_TOKEN
