### PR TITLE
Add component ownership to PCB cutouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1680,6 +1680,7 @@ Defines a rectangular cutout on the PCB.
 interface PcbCutoutRect {
   type: "pcb_cutout"
   pcb_cutout_id: string
+  pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
   pcb_board_id?: string

--- a/src/pcb/pcb_cutout.ts
+++ b/src/pcb/pcb_cutout.ts
@@ -1,12 +1,13 @@
-import { z } from "zod"
-import { point, type Point, getZodPrefixedIdWithDefault } from "src/common"
-import { length, type Length, rotation, type Rotation } from "src/units"
+import { type Point, getZodPrefixedIdWithDefault, point } from "src/common"
+import { type Length, type Rotation, length, rotation } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
 
 // Common properties base for all cutout shapes (internal)
 const pcb_cutout_base = z.object({
   type: z.literal("pcb_cutout"),
   pcb_cutout_id: getZodPrefixedIdWithDefault("pcb_cutout"),
+  pcb_component_id: z.string().optional(),
   pcb_group_id: z.string().optional(),
   subcircuit_id: z.string().optional(),
   pcb_board_id: z.string().optional(),
@@ -30,6 +31,7 @@ type InferredPcbCutoutRect = z.infer<typeof pcb_cutout_rect>
 export interface PcbCutoutRect {
   type: "pcb_cutout"
   pcb_cutout_id: string
+  pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
   pcb_board_id?: string
@@ -57,6 +59,7 @@ type InferredPcbCutoutCircle = z.infer<typeof pcb_cutout_circle>
 export interface PcbCutoutCircle {
   type: "pcb_cutout"
   pcb_cutout_id: string
+  pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
   pcb_board_id?: string
@@ -81,6 +84,7 @@ type InferredPcbCutoutPolygon = z.infer<typeof pcb_cutout_polygon>
 export interface PcbCutoutPolygon {
   type: "pcb_cutout"
   pcb_cutout_id: string
+  pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
   pcb_board_id?: string
@@ -110,6 +114,7 @@ type InferredPcbCutoutPath = z.infer<typeof pcb_cutout_path>
 export interface PcbCutoutPath {
   type: "pcb_cutout"
   pcb_cutout_id: string
+  pcb_component_id?: string
   pcb_group_id?: string
   subcircuit_id?: string
   pcb_board_id?: string

--- a/tests/pcb-cutout-component-ownership.test.ts
+++ b/tests/pcb-cutout-component-ownership.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { pcb_cutout } from "src/pcb/pcb_cutout"
+
+const ownedCutouts = [
+  {
+    type: "pcb_cutout" as const,
+    shape: "rect" as const,
+    center: { x: 0, y: 0 },
+    width: 8.6,
+    height: 17.26,
+  },
+  {
+    type: "pcb_cutout" as const,
+    shape: "circle" as const,
+    center: { x: 0, y: 0 },
+    radius: 2,
+  },
+  {
+    type: "pcb_cutout" as const,
+    shape: "polygon" as const,
+    points: [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 1, y: 2 },
+    ],
+  },
+  {
+    type: "pcb_cutout" as const,
+    shape: "path" as const,
+    route: [
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+    ],
+    slot_width: 1,
+  },
+]
+
+test("pcb cutout shapes preserve their owning component id", () => {
+  for (const cutout of ownedCutouts) {
+    const parsedCutout = pcb_cutout.parse({
+      ...cutout,
+      pcb_component_id: "pcb_component_1",
+    })
+
+    expect(parsedCutout.pcb_component_id).toBe("pcb_component_1")
+  }
+})
+
+test("pcb cutout ownership remains optional", () => {
+  const cutout = pcb_cutout.parse(ownedCutouts[0])
+
+  expect(cutout.pcb_component_id).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add an optional pcb_component_id to the shared PCB cutout schema
- expose the field on rectangular, circular, polygon, and path cutout interfaces
- document the field and test both owned and board-level cutouts

## Motivation
Footprint-defined cutouts need to identify their owning PCB component so downstream checks can allow that component to span its own cutout while still rejecting unrelated overlaps. Follow-up changes in core and checks will populate and consume this metadata.

## Testing
- bun test (318 passed)
- bunx tsc --noEmit
- bun run build
- bun run lint:zod
- bun run check-snake-case
- bunx biome check src/pcb/pcb_cutout.ts tests/pcb-cutout-component-ownership.test.ts