### PR TITLE
Add explicit schematic sheet dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3397,6 +3397,8 @@ interface SchematicSheet {
   name?: string
   sheet_index?: number
   sheet_size?: "a4" | "ansi_b"
+  sheet_width?: number
+  sheet_height?: number
   subcircuit_id?: string
   outline_color?: string
 }

--- a/src/schematic/schematic_sheet.ts
+++ b/src/schematic/schematic_sheet.ts
@@ -12,6 +12,8 @@ export const schematic_sheet = z
     name: z.string().optional(),
     sheet_index: z.number().optional(),
     sheet_size: schematic_sheet_size.optional(),
+    sheet_width: z.number().positive().optional(),
+    sheet_height: z.number().positive().optional(),
     subcircuit_id: z.string().optional(),
     outline_color: z.string().optional(),
   })
@@ -31,6 +33,8 @@ export interface SchematicSheet {
   name?: string
   sheet_index?: number
   sheet_size?: SchematicSheetSize
+  sheet_width?: number
+  sheet_height?: number
   subcircuit_id?: string
   outline_color?: string
 }

--- a/tests/schematic_sheet.test.ts
+++ b/tests/schematic_sheet.test.ts
@@ -8,6 +8,8 @@ test("schematic_sheet parse", () => {
     name: "Main Schematic",
     sheet_index: 0,
     sheet_size: "ansi_b",
+    sheet_width: 431.8,
+    sheet_height: 279.4,
   })
 
   expect(sheet.type).toBe("schematic_sheet")
@@ -15,6 +17,8 @@ test("schematic_sheet parse", () => {
   expect(sheet.name).toBe("Main Schematic")
   expect(sheet.sheet_index).toBe(0)
   expect(sheet.sheet_size).toBe("ansi_b")
+  expect(sheet.sheet_width).toBe(431.8)
+  expect(sheet.sheet_height).toBe(279.4)
 })
 
 test("schematic_sheet rejects unsupported sheet sizes", () => {
@@ -23,6 +27,17 @@ test("schematic_sheet rejects unsupported sheet sizes", () => {
       type: "schematic_sheet",
       schematic_sheet_id: "sheet1",
       sheet_size: "A3",
+    }),
+  ).toThrow()
+})
+
+test("schematic_sheet rejects non-positive explicit dimensions", () => {
+  expect(() =>
+    schematic_sheet.parse({
+      type: "schematic_sheet",
+      schematic_sheet_id: "sheet1",
+      sheet_width: 0,
+      sheet_height: -1,
     }),
   ).toThrow()
 })


### PR DESCRIPTION
Summary

- add optional sheet_width and sheet_height fields to schematic_sheet
- store explicit dimensions as positive millimetre values
- document and test the new fields

Verification

- bun test
- bunx tsc --noEmit
- bun run lint:zod
- bun run check-snake-case