### PR TITLE
Reproduce missing fabrication-process warning schema

### DIFF
--- a/tests/pcb_fabrication_process_warning.test.ts
+++ b/tests/pcb_fabrication_process_warning.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "src/any_circuit_element"
+
+const osmFinePitchWarningInput = {
+  type: "pcb_fabrication_process_warning",
+  warning_type: "pcb_fabrication_process_warning",
+  message:
+    "U1 uses a 0.5 mm land array that needs laser microvias or via-in-pad review",
+  pcb_component_id: "pcb_component_1",
+  source_component_id: "source_component_1",
+  pcb_board_id: "pcb_board_1",
+  land_pitch: 0.5,
+  required_process: "laser_microvia_or_via_in_pad",
+  manufacturer: "jlcpcb",
+  reference_url: "https://jlcpcb.com/blog/effective-escape-routing-strategies",
+}
+
+test.failing(
+  "any_circuit_element represents a fine-pitch fabrication-process warning",
+  () => {
+    const warning = any_circuit_element.parse(osmFinePitchWarningInput)
+
+    expect(warning.type).toBe("pcb_fabrication_process_warning")
+  },
+)

--- a/tests/pcb_fabrication_process_warning.test.ts
+++ b/tests/pcb_fabrication_process_warning.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test"
+import { test } from "bun:test"
 import { any_circuit_element } from "src/any_circuit_element"
 
 const osmFinePitchWarningInput = {
@@ -18,8 +18,6 @@ const osmFinePitchWarningInput = {
 test.failing(
   "any_circuit_element represents a fine-pitch fabrication-process warning",
   () => {
-    const warning = any_circuit_element.parse(osmFinePitchWarningInput)
-
-    expect(warning.type).toBe("pcb_fabrication_process_warning")
+    any_circuit_element.parse(osmFinePitchWarningInput)
   },
 )


### PR DESCRIPTION
## Reproduction

A realistic 0.5 mm OSM land array can satisfy generic copper-clearance rules while still requiring laser-microvia or via-in-pad process review. Circuit JSON currently has no typed diagnostic that can preserve that distinction.

The expected-failure test tries to parse a `pcb_fabrication_process_warning` carrying the component, board, measured pitch, required process, manufacturer, and the manufacturing reference. `any_circuit_element` rejects it on `main`.

This is intentionally a reproduction-only PR. The child PR adds the schema.

## Validation

- focused expected-failure test
- snake-case schema check
- Zod lint
- diff check

## Reference

JLCPCB documents that conventional 0.2 mm mechanical vias reach about 0.8 mm BGA pitch, while denser arrays need laser microvias and/or via-in-pad: https://jlcpcb.com/blog/effective-escape-routing-strategies