### PR TITLE
Preserve customer-supplied component intent

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "keywords": [],
   "license": "ISC",
   "scripts": {
-    "prepare": "bun --cwd \"${npm_package_json%/package.json}\" run build",
     "prepublish": "npm run build",
     "build": "tsup-node ./src/index.ts --format esm --dts --sourcemap",
     "format": "biome format . --write",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "keywords": [],
   "license": "ISC",
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "tsup-node ./src/index.ts --format esm --dts --sourcemap --tsconfig ./tsconfig.json",
     "prepublish": "npm run build",
     "build": "tsup-node ./src/index.ts --format esm --dts --sourcemap",
     "format": "biome format . --write",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "keywords": [],
   "license": "ISC",
   "scripts": {
-    "prepare": "tsup-node ./src/index.ts --format esm --dts --sourcemap --tsconfig ./tsconfig.json",
+    "prepare": "bun --cwd \"${npm_package_json%/package.json}\" run build",
     "prepublish": "npm run build",
     "build": "tsup-node ./src/index.ts --format esm --dts --sourcemap",
     "format": "biome format . --write",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "keywords": [],
   "license": "ISC",
   "scripts": {
+    "prepare": "npm run build",
     "prepublish": "npm run build",
     "build": "tsup-node ./src/index.ts --format esm --dts --sourcemap",
     "format": "biome format . --write",

--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -12,6 +12,8 @@ export interface SourceComponentBase {
   name: string
   manufacturer_part_number?: string
   supplier_part_numbers?: Partial<Record<SupplierName, string[]>>
+  /** The assembly part is supplied outside the selected supplier catalog. */
+  customer_supplied?: boolean
   display_value?: string
   display_name?: string
   are_pins_interchangeable?: boolean
@@ -29,6 +31,7 @@ export const source_component_base = z.object({
   supplier_part_numbers: z
     .record(supplier_name, z.array(z.string()))
     .optional(),
+  customer_supplied: z.boolean().optional(),
   display_value: z.string().optional(),
   display_name: z.string().optional(),
   are_pins_interchangeable: z.boolean().optional(),

--- a/tests/source_component_customer_supplied.test.ts
+++ b/tests/source_component_customer_supplied.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { source_component_base } from "../src/source/base/source_component_base"
 
-test.failing("source components preserve customer-supplied assembly intent", () => {
+test("source components preserve customer-supplied assembly intent", () => {
   const sourceComponent = source_component_base.parse({
     type: "source_component",
     source_component_id: "source_component_module",


### PR DESCRIPTION
## Summary

- add optional `customer_supplied` assembly intent to `SourceComponentBase`
- preserve the field through the shared Zod schema
- convert the stacked expected-failure test into a normal regression

## Stack

Depends on #712, which demonstrates that the current schema silently drops the field.

## Semantics

`customer_supplied` describes sourcing, not placement. It is intentionally distinct from `pcb_component.do_not_place`: exporters can retain the module in engineering/assembly BOMs while avoiding the false claim that it is an ordinary catalog-selected part.

## Validation

- focused schema regression
- Zod lint
- snake-case audit
- package build and declaration generation
- `git diff --check`
