### PR TITLE
Add schematic sheet sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3396,6 +3396,7 @@ interface SchematicSheet {
   schematic_sheet_id: string
   name?: string
   sheet_index?: number
+  paper_size?: "a4" | "ansi_b"
   subcircuit_id?: string
   outline_color?: string
 }

--- a/README.md
+++ b/README.md
@@ -3396,7 +3396,7 @@ interface SchematicSheet {
   schematic_sheet_id: string
   name?: string
   sheet_index?: number
-  paper_size?: "a4" | "ansi_b"
+  sheet_size?: "a4" | "ansi_b"
   subcircuit_id?: string
   outline_color?: string
 }

--- a/src/schematic/schematic_sheet.ts
+++ b/src/schematic/schematic_sheet.ts
@@ -2,12 +2,16 @@ import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
+export const schematic_sheet_paper_size = z.enum(["a4", "ansi_b"])
+export type SchematicSheetPaperSize = z.infer<typeof schematic_sheet_paper_size>
+
 export const schematic_sheet = z
   .object({
     type: z.literal("schematic_sheet"),
     schematic_sheet_id: getZodPrefixedIdWithDefault("schematic_sheet"),
     name: z.string().optional(),
     sheet_index: z.number().optional(),
+    paper_size: schematic_sheet_paper_size.optional(),
     subcircuit_id: z.string().optional(),
     outline_color: z.string().optional(),
   })
@@ -26,6 +30,7 @@ export interface SchematicSheet {
   schematic_sheet_id: string
   name?: string
   sheet_index?: number
+  paper_size?: SchematicSheetPaperSize
   subcircuit_id?: string
   outline_color?: string
 }

--- a/src/schematic/schematic_sheet.ts
+++ b/src/schematic/schematic_sheet.ts
@@ -2,8 +2,8 @@ import { z } from "zod"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-export const schematic_sheet_paper_size = z.enum(["a4", "ansi_b"])
-export type SchematicSheetPaperSize = z.infer<typeof schematic_sheet_paper_size>
+export const schematic_sheet_size = z.enum(["a4", "ansi_b"])
+export type SchematicSheetSize = z.infer<typeof schematic_sheet_size>
 
 export const schematic_sheet = z
   .object({
@@ -11,7 +11,7 @@ export const schematic_sheet = z
     schematic_sheet_id: getZodPrefixedIdWithDefault("schematic_sheet"),
     name: z.string().optional(),
     sheet_index: z.number().optional(),
-    paper_size: schematic_sheet_paper_size.optional(),
+    sheet_size: schematic_sheet_size.optional(),
     subcircuit_id: z.string().optional(),
     outline_color: z.string().optional(),
   })
@@ -30,7 +30,7 @@ export interface SchematicSheet {
   schematic_sheet_id: string
   name?: string
   sheet_index?: number
-  paper_size?: SchematicSheetPaperSize
+  sheet_size?: SchematicSheetSize
   subcircuit_id?: string
   outline_color?: string
 }

--- a/tests/schematic_sheet.test.ts
+++ b/tests/schematic_sheet.test.ts
@@ -7,10 +7,22 @@ test("schematic_sheet parse", () => {
     schematic_sheet_id: "sheet1",
     name: "Main Schematic",
     sheet_index: 0,
+    paper_size: "ansi_b",
   })
 
   expect(sheet.type).toBe("schematic_sheet")
   expect(sheet.schematic_sheet_id).toBe("sheet1")
   expect(sheet.name).toBe("Main Schematic")
   expect(sheet.sheet_index).toBe(0)
+  expect(sheet.paper_size).toBe("ansi_b")
+})
+
+test("schematic_sheet rejects unsupported paper sizes", () => {
+  expect(() =>
+    schematic_sheet.parse({
+      type: "schematic_sheet",
+      schematic_sheet_id: "sheet1",
+      paper_size: "A3",
+    }),
+  ).toThrow()
 })

--- a/tests/schematic_sheet.test.ts
+++ b/tests/schematic_sheet.test.ts
@@ -7,22 +7,22 @@ test("schematic_sheet parse", () => {
     schematic_sheet_id: "sheet1",
     name: "Main Schematic",
     sheet_index: 0,
-    paper_size: "ansi_b",
+    sheet_size: "ansi_b",
   })
 
   expect(sheet.type).toBe("schematic_sheet")
   expect(sheet.schematic_sheet_id).toBe("sheet1")
   expect(sheet.name).toBe("Main Schematic")
   expect(sheet.sheet_index).toBe(0)
-  expect(sheet.paper_size).toBe("ansi_b")
+  expect(sheet.sheet_size).toBe("ansi_b")
 })
 
-test("schematic_sheet rejects unsupported paper sizes", () => {
+test("schematic_sheet rejects unsupported sheet sizes", () => {
   expect(() =>
     schematic_sheet.parse({
       type: "schematic_sheet",
       schematic_sheet_id: "sheet1",
-      paper_size: "A3",
+      sheet_size: "A3",
     }),
   ).toThrow()
 })


### PR DESCRIPTION
Summary

- add optional sheet_size metadata to schematic sheets
- support a4 and ansi_b
- retain compatibility with circuit JSON that omits the field

Verification

- bun test
- bunx tsc --noEmit
- bun run lint:zod
- bun run check-snake-case