### PR TITLE
Add PCB debug object schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbCourtyardPolygon](#pcbcourtyardpolygon)
     - [PcbCourtyardRect](#pcbcourtyardrect)
     - [PcbCutout](#pcbcutout)
+    - [PcbDebugObject](#pcbdebugobject)
     - [PcbFabricationNoteDimension](#pcbfabricationnotedimension)
     - [PcbFabricationNotePath](#pcbfabricationnotepath)
     - [PcbFabricationNoteRect](#pcbfabricationnoterect)
@@ -1685,6 +1686,43 @@ interface PcbCutoutRect {
   height: Length
   rotation?: Rotation
   corner_radius?: Length
+}
+```
+
+### PcbDebugObject
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_debug_object.ts)
+
+```typescript
+type PcbDebugObject = PcbDebugRect | PcbDebugLine | PcbDebugPoint
+
+interface PcbDebugRect {
+  type: "pcb_debug_object"
+  pcb_debug_object_id: string
+  label?: string
+  shape: "rect"
+  center: Point
+  size: Size
+  subcircuit_id?: string
+}
+
+interface PcbDebugLine {
+  type: "pcb_debug_object"
+  pcb_debug_object_id: string
+  label?: string
+  shape: "line"
+  start: Point
+  end: Point
+  subcircuit_id?: string
+}
+
+interface PcbDebugPoint {
+  type: "pcb_debug_object"
+  pcb_debug_object_id: string
+  label?: string
+  shape: "point"
+  center: Point
+  subcircuit_id?: string
 }
 ```
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -58,6 +58,7 @@ export const any_circuit_element = z.union([
   src.source_component_misconfigured_error,
   src.source_ambiguous_port_reference,
   pcb.pcb_component,
+  pcb.pcb_debug_object,
   pcb.pcb_hole,
   pcb.pcb_missing_footprint_error,
   pcb.external_footprint_load_error,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -8,6 +8,7 @@ export * from "./properties/route_hint_point"
 export * from "./properties/manufacturing_drc_properties"
 
 export * from "./pcb_component"
+export * from "./pcb_debug_object"
 export * from "./pcb_hole"
 export * from "./pcb_plated_hole"
 export * from "./pcb_port"
@@ -80,6 +81,7 @@ export * from "./pcb_courtyard_circle"
 export * from "./pcb_courtyard_pill"
 
 import type { PcbComponent } from "./pcb_component"
+import type { PcbDebugObject } from "./pcb_debug_object"
 import type { PcbHole } from "./pcb_hole"
 import type { PcbPlatedHole } from "./pcb_plated_hole"
 import type { PcbPort } from "./pcb_port"
@@ -148,6 +150,7 @@ import type { PcbCourtyardPill } from "./pcb_courtyard_pill"
 
 export type PcbCircuitElement =
   | PcbComponent
+  | PcbDebugObject
   | PcbHole
   | PcbPlatedHole
   | PcbPort

--- a/src/pcb/pcb_debug_object.ts
+++ b/src/pcb/pcb_debug_object.ts
@@ -1,0 +1,74 @@
+import { z } from "zod"
+import {
+  getZodPrefixedIdWithDefault,
+  point,
+  type Point,
+  size,
+  type Size,
+} from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_debug_object_base = z.object({
+  type: z.literal("pcb_debug_object"),
+  pcb_debug_object_id: getZodPrefixedIdWithDefault("pcb_debug_object"),
+  label: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+})
+
+export const pcb_debug_rect = pcb_debug_object_base.extend({
+  shape: z.literal("rect"),
+  center: point,
+  size: size,
+})
+
+export const pcb_debug_line = pcb_debug_object_base.extend({
+  shape: z.literal("line"),
+  start: point,
+  end: point,
+})
+
+export const pcb_debug_point = pcb_debug_object_base.extend({
+  shape: z.literal("point"),
+  center: point,
+})
+
+export const pcb_debug_object = z.discriminatedUnion("shape", [
+  pcb_debug_rect,
+  pcb_debug_line,
+  pcb_debug_point,
+])
+type InferredPcbDebugObject = z.infer<typeof pcb_debug_object>
+
+export interface PcbDebugRect {
+  type: "pcb_debug_object"
+  pcb_debug_object_id: string
+  label?: string
+  shape: "rect"
+  center: Point
+  size: Size
+  subcircuit_id?: string
+}
+
+export interface PcbDebugLine {
+  type: "pcb_debug_object"
+  pcb_debug_object_id: string
+  label?: string
+  shape: "line"
+  start: Point
+  end: Point
+  subcircuit_id?: string
+}
+
+export interface PcbDebugPoint {
+  type: "pcb_debug_object"
+  pcb_debug_object_id: string
+  label?: string
+  shape: "point"
+  center: Point
+  subcircuit_id?: string
+}
+
+export type PcbDebugObject = PcbDebugRect | PcbDebugLine | PcbDebugPoint
+
+expectTypesMatch<PcbDebugObject, InferredPcbDebugObject>(true)
+export type PcbDebugObjectInput = z.input<typeof pcb_debug_object>

--- a/tests/pcb_debug_object.test.ts
+++ b/tests/pcb_debug_object.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "src/any_circuit_element"
+import {
+  pcb_debug_line,
+  pcb_debug_object,
+  pcb_debug_point,
+  pcb_debug_rect,
+} from "src/pcb/pcb_debug_object"
+
+test("parses a PCB debug rectangle", () => {
+  const rect = pcb_debug_rect.parse({
+    type: "pcb_debug_object",
+    shape: "rect",
+    center: { x: 1, y: 2 },
+    size: { width: 3, height: 4 },
+    label: "component bounds",
+    subcircuit_id: "subcircuit_1",
+  })
+
+  expect(rect.pcb_debug_object_id).toStartWith("pcb_debug_object")
+  expect(rect.center).toEqual({ x: 1, y: 2 })
+  expect(rect.size).toEqual({ width: 3, height: 4 })
+  expect(rect.label).toBe("component bounds")
+  expect(rect.subcircuit_id).toBe("subcircuit_1")
+})
+
+test("parses a PCB debug line", () => {
+  const line = pcb_debug_line.parse({
+    type: "pcb_debug_object",
+    shape: "line",
+    start: { x: 1, y: 2 },
+    end: { x: 3, y: 4 },
+  })
+
+  expect(line.start).toEqual({ x: 1, y: 2 })
+  expect(line.end).toEqual({ x: 3, y: 4 })
+})
+
+test("parses a PCB debug point", () => {
+  const point = pcb_debug_point.parse({
+    type: "pcb_debug_object",
+    shape: "point",
+    center: { x: 1, y: 2 },
+  })
+
+  expect(point.center).toEqual({ x: 1, y: 2 })
+})
+
+test("pcb_debug_object rejects unsupported shapes", () => {
+  const result = pcb_debug_object.safeParse({
+    type: "pcb_debug_object",
+    shape: "circle",
+    center: { x: 1, y: 2 },
+  })
+
+  expect(result.success).toBe(false)
+})
+
+test("any_circuit_element includes pcb_debug_object", () => {
+  const parsed = any_circuit_element.parse({
+    type: "pcb_debug_object",
+    shape: "point",
+    center: { x: 1, y: 2 },
+  })
+
+  expect(parsed.type).toBe("pcb_debug_object")
+})


### PR DESCRIPTION
## Summary

- add `pcb_debug_object` with rect, line, and point variants matching `schematic_debug_object`
- generate `pcb_debug_object_id` values to satisfy the Circuit JSON element ID invariant
- export the schema and types through PCB and generic circuit-element unions
- document and test all supported variants

## Validation

- `bun test`
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- `git diff --check`