### PR TITLE
Add PCB soldermask openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
     - [PcbSilkscreenPill](#pcbsilkscreenpill)
     - [PcbSilkscreenRect](#pcbsilkscreenrect)
     - [PcbSilkscreenText](#pcbsilkscreentext)
+    - [PcbSoldermaskOpening](#pcbsoldermaskopening)
     - [PcbSolderPaste](#pcbsolderpaste)
     - [PcbText](#pcbtext)
     - [PcbThermalSpoke](#pcbthermalspoke)
@@ -2655,6 +2656,26 @@ interface PcbSilkscreenText {
   is_mirrored?: boolean
   anchor_position: Point
   anchor_alignment: NinePointAnchor
+}
+```
+
+### PcbSoldermaskOpening
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_soldermask_opening.ts)
+
+```typescript
+/** Defines a circular opening in the PCB solder mask. */
+interface PcbSoldermaskOpeningCircle {
+  type: "pcb_soldermask_opening"
+  pcb_soldermask_opening_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  shape: "circle"
+  x: Distance
+  y: Distance
+  radius: Distance
+  layer: LayerRef
+  pcb_component_id?: string
 }
 ```
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -79,6 +79,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_via,
   pcb.pcb_smtpad,
   pcb.pcb_solder_paste,
+  pcb.pcb_soldermask_opening,
   pcb.pcb_board,
   pcb.pcb_panel,
   pcb.pcb_group,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -14,6 +14,7 @@ export * from "./pcb_plated_hole"
 export * from "./pcb_port"
 export * from "./pcb_smtpad"
 export * from "./pcb_solder_paste"
+export * from "./pcb_soldermask_opening"
 export * from "./pcb_text"
 export * from "./pcb_trace"
 export * from "./pcb_trace_warning"
@@ -87,6 +88,7 @@ import type { PcbPlatedHole } from "./pcb_plated_hole"
 import type { PcbPort } from "./pcb_port"
 import type { PcbSmtPad } from "./pcb_smtpad"
 import type { PcbSolderPaste } from "./pcb_solder_paste"
+import type { PcbSoldermaskOpening } from "./pcb_soldermask_opening"
 import type { PcbText } from "./pcb_text"
 import type { PcbTrace } from "./pcb_trace"
 import type { PcbTraceWarning } from "./pcb_trace_warning"
@@ -156,6 +158,7 @@ export type PcbCircuitElement =
   | PcbPort
   | PcbSmtPad
   | PcbSolderPaste
+  | PcbSoldermaskOpening
   | PcbText
   | PcbTrace
   | PcbTraceWarning

--- a/src/pcb/pcb_soldermask_opening.ts
+++ b/src/pcb/pcb_soldermask_opening.ts
@@ -1,0 +1,144 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault, point, type Point } from "src/common"
+import { layer_ref, type LayerRef } from "src/pcb/properties/layer_ref"
+import { distance, type Distance, rotation, type Rotation } from "src/units"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+const pcb_soldermask_opening_circle = z.object({
+  type: z.literal("pcb_soldermask_opening"),
+  shape: z.literal("circle"),
+  pcb_soldermask_opening_id: getZodPrefixedIdWithDefault(
+    "pcb_soldermask_opening",
+  ),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  x: distance,
+  y: distance,
+  radius: distance,
+  layer: layer_ref,
+  pcb_component_id: z.string().optional(),
+})
+
+const pcb_soldermask_opening_rect = z.object({
+  type: z.literal("pcb_soldermask_opening"),
+  shape: z.literal("rect"),
+  pcb_soldermask_opening_id: getZodPrefixedIdWithDefault(
+    "pcb_soldermask_opening",
+  ),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  x: distance,
+  y: distance,
+  width: distance,
+  height: distance,
+  layer: layer_ref,
+  pcb_component_id: z.string().optional(),
+})
+
+const pcb_soldermask_opening_rotated_rect = z.object({
+  type: z.literal("pcb_soldermask_opening"),
+  shape: z.literal("rotated_rect"),
+  pcb_soldermask_opening_id: getZodPrefixedIdWithDefault(
+    "pcb_soldermask_opening",
+  ),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  x: distance,
+  y: distance,
+  width: distance,
+  height: distance,
+  ccw_rotation: rotation,
+  layer: layer_ref,
+  pcb_component_id: z.string().optional(),
+})
+
+const pcb_soldermask_opening_polygon = z.object({
+  type: z.literal("pcb_soldermask_opening"),
+  shape: z.literal("polygon"),
+  pcb_soldermask_opening_id: getZodPrefixedIdWithDefault(
+    "pcb_soldermask_opening",
+  ),
+  pcb_group_id: z.string().optional(),
+  subcircuit_id: z.string().optional(),
+  points: z.array(point).min(3),
+  layer: layer_ref,
+  pcb_component_id: z.string().optional(),
+})
+
+export const pcb_soldermask_opening = z
+  .discriminatedUnion("shape", [
+    pcb_soldermask_opening_circle,
+    pcb_soldermask_opening_rect,
+    pcb_soldermask_opening_rotated_rect,
+    pcb_soldermask_opening_polygon,
+  ])
+  .describe("Defines an explicit opening in the PCB solder mask")
+
+export type PcbSoldermaskOpeningInput = z.input<typeof pcb_soldermask_opening>
+
+type InferredPcbSoldermaskOpening = z.infer<typeof pcb_soldermask_opening>
+
+/** Defines a circular opening in the PCB solder mask. */
+export interface PcbSoldermaskOpeningCircle {
+  type: "pcb_soldermask_opening"
+  pcb_soldermask_opening_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  shape: "circle"
+  x: Distance
+  y: Distance
+  radius: Distance
+  layer: LayerRef
+  pcb_component_id?: string
+}
+
+/** Defines a rectangular opening in the PCB solder mask. */
+export interface PcbSoldermaskOpeningRect {
+  type: "pcb_soldermask_opening"
+  pcb_soldermask_opening_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  shape: "rect"
+  x: Distance
+  y: Distance
+  width: Distance
+  height: Distance
+  layer: LayerRef
+  pcb_component_id?: string
+}
+
+/** Defines a rotated rectangular opening in the PCB solder mask. */
+export interface PcbSoldermaskOpeningRotatedRect {
+  type: "pcb_soldermask_opening"
+  pcb_soldermask_opening_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  shape: "rotated_rect"
+  x: Distance
+  y: Distance
+  width: Distance
+  height: Distance
+  ccw_rotation: Rotation
+  layer: LayerRef
+  pcb_component_id?: string
+}
+
+/** Defines a polygonal opening in the PCB solder mask. */
+export interface PcbSoldermaskOpeningPolygon {
+  type: "pcb_soldermask_opening"
+  pcb_soldermask_opening_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  shape: "polygon"
+  points: Point[]
+  layer: LayerRef
+  pcb_component_id?: string
+}
+
+export type PcbSoldermaskOpening =
+  | PcbSoldermaskOpeningCircle
+  | PcbSoldermaskOpeningRect
+  | PcbSoldermaskOpeningRotatedRect
+  | PcbSoldermaskOpeningPolygon
+
+expectTypesMatch<PcbSoldermaskOpening, InferredPcbSoldermaskOpening>(true)

--- a/tests/pcb_soldermask_opening.test.ts
+++ b/tests/pcb_soldermask_opening.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "src/any_circuit_element"
+import { pcb_soldermask_opening } from "src/pcb/pcb_soldermask_opening"
+
+test("parses rectangular and polygonal PCB soldermask openings", () => {
+  const rectangularOpening = pcb_soldermask_opening.parse({
+    type: "pcb_soldermask_opening",
+    shape: "rotated_rect",
+    x: 1,
+    y: 2,
+    width: 3,
+    height: 4,
+    ccw_rotation: 45,
+    layer: "top",
+    pcb_component_id: "pcb_component_1",
+  })
+  const polygonalOpening = pcb_soldermask_opening.parse({
+    type: "pcb_soldermask_opening",
+    shape: "polygon",
+    points: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 1, y: 1 },
+    ],
+    layer: "bottom",
+  })
+
+  expect(rectangularOpening).toMatchObject({
+    shape: "rotated_rect",
+    ccw_rotation: 45,
+    layer: "top",
+  })
+  expect(polygonalOpening).toMatchObject({
+    shape: "polygon",
+    layer: "bottom",
+    points: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 1, y: 1 },
+    ],
+  })
+  expect(any_circuit_element.parse(rectangularOpening)).toEqual(
+    rectangularOpening,
+  )
+  expect(any_circuit_element.parse(polygonalOpening)).toEqual(polygonalOpening)
+})


### PR DESCRIPTION
## Why

Altium PCB files can contain standalone solder-mask openings that are not owned by a pad or hole. Existing pad and hole margin fields cannot represent those shapes, so converters currently have to discard them.

## What changed

- Add a typed pcb_soldermask_opening element for circle, rectangle, rotated-rectangle, and polygon geometry.
- Keep the existing layer, group, subcircuit, and optional component ownership conventions used by other PCB elements.
- Register the element in PcbCircuitElement and AnyCircuitElement.
- Document it in the generated schema reference.
- Add one focused schema test file.

## Why a standalone element

A mask opening is fabrication-layer geometry, not necessarily part of a pad or hole. Making it its own PCB element preserves source geometry without pretending it belongs to a component primitive.

## Validation

- bun test
- bun run typecheck
- bun run build
- bun run lint-zod-errors
- bun run check-snake-case
- bun run format

Stacked on #738 so downstream converters can pin one commit containing both issue-5 schema additions.