### PR TITLE
Preserve optional metadata on source components

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ interface SourceComponentBase {
   ftype?: string
   source_component_id: string
   name: string
+  // Opaque, JSON-serializable tool metadata. Prefer namespaced keys.
+  metadata?: Record<string, unknown>
   manufacturer_part_number?: string
   supplier_part_numbers?: Partial<Record<SupplierName, string[]>>
   display_value?: string

--- a/src/source/base/source_component_base.ts
+++ b/src/source/base/source_component_base.ts
@@ -10,6 +10,8 @@ export interface SourceComponentBase {
   ftype?: string
   source_component_id: string
   name: string
+  // Opaque, JSON-serializable tool metadata. Prefer namespaced keys.
+  metadata?: Record<string, unknown>
   manufacturer_part_number?: string
   supplier_part_numbers?: Partial<Record<SupplierName, string[]>>
   display_value?: string
@@ -25,6 +27,7 @@ export const source_component_base = z.object({
   ftype: z.string().optional(),
   source_component_id: z.string(),
   name: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   manufacturer_part_number: z.string().optional(),
   supplier_part_numbers: z
     .record(supplier_name, z.array(z.string()))

--- a/tests/source_component_metadata.test.ts
+++ b/tests/source_component_metadata.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test"
+import {
+  any_circuit_element,
+  source_simple_capacitor,
+  source_simple_chip,
+  source_simple_resistor,
+} from "../src"
+
+const components = [
+  {
+    schema: source_simple_chip,
+    component: {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_U1",
+      name: "U1",
+    },
+  },
+  {
+    schema: source_simple_resistor,
+    component: {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_R1",
+      name: "R1",
+      resistance: 1000,
+    },
+  },
+  {
+    schema: source_simple_capacitor,
+    component: {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_C1",
+      name: "C1",
+      capacitance: 0.000001,
+    },
+  },
+] as const
+
+test("source components preserve opaque metadata through parsing and JSON round trips", () => {
+  const metadata = {
+    "spice.model": "OPA388.lib",
+    "mytool.constraint": {
+      enabled: true,
+      max_current: 0.25,
+      matching_groups: ["input", "feedback"],
+      optional_limit: null,
+      nested: [{ pin: 1 }, { pin: 2 }],
+    },
+  }
+
+  for (const { schema, component } of components) {
+    const input = { ...component, metadata }
+    const parsed = schema.parse(input)
+    expect(parsed).toEqual(input)
+    expect(any_circuit_element.parse(input)).toEqual(input)
+    expect(
+      any_circuit_element.parse(JSON.parse(JSON.stringify(parsed))),
+    ).toEqual(input)
+  }
+})
+
+test("source component metadata is optional and allows an empty record", () => {
+  for (const { schema, component } of components) {
+    expect(schema.parse(component)).not.toHaveProperty("metadata")
+    expect(any_circuit_element.parse(component)).not.toHaveProperty("metadata")
+
+    const input = { ...component, metadata: {} }
+    expect(schema.parse(input)).toEqual(input)
+    expect(any_circuit_element.parse(input)).toEqual(input)
+  }
+})
+
+test("source component metadata must be a record", () => {
+  for (const metadata of [null, "model.lib", 42, true, ["model.lib"]]) {
+    for (const { schema, component } of components) {
+      const input = { ...component, metadata }
+      expect(schema.safeParse(input).success).toBe(false)
+      expect(any_circuit_element.safeParse(input).success).toBe(false)
+    }
+  }
+})
+
+test("metadata does not replace required typed component properties", () => {
+  const resistor = {
+    type: "source_component",
+    ftype: "simple_resistor",
+    source_component_id: "source_component_R1",
+    name: "R1",
+    metadata: { resistance: 1000 },
+  }
+
+  expect(source_simple_resistor.safeParse(resistor).success).toBe(false)
+  expect(any_circuit_element.safeParse(resistor).success).toBe(false)
+})


### PR DESCRIPTION
Fixes #697.

Source component parsing currently strips tool-specific metadata, so simulation model references and other extension fields disappear when a component is parsed. Add the proposed optional `metadata: Record<string, unknown>` to the shared source-component interface and Zod schema. Concrete component schemas inherit the field, and the README documents it.

The regression tests cover chip, resistor, and capacitor parsers, the public `any_circuit_element` parser, nested JSON round trips, omitted/empty metadata, invalid record containers, and required typed fields. Metadata remains opaque; this does not add application-specific value validation or metadata fields to PCB/schematic components.

Validation:

- Before the schema change: 3 regression tests failed and 1 passed.
- `bun test`: 320 passed, 0 failed.
- `bunx --no-install tsc --noEmit` and `bun run build`: passed.
- Zod lint, snake-case check, changed-file formatting, and `git diff --check`: passed.
