### PR TITLE
Add schematic pin text presentation fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -3345,6 +3345,9 @@ interface SchematicPort {
   true_ccw_index?: number
   pin_number?: number
   display_pin_label?: string
+  is_pin_name_visible?: boolean
+  is_pin_number_visible?: boolean
+  pin_text_font_size?: number
   subcircuit_id?: string
   is_connected?: boolean
   is_internal_circuit_port?: boolean

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -15,6 +15,9 @@ export interface SchematicPort {
   true_ccw_index?: number
   pin_number?: number
   display_pin_label?: string
+  is_pin_name_visible?: boolean
+  is_pin_number_visible?: boolean
+  pin_text_font_size?: number
   subcircuit_id?: string
   is_connected?: boolean
   is_internal_circuit_port?: boolean
@@ -38,6 +41,9 @@ export const schematic_port = z
     true_ccw_index: z.number().optional(),
     pin_number: z.number().optional(),
     display_pin_label: z.string().optional(),
+    is_pin_name_visible: z.boolean().optional(),
+    is_pin_number_visible: z.boolean().optional(),
+    pin_text_font_size: z.number().optional(),
     subcircuit_id: z.string().optional(),
     is_connected: z.boolean().optional(),
     is_internal_circuit_port: z.boolean().optional(),

--- a/tests/schematic-port-text-presentation.test.ts
+++ b/tests/schematic-port-text-presentation.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { schematic_port } from "src/schematic/schematic_port"
+
+test("schematic ports preserve pin text presentation", () => {
+  const schematicPort = schematic_port.parse({
+    type: "schematic_port",
+    schematic_port_id: "schematic_port_1",
+    source_port_id: "source_port_1",
+    center: { x: 0, y: 0 },
+    is_pin_name_visible: false,
+    is_pin_number_visible: true,
+    pin_text_font_size: 0.5,
+  })
+
+  expect(schematicPort).toMatchObject({
+    is_pin_name_visible: false,
+    is_pin_number_visible: true,
+    pin_text_font_size: 0.5,
+  })
+})


### PR DESCRIPTION
## Why

Circuit JSON can carry a pin label and number, but it cannot say whether either text is visible or preserve its font size. Format round trips therefore turn hidden pin text back on and replace the source text size with a converter default.

## What changed

- Add optional `is_pin_name_visible` and `is_pin_number_visible` properties to `schematic_port`.
- Add optional `pin_text_font_size` to preserve the size of both texts attached to that pin.
- Keep the fields optional so existing Circuit JSON keeps its current default presentation.

These properties belong on `schematic_port` because the presentation is specific to one rendered pin; no new element type is needed.

## Testing

- Added a focused schema test.
- `bun test`
- `bun run build`
- `bun run lint:zod`
- `bun run check-snake-case`