### PR TITLE
Add schematic sheet geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -3397,6 +3397,10 @@ interface SchematicSheet {
   sheet_index?: number
   subcircuit_id?: string
   outline_color?: string
+  center?: Point
+  width?: Length
+  height?: Length
+  is_root?: boolean
 }
 ```
 

--- a/src/schematic/schematic_sheet.ts
+++ b/src/schematic/schematic_sheet.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
-import { getZodPrefixedIdWithDefault } from "src/common"
+import { type Point, getZodPrefixedIdWithDefault, point } from "src/common"
+import { type Length, length } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 export const schematic_sheet = z
@@ -10,6 +11,10 @@ export const schematic_sheet = z
     sheet_index: z.number().optional(),
     subcircuit_id: z.string().optional(),
     outline_color: z.string().optional(),
+    center: point.optional(),
+    width: length.optional(),
+    height: length.optional(),
+    is_root: z.boolean().optional(),
   })
   .describe(
     "Defines a schematic sheet or page that components can be placed on",
@@ -28,6 +33,10 @@ export interface SchematicSheet {
   sheet_index?: number
   subcircuit_id?: string
   outline_color?: string
+  center?: Point
+  width?: Length
+  height?: Length
+  is_root?: boolean
 }
 
 expectTypesMatch<SchematicSheet, InferredSchematicSheet>(true)

--- a/tests/schematic_sheet.test.ts
+++ b/tests/schematic_sheet.test.ts
@@ -7,10 +7,18 @@ test("schematic_sheet parse", () => {
     schematic_sheet_id: "sheet1",
     name: "Main Schematic",
     sheet_index: 0,
+    center: { x: 75, y: 47.5 },
+    width: 150,
+    height: 95,
+    is_root: true,
   })
 
   expect(sheet.type).toBe("schematic_sheet")
   expect(sheet.schematic_sheet_id).toBe("sheet1")
   expect(sheet.name).toBe("Main Schematic")
   expect(sheet.sheet_index).toBe(0)
+  expect(sheet.center).toEqual({ x: 75, y: 47.5 })
+  expect(sheet.width).toBe(150)
+  expect(sheet.height).toBe(95)
+  expect(sheet.is_root).toBe(true)
 })


### PR DESCRIPTION
## Why

Circuit JSON could identify schematic sheets, but it could not describe their paper bounds or which sheet is the project root. Exporters therefore had to infer a new page from content, changing the page size and the placement of the schematic relative to its frame.

## What changed

- add optional `center`, `width`, and `height` fields to `schematic_sheet`
- add optional `is_root` so exporters can distinguish the project root from hierarchical child sheets
- cover the fields in the existing focused schema test and generated reference

All fields are optional, so existing Circuit JSON remains valid.

## Validation

- `bun test`
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`