### PR TITLE
Add colors to schematic traces

### DIFF
--- a/src/schematic/schematic_trace.ts
+++ b/src/schematic/schematic_trace.ts
@@ -16,15 +16,21 @@ export interface SchematicTraceEdge {
   to_schematic_port_id?: string
 }
 
+export interface SchematicTraceJunction {
+  x: number
+  y: number
+  /** Optional CSS color for the junction marker. */
+  color?: string
+}
+
 export interface SchematicTrace {
   type: "schematic_trace"
   schematic_trace_id: string
   schematic_sheet_id?: string
   source_trace_id?: string
-  junctions: {
-    x: number
-    y: number
-  }[]
+  /** Optional CSS color for the trace edges. */
+  color?: string
+  junctions: SchematicTraceJunction[]
   edges: SchematicTraceEdge[]
   subcircuit_id?: string
   /** Optional for now, but will be required in a future release */
@@ -36,10 +42,12 @@ export const schematic_trace = z.object({
   schematic_trace_id: z.string(),
   schematic_sheet_id: z.string().optional(),
   source_trace_id: z.string().optional(),
+  color: z.string().optional(),
   junctions: z.array(
     z.object({
       x: z.number(),
       y: z.number(),
+      color: z.string().optional(),
     }),
   ),
   edges: z.array(

--- a/tests/schematic_trace_colors.test.ts
+++ b/tests/schematic_trace_colors.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { schematic_trace } from "../src/schematic/schematic_trace"
+
+test("schematic traces preserve wire and junction colors", () => {
+  const trace = schematic_trace.parse({
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_1",
+    color: "#000080",
+    edges: [
+      {
+        from: { x: 0, y: 0 },
+        to: { x: 1, y: 0 },
+      },
+    ],
+    junctions: [{ x: 1, y: 0, color: "#800000" }],
+  })
+
+  expect(trace.color).toBe("#000080")
+  expect(trace.junctions[0]?.color).toBe("#800000")
+})


### PR DESCRIPTION
## Why

Schematic traces can preserve their geometry and connectivity, but Circuit JSON had nowhere to carry their display colors. Format converters therefore had to replace source wire and junction colors with a default.

## What changed

- Add an optional `color` to `schematic_trace` for its wire edges.
- Add an optional `color` to each existing junction point because native formats can style junction markers independently from their wires.
- Keep both fields optional so existing Circuit JSON remains valid.
- Add a focused schema test for both colors.

These are presentation properties of the existing trace and junction objects; no new element or metadata channel is needed.

## Verification

- `bun test` — 307 pass, 0 fail
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`
- `git diff --check`
