### PR TITLE
Add PCB trace segment curvature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2736,6 +2736,12 @@ interface PcbTraceRoutePointWire {
   route_type: "wire"
   x: Distance
   y: Distance
+  /**
+   * Curvature of the segment from this point to the next route point.
+   * The value is tan(sweepAngle / 4), where a positive sweep is
+   * counterclockwise. Omit this field for a straight segment.
+   */
+  bulge?: number
   width: Distance
   copper_pour_id?: string
   is_inside_copper_pour?: boolean

--- a/src/pcb/pcb_trace.ts
+++ b/src/pcb/pcb_trace.ts
@@ -8,6 +8,7 @@ export const pcb_trace_route_point_wire = z.object({
   route_type: z.literal("wire"),
   x: distance,
   y: distance,
+  bulge: z.number().finite().optional(),
   width: distance,
   copper_pour_id: z.string().optional(),
   is_inside_copper_pour: z.boolean().optional(),
@@ -73,6 +74,12 @@ export interface PcbTraceRoutePointWire {
   route_type: "wire"
   x: Distance
   y: Distance
+  /**
+   * Curvature of the segment from this point to the next route point.
+   * The value is tan(sweepAngle / 4), where a positive sweep is
+   * counterclockwise. Omit this field for a straight segment.
+   */
+  bulge?: number
   width: Distance
   copper_pour_id?: string
   is_inside_copper_pour?: boolean

--- a/tests/pcb_trace_bulge.test.ts
+++ b/tests/pcb_trace_bulge.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { pcb_trace } from "../src/pcb/pcb_trace"
+
+test("preserves curvature on a PCB trace segment", () => {
+  const trace = pcb_trace.parse({
+    type: "pcb_trace",
+    route: [
+      {
+        route_type: "wire",
+        x: 0,
+        y: 0,
+        bulge: Math.SQRT2 - 1,
+        width: 0.2,
+        layer: "top",
+      },
+      {
+        route_type: "wire",
+        x: 1,
+        y: 1,
+        width: 0.2,
+        layer: "top",
+      },
+    ],
+  })
+
+  const firstRoutePoint = trace.route[0]
+  expect(firstRoutePoint?.route_type).toBe("wire")
+  if (firstRoutePoint?.route_type !== "wire") return
+  expect(firstRoutePoint.bulge).toBe(Math.SQRT2 - 1)
+})
+
+test("rejects non-finite PCB trace bulges", () => {
+  expect(() =>
+    pcb_trace.parse({
+      type: "pcb_trace",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 0,
+          bulge: Number.POSITIVE_INFINITY,
+          width: 0.2,
+          layer: "top",
+        },
+      ],
+    }),
+  ).toThrow()
+})


### PR DESCRIPTION
## Summary
- add an optional finite `bulge` to PCB wire route points
- define the field using the standard `tan(sweepAngle / 4)` convention
- document that curvature applies from a route point to the next point

This is the Circuit JSON schema half of preserving native curved copper routes in converters.

## Tests
- `bun test` (318 pass)
- `bun run lint:zod`
- `bun run check-snake-case`
- `bun run build`