### PR TITLE
Add PCB fabrication-process warning schema

### DIFF
--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -65,6 +65,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_manual_edit_conflict_warning,
   pcb.pcb_connector_not_in_accessible_orientation_warning,
   pcb.pcb_component_missing_courtyard_warning,
+  pcb.pcb_fabrication_process_warning,
   pcb.supplier_footprint_mismatch_warning,
   pcb.pcb_plated_hole,
   pcb.pcb_keepout,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -60,6 +60,7 @@ export * from "./pcb_autorouting_error"
 export * from "./pcb_manual_edit_conflict_warning"
 export * from "./pcb_connector_not_in_accessible_orientation_warning"
 export * from "./pcb_component_missing_courtyard_warning"
+export * from "./pcb_fabrication_process_warning"
 export * from "./supplier_footprint_mismatch_warning"
 export * from "./pcb_breakout_point"
 export * from "./pcb_ground_plane"
@@ -106,6 +107,7 @@ import type { ExternalFootprintLoadError } from "./external_footprint_load_error
 import type { PcbManualEditConflictWarning } from "./pcb_manual_edit_conflict_warning"
 import type { PcbConnectorNotInAccessibleOrientationWarning } from "./pcb_connector_not_in_accessible_orientation_warning"
 import type { PcbComponentMissingCourtyardWarning } from "./pcb_component_missing_courtyard_warning"
+import type { PcbFabricationProcessWarning } from "./pcb_fabrication_process_warning"
 import type { SupplierFootprintMismatchWarning } from "./supplier_footprint_mismatch_warning"
 import type { PcbTraceHint } from "./pcb_trace_hint"
 import type { PcbSilkscreenLine } from "./pcb_silkscreen_line"
@@ -166,6 +168,7 @@ export type PcbCircuitElement =
   | PcbManualEditConflictWarning
   | PcbConnectorNotInAccessibleOrientationWarning
   | PcbComponentMissingCourtyardWarning
+  | PcbFabricationProcessWarning
   | SupplierFootprintMismatchWarning
   | PcbPortNotMatchedError
   | PcbPortNotConnectedError

--- a/src/pcb/pcb_fabrication_process_warning.ts
+++ b/src/pcb/pcb_fabrication_process_warning.ts
@@ -1,0 +1,55 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_fabrication_process_warning = z
+  .object({
+    type: z.literal("pcb_fabrication_process_warning"),
+    pcb_fabrication_process_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_fabrication_process_warning",
+    ),
+    warning_type: z
+      .literal("pcb_fabrication_process_warning")
+      .default("pcb_fabrication_process_warning"),
+    message: z.string(),
+    pcb_component_id: z.string(),
+    source_component_id: z.string().optional(),
+    pcb_board_id: z.string().optional(),
+    land_pitch: z.number().positive(),
+    required_process: z.string(),
+    manufacturer: z.string(),
+    reference_url: z.string().url().optional(),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Warning emitted when a PCB component needs a fabrication process that generic geometry checks do not qualify",
+  )
+
+export type PcbFabricationProcessWarningInput = z.input<
+  typeof pcb_fabrication_process_warning
+>
+
+type InferredPcbFabricationProcessWarning = z.infer<
+  typeof pcb_fabrication_process_warning
+>
+
+/** Warning emitted when a component requires process-specific fabrication review */
+export interface PcbFabricationProcessWarning {
+  type: "pcb_fabrication_process_warning"
+  pcb_fabrication_process_warning_id: string
+  warning_type: "pcb_fabrication_process_warning"
+  message: string
+  pcb_component_id: string
+  source_component_id?: string
+  pcb_board_id?: string
+  land_pitch: number
+  required_process: string
+  manufacturer: string
+  reference_url?: string
+  subcircuit_id?: string
+}
+
+expectTypesMatch<
+  PcbFabricationProcessWarning,
+  InferredPcbFabricationProcessWarning
+>(true)

--- a/tests/pcb_fabrication_process_warning.test.ts
+++ b/tests/pcb_fabrication_process_warning.test.ts
@@ -1,4 +1,4 @@
-import { test } from "bun:test"
+import { expect, test } from "bun:test"
 import { any_circuit_element } from "src/any_circuit_element"
 
 const osmFinePitchWarningInput = {
@@ -15,9 +15,16 @@ const osmFinePitchWarningInput = {
   reference_url: "https://jlcpcb.com/blog/effective-escape-routing-strategies",
 }
 
-test.failing(
-  "any_circuit_element represents a fine-pitch fabrication-process warning",
-  () => {
-    any_circuit_element.parse(osmFinePitchWarningInput)
-  },
-)
+test("any_circuit_element represents a fine-pitch fabrication-process warning", () => {
+  const warning = any_circuit_element.parse(osmFinePitchWarningInput)
+
+  expect(warning.type).toBe("pcb_fabrication_process_warning")
+  if (warning.type !== "pcb_fabrication_process_warning") return
+
+  expect(warning.pcb_fabrication_process_warning_id).toStartWith(
+    "pcb_fabrication_process_warning",
+  )
+  expect(warning.land_pitch).toBe(0.5)
+  expect(warning.required_process).toBe("laser_microvia_or_via_in_pad")
+  expect(warning.manufacturer).toBe("jlcpcb")
+})


### PR DESCRIPTION
## Summary

- add a typed `pcb_fabrication_process_warning` Circuit JSON element
- retain the affected component and board, measured land pitch, required process, fabricator, and authoritative reference URL
- include the warning in `any_circuit_element` and `PcbCircuitElement`
- turn the 0.5 mm OSM expected failure into a regression test

## Stack

Depends on #714.

## Validation

- focused schema test
- snake-case schema check
- Zod lint
- package build
- diff check