### PR TITLE
Add layer to pcb breakout points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,7 @@ interface PcbBreakoutPoint {
   source_trace_id?: string
   source_port_id?: string
   source_net_id?: string
+  layer?: LayerRef
   x: Distance
   y: Distance
 }

--- a/src/pcb/pcb_breakout_point.ts
+++ b/src/pcb/pcb_breakout_point.ts
@@ -1,7 +1,8 @@
-import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
-import { distance, type Distance } from "src/units"
+import { type LayerRef, layer_ref } from "src/pcb/properties/layer_ref"
+import { type Distance, distance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 export const pcb_breakout_point = z
   .object({
@@ -12,6 +13,7 @@ export const pcb_breakout_point = z
     source_trace_id: z.string().optional(),
     source_port_id: z.string().optional(),
     source_net_id: z.string().optional(),
+    layer: layer_ref.optional(),
     x: distance,
     y: distance,
   })
@@ -33,6 +35,7 @@ export interface PcbBreakoutPoint {
   source_trace_id?: string
   source_port_id?: string
   source_net_id?: string
+  layer?: LayerRef
   x: Distance
   y: Distance
 }

--- a/tests/pcb_group_autorouter.test.ts
+++ b/tests/pcb_group_autorouter.test.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
+import { pcb_breakout_point } from "../src/pcb/pcb_breakout_point"
 import { pcb_group } from "../src/pcb/pcb_group"
 
 // Test autorouter_configuration optional and shape
@@ -66,4 +67,23 @@ test("pcb_group allows width and height to be omitted when outline is provided",
   expect(group.width).toBeUndefined()
   expect(group.height).toBeUndefined()
   expect(group.outline?.length).toBe(4)
+})
+
+test("pcb_breakout_point accepts an optional routing layer", () => {
+  const withoutLayer = pcb_breakout_point.parse({
+    type: "pcb_breakout_point",
+    pcb_group_id: "pcb_group_1",
+    x: 1,
+    y: 2,
+  })
+  const withLayer = pcb_breakout_point.parse({
+    type: "pcb_breakout_point",
+    pcb_group_id: "pcb_group_1",
+    layer: { name: "inner1" },
+    x: 1,
+    y: 2,
+  })
+
+  expect(withoutLayer.layer).toBeUndefined()
+  expect(withLayer.layer).toBe("inner1")
 })


### PR DESCRIPTION
## Summary

- add an optional native `layer?: LayerRef` to `pcb_breakout_point`
- normalize object layer refs through the existing `layer_ref` schema
- keep existing Circuit JSON valid when `layer` is omitted

A breakout point layer is part of its routing constraint and z-coordinate. Carrying it in Circuit JSON lets routing consumers use the producer-selected layer without reaching back into a live component tree.

## Checks

- `bun test tests/pcb_group_autorouter.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`