### PR TITLE
feat: add blind and buried via board field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,8 @@ interface PcbBoard extends ManufacturingDrcProperties {
   display_offset_y?: string
   thickness: Length
   num_layers: number
+  /** Whether autorouters may generate blind and buried vias. */
+  allow_blind_and_buried_vias?: boolean
   center: Point
   outline?: Point[]
   shape?: "rect" | "polygon"

--- a/src/pcb/pcb_board.ts
+++ b/src/pcb/pcb_board.ts
@@ -1,17 +1,17 @@
-import { z } from "zod"
 import {
-  point,
+  type NinePointAnchor,
   type Point,
   getZodPrefixedIdWithDefault,
   ninePointAnchor,
-  type NinePointAnchor,
+  point,
 } from "src/common"
-import { length, type Length } from "src/units"
-import { expectTypesMatch } from "src/utils/expect-types-match"
 import {
-  manufacturing_drc_properties,
   type ManufacturingDrcProperties,
+  manufacturing_drc_properties,
 } from "src/pcb/properties/manufacturing_drc_properties"
+import { type Length, length } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_board = z
   .object({
@@ -40,6 +40,12 @@ export const pcb_board = z
       ),
     thickness: length.optional().default(1.4),
     num_layers: z.number().optional().default(4),
+    allow_blind_and_buried_vias: z
+      .boolean()
+      .optional()
+      .describe(
+        "Whether autorouters may generate blind and buried vias. False restricts newly generated vias to the full board stack.",
+      ),
     outline: z.array(point).optional(),
     shape: z.enum(["rect", "polygon"]).optional(),
     material: z.enum(["fr4", "fr1"]).default("fr4"),
@@ -70,6 +76,8 @@ export interface PcbBoard extends ManufacturingDrcProperties {
   display_offset_y?: string
   thickness: Length
   num_layers: number
+  /** Whether autorouters may generate blind and buried vias. */
+  allow_blind_and_buried_vias?: boolean
   center: Point
   outline?: Point[]
   shape?: "rect" | "polygon"

--- a/tests/pcb-board-allow-blind-and-buried-vias-optional.test.ts
+++ b/tests/pcb-board-allow-blind-and-buried-vias-optional.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { pcb_board } from "../src/pcb/pcb_board"
+
+test("pcb_board keeps the blind and buried via flag optional", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    center: { x: 0, y: 0 },
+  })
+
+  expect(board.allow_blind_and_buried_vias).toBeUndefined()
+})

--- a/tests/pcb-board-allow-blind-and-buried-vias.test.ts
+++ b/tests/pcb-board-allow-blind-and-buried-vias.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { pcb_board } from "../src/pcb/pcb_board"
+
+test("pcb_board parses the blind and buried via flag", () => {
+  const board = pcb_board.parse({
+    type: "pcb_board",
+    width: "10mm",
+    height: "20mm",
+    center: { x: 0, y: 0 },
+    num_layers: 4,
+    allow_blind_and_buried_vias: true,
+  })
+
+  expect(board.allow_blind_and_buried_vias).toBe(true)
+})


### PR DESCRIPTION
## Summary

- add optional `pcb_board.allow_blind_and_buried_vias` transport
- document the field in the generated Circuit JSON reference
- cover both explicit opt-in and omitted compatibility behavior

## Contract

The Circuit JSON field remains optional so existing authored JSON keeps parsing unchanged. Core emits an explicit `false` for an actual `<board>` unless the board opts in, then translates the snake-case field to the autorouter's camel-case `allowBlindAndBuriedVias` input.

The field governs newly generated or replaced vias. Existing authored partial-depth vias remain unchanged.

## Cross-repository stack

- public board prop: [tscircuit/props#808](https://github.com/tscircuit/props/pull/808)
- core propagation and defaulting: [tscircuit/core#3374](https://github.com/tscircuit/core/pull/3374)
- autorouter enforcement: [tscircuit/tscircuit-autorouter#2200](https://github.com/tscircuit/tscircuit-autorouter/pull/2200)

## Validation

- `bun test` — 305 pass, 0 fail
- focused schema tests — 2 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`
- changed-file Biome check

