### PR TITLE
test: reproduce dropped customer-supplied intent

### DIFF
--- a/tests/source_component_customer_supplied.test.ts
+++ b/tests/source_component_customer_supplied.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { source_component_base } from "../src/source/base/source_component_base"
+
+test.failing("source components preserve customer-supplied assembly intent", () => {
+  const sourceComponent = source_component_base.parse({
+    type: "source_component",
+    source_component_id: "source_component_module",
+    name: "U1",
+    manufacturer_part_number: "OSM-S-AM62L",
+    customer_supplied: true,
+  })
+
+  expect(sourceComponent).toHaveProperty("customer_supplied", true)
+})


### PR DESCRIPTION
## Summary

- add the smallest schema-level reproduction for a non-catalog assembly component
- use the Kontron OSM-S-AM62L module as the concrete manufacturer-part-number example
- record the intended `customer_supplied` flag without changing the schema

## Current behavior

Zod accepts the source component object but silently strips `customer_supplied`. Downstream BOM and assembly exporters therefore cannot distinguish a customer-supplied module from a part expected to exist in the assembly supplier's catalog.

The `test.failing` assertion makes that data loss explicit. This is separate from `do_not_place`: a customer-supplied component may still need placement and must remain in the engineering BOM.

## Validation

- `bun test ./tests/source_component_customer_supplied.test.ts`
- current schema reproduces the expected failure and Bun reports the `test.failing` case as passing
