### PR TITLE
Represent PCB path arcs with bulges

### DIFF
--- a/src/pcb/pcb_courtyard_outline.ts
+++ b/src/pcb/pcb_courtyard_outline.ts
@@ -1,8 +1,8 @@
-import { z } from "zod"
-import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
-import { visible_layer, type VisibleLayer } from "src/pcb/properties/layer_ref"
-import { length, type Length } from "src/units"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { type PointWithBulge, point_with_bulge } from "src/pcb/properties/brep"
+import { type VisibleLayer, visible_layer } from "src/pcb/properties/layer_ref"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_courtyard_outline = z
   .object({
@@ -14,7 +14,7 @@ export const pcb_courtyard_outline = z
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
     layer: visible_layer,
-    outline: z.array(point).min(2),
+    outline: z.array(point_with_bulge).min(2),
   })
   .describe("Defines a courtyard outline on the PCB")
 
@@ -31,7 +31,7 @@ export interface PcbCourtyardOutline {
   pcb_group_id?: string
   subcircuit_id?: string
   layer: VisibleLayer
-  outline: Point[]
+  outline: PointWithBulge[]
 }
 
 /**

--- a/src/pcb/pcb_fabrication_note_path.ts
+++ b/src/pcb/pcb_fabrication_note_path.ts
@@ -1,13 +1,13 @@
-import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
+import { type PointWithBulge, point_with_bulge } from "src/pcb/properties/brep"
 import {
+  type LayerRef,
   layer_ref,
   visible_layer,
-  type LayerRef,
 } from "src/pcb/properties/layer_ref"
-import { point, type Point } from "src/common"
-import { length, type Length } from "src/units"
+import { type Length, length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_fabrication_note_path = z
   .object({
@@ -18,7 +18,7 @@ export const pcb_fabrication_note_path = z
     pcb_component_id: z.string(),
     subcircuit_id: z.string().optional(),
     layer: layer_ref,
-    route: z.array(point),
+    route: z.array(point_with_bulge),
     stroke_width: length,
     color: z.string().optional(),
   })
@@ -40,7 +40,7 @@ export interface PcbFabricationNotePath {
   pcb_component_id: string
   subcircuit_id?: string
   layer: LayerRef
-  route: Point[]
+  route: PointWithBulge[]
   stroke_width: Length
   color?: string
 }

--- a/src/pcb/pcb_note_path.ts
+++ b/src/pcb/pcb_note_path.ts
@@ -1,8 +1,9 @@
-import { z } from "zod"
-import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
-import { visible_layer, type VisibleLayer } from "src/pcb/properties/layer_ref"
-import { length, type Length } from "src/units"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { type PointWithBulge, point_with_bulge } from "src/pcb/properties/brep"
+import { type VisibleLayer, visible_layer } from "src/pcb/properties/layer_ref"
+import { type Length, length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_note_path = z
   .object({
@@ -13,7 +14,7 @@ export const pcb_note_path = z
     subcircuit_id: z.string().optional(),
     name: z.string().optional(),
     text: z.string().optional(),
-    route: z.array(point),
+    route: z.array(point_with_bulge),
     layer: visible_layer.default("top"),
     stroke_width: length.default("0.1mm"),
     color: z.string().optional(),
@@ -34,7 +35,7 @@ export interface PcbNotePath {
   subcircuit_id?: string
   name?: string
   text?: string
-  route: Point[]
+  route: PointWithBulge[]
   layer: VisibleLayer
   stroke_width: Length
   color?: string

--- a/src/pcb/pcb_silkscreen_path.ts
+++ b/src/pcb/pcb_silkscreen_path.ts
@@ -1,11 +1,12 @@
-import { z } from "zod"
-import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { type PointWithBulge, point_with_bulge } from "src/pcb/properties/brep"
 import {
-  visible_layer,
   type VisibleLayerRef,
+  visible_layer,
 } from "src/pcb/properties/layer_ref"
-import { length, type Length } from "src/units"
+import { type Length, length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_silkscreen_path = z
   .object({
@@ -15,7 +16,7 @@ export const pcb_silkscreen_path = z
     pcb_group_id: z.string().optional(),
     subcircuit_id: z.string().optional(),
     layer: visible_layer,
-    route: z.array(point),
+    route: z.array(point_with_bulge),
     stroke_width: length,
   })
   .describe("Defines a silkscreen path on the PCB")
@@ -33,7 +34,8 @@ export interface PcbSilkscreenPath {
   pcb_group_id?: string
   subcircuit_id?: string
   layer: VisibleLayerRef
-  route: Point[]
+  /** Each bulge describes the circular arc from that point to the next. */
+  route: PointWithBulge[]
   stroke_width: Length
 }
 

--- a/src/pcb/pcb_trace.ts
+++ b/src/pcb/pcb_trace.ts
@@ -1,13 +1,14 @@
-import { z } from "zod"
-import { getZodPrefixedIdWithDefault, point, type Point } from "src/common"
-import { distance, type Distance } from "src/units"
-import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
+import { type Point, getZodPrefixedIdWithDefault, point } from "src/common"
+import { type LayerRef, layer_ref } from "src/pcb/properties/layer_ref"
+import { type Distance, distance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_trace_route_point_wire = z.object({
   route_type: z.literal("wire"),
   x: distance,
   y: distance,
+  bulge: z.number().optional(),
   width: distance,
   copper_pour_id: z.string().optional(),
   is_inside_copper_pour: z.boolean().optional(),
@@ -73,6 +74,11 @@ export interface PcbTraceRoutePointWire {
   route_type: "wire"
   x: Distance
   y: Distance
+  /**
+   * tan(ccw_sweep_radians / 4) for the circular arc from this route point to
+   * the next route point. Omit for a straight segment.
+   */
+  bulge?: number
   width: Distance
   copper_pour_id?: string
   is_inside_copper_pour?: boolean

--- a/src/pcb/properties/brep.ts
+++ b/src/pcb/properties/brep.ts
@@ -1,6 +1,6 @@
-import { z } from "zod"
-import { distance, type Distance } from "src/units"
+import { type Distance, distance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const point_with_bulge = z.object({
   x: distance,
@@ -11,6 +11,10 @@ export const point_with_bulge = z.object({
 export interface PointWithBulge {
   x: Distance
   y: Distance
+  /**
+   * tan(ccw_sweep_radians / 4) for the circular arc from this point to the
+   * next point. Omit for a straight segment.
+   */
   bulge?: number
 }
 type InferredPointWithBulge = z.infer<typeof point_with_bulge>

--- a/tests/pcb-courtyard-outline-arc-bulge.test.ts
+++ b/tests/pcb-courtyard-outline-arc-bulge.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { pcb_courtyard_outline } from "../src/pcb/pcb_courtyard_outline"
+
+test("parses an arc bulge on a PCB courtyard outline", () => {
+  const outline = pcb_courtyard_outline.parse({
+    type: "pcb_courtyard_outline",
+    pcb_courtyard_outline_id: "pcb_courtyard_outline_arc",
+    pcb_component_id: "pcb_component_1",
+    layer: "top",
+    outline: [
+      { x: 0, y: 0, bulge: 1 },
+      { x: 2, y: 0 },
+    ],
+  })
+
+  expect(outline.outline[0]?.bulge).toBe(1)
+})

--- a/tests/pcb-fabrication-note-path-arc-bulge.test.ts
+++ b/tests/pcb-fabrication-note-path-arc-bulge.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { pcb_fabrication_note_path } from "../src/pcb/pcb_fabrication_note_path"
+
+test("parses an arc bulge on a PCB fabrication note path", () => {
+  const path = pcb_fabrication_note_path.parse({
+    type: "pcb_fabrication_note_path",
+    pcb_fabrication_note_path_id: "pcb_fabrication_note_path_arc",
+    pcb_component_id: "pcb_component_1",
+    layer: "top",
+    route: [
+      { x: 0, y: 0, bulge: -0.41421356237309503 },
+      { x: 1, y: -1 },
+    ],
+    stroke_width: 0.1,
+  })
+
+  expect(path.route[0]?.bulge).toBe(-0.41421356237309503)
+})

--- a/tests/pcb-note-path-arc-bulge.test.ts
+++ b/tests/pcb-note-path-arc-bulge.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { pcb_note_path } from "../src/pcb/pcb_note_path"
+
+test("parses an arc bulge on a PCB note path", () => {
+  const path = pcb_note_path.parse({
+    type: "pcb_note_path",
+    pcb_note_path_id: "pcb_note_path_arc",
+    route: [
+      { x: 0, y: 0, bulge: 0.41421356237309503 },
+      { x: 1, y: 1 },
+    ],
+  })
+
+  expect(path.route[0]?.bulge).toBe(0.41421356237309503)
+})

--- a/tests/pcb-silkscreen-path-arc-bulge.test.ts
+++ b/tests/pcb-silkscreen-path-arc-bulge.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { pcb_silkscreen_path } from "../src/pcb/pcb_silkscreen_path"
+
+test("preserves circular arc bulges on PCB silkscreen paths", () => {
+  const path = pcb_silkscreen_path.parse({
+    type: "pcb_silkscreen_path",
+    pcb_silkscreen_path_id: "pcb_silkscreen_path_arc",
+    pcb_component_id: "pcb_component_1",
+    layer: "top",
+    route: [
+      { x: 0, y: 0, bulge: -1 },
+      { x: 4, y: 0 },
+    ],
+    stroke_width: 0.15,
+  })
+
+  expect(path.route[0]?.bulge).toBe(-1)
+})

--- a/tests/pcb-trace-arc-bulge.test.ts
+++ b/tests/pcb-trace-arc-bulge.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { pcb_trace } from "../src/pcb/pcb_trace"
+
+test("preserves circular arc bulges on PCB trace routes", () => {
+  const trace = pcb_trace.parse({
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_arc",
+    route: [
+      {
+        route_type: "wire",
+        x: 0,
+        y: 0,
+        bulge: Math.tan(Math.PI / 8),
+        width: 0.2,
+        layer: "top",
+      },
+      {
+        route_type: "wire",
+        x: 2,
+        y: 2,
+        width: 0.2,
+        layer: "top",
+      },
+    ],
+  })
+  const arcStart = trace.route[0]
+
+  expect(arcStart?.route_type).toBe("wire")
+  if (!arcStart || arcStart.route_type !== "wire") {
+    throw new Error("Expected the trace to start with a wire route point")
+  }
+  expect(arcStart.bulge).toBeCloseTo(Math.tan(Math.PI / 8))
+})


### PR DESCRIPTION
## Why

Circuit JSON path points had no way to say that the segment to the next point is curved. Converters therefore had to replace a native CAD arc with many short straight segments, losing the original arc.

## What changed

- add an optional `bulge` to PCB path points and PCB trace wire points
- define `bulge` as `tan(signed sweep angle / 4)`, which preserves clockwise/counterclockwise and minor/major arcs using the existing two endpoints
- reuse the shared point-with-bulge schema for silkscreen, note, fabrication-note, and courtyard paths
- keep each affected schema test in its own file

## Verification

- `bun test` — 313 passed
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`
- Biome check on every changed file
