### PR TITLE
Add polygon solder paste apertures

### DIFF
--- a/src/pcb/pcb_solder_paste.ts
+++ b/src/pcb/pcb_solder_paste.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import { distance, type Distance, rotation, type Rotation } from "src/units"
 import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
-import { getZodPrefixedIdWithDefault } from "src/common"
+import { getZodPrefixedIdWithDefault, point, type Point } from "src/common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
 const pcb_solder_paste_circle = z.object({
@@ -95,14 +95,27 @@ const pcb_solder_paste_oval = z.object({
   pcb_smtpad_id: z.string().optional(),
 })
 
+const pcb_solder_paste_polygon = z.object({
+  type: z.literal("pcb_solder_paste"),
+  shape: z.literal("polygon"),
+  pcb_solder_paste_id: getZodPrefixedIdWithDefault("pcb_solder_paste"),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  points: z.array(point),
+  layer: layer_ref,
+  pcb_component_id: z.string().optional(),
+  pcb_smtpad_id: z.string().optional(),
+})
+
 export const pcb_solder_paste = z
-  .union([
+  .discriminatedUnion("shape", [
     pcb_solder_paste_circle,
     pcb_solder_paste_rect,
     pcb_solder_paste_pill,
     pcb_solder_paste_rotated_rect,
     pcb_solder_paste_rotated_pill,
     pcb_solder_paste_oval,
+    pcb_solder_paste_polygon,
   ])
   .describe("Defines solderpaste on the PCB")
 
@@ -117,6 +130,7 @@ type InferredPcbSolderPasteRotatedPill = z.infer<
   typeof pcb_solder_paste_rotated_pill
 >
 type InferredPcbSolderPasteOval = z.infer<typeof pcb_solder_paste_oval>
+type InferredPcbSolderPastePolygon = z.infer<typeof pcb_solder_paste_polygon>
 
 /**
  * Defines solderpaste on the PCB
@@ -225,6 +239,21 @@ export interface PcbSolderPasteOval {
   pcb_smtpad_id?: string
 }
 
+/**
+ * Defines polygonal solder paste on the PCB
+ */
+export interface PcbSolderPastePolygon {
+  type: "pcb_solder_paste"
+  shape: "polygon"
+  pcb_solder_paste_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  points: Point[]
+  layer: LayerRef
+  pcb_component_id?: string
+  pcb_smtpad_id?: string
+}
+
 export type PcbSolderPaste =
   | PcbSolderPasteCircle
   | PcbSolderPasteRect
@@ -232,6 +261,7 @@ export type PcbSolderPaste =
   | PcbSolderPasteRotatedRect
   | PcbSolderPasteRotatedPill
   | PcbSolderPasteOval
+  | PcbSolderPastePolygon
 
 expectTypesMatch<PcbSolderPasteCircle, InferredPcbSolderPasteCircle>(true)
 expectTypesMatch<PcbSolderPasteRect, InferredPcbSolderPasteRect>(true)
@@ -243,3 +273,4 @@ expectTypesMatch<PcbSolderPasteRotatedPill, InferredPcbSolderPasteRotatedPill>(
   true,
 )
 expectTypesMatch<PcbSolderPasteOval, InferredPcbSolderPasteOval>(true)
+expectTypesMatch<PcbSolderPastePolygon, InferredPcbSolderPastePolygon>(true)

--- a/tests/pcb_solder_paste_polygon.test.ts
+++ b/tests/pcb_solder_paste_polygon.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { pcb_solder_paste } from "src/pcb/pcb_solder_paste"
+
+test("pcb_solder_paste parses the polygon shape", () => {
+  const pcbSolderPaste = pcb_solder_paste.parse({
+    type: "pcb_solder_paste",
+    shape: "polygon",
+    points: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 1.5, y: 1 },
+      { x: 0, y: 1 },
+    ],
+    layer: "top",
+    pcb_component_id: "pcb_component_1",
+    pcb_smtpad_id: "pcb_smtpad_1",
+  })
+
+  if (pcbSolderPaste.shape !== "polygon") {
+    throw new Error("Expected polygon")
+  }
+  expect(pcbSolderPaste.pcb_solder_paste_id).toStartWith("pcb_solder_paste")
+  expect(pcbSolderPaste.points).toEqual([
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 1.5, y: 1 },
+    { x: 0, y: 1 },
+  ])
+  expect(pcbSolderPaste.layer).toBe("top")
+})


### PR DESCRIPTION
## Why

Stencil apertures can have arbitrary polygon outlines. The existing `pcb_solder_paste` element only supported circle, rectangle, pill, and oval variants, so non-rectangular apertures could not be represented without changing their geometry.

## What changed

- Extend the existing `pcb_solder_paste` element with `shape: "polygon"`
- Store the aperture geometry as Circuit JSON `points`
- Add a focused schema and type-inference test

This uses the existing solder-paste element instead of introducing another PCB element.

## Validation

- `bun test` — 317 pass
- `bun run build`
- `bunx tsc --noEmit`
- `bun run lint:zod`
- `bun run check-snake-case`
- Biome formatting check on both changed files
