### PR TITLE
feat: add schematic text overline ranges

### DIFF
--- a/src/schematic/schematic_text.ts
+++ b/src/schematic/schematic_text.ts
@@ -1,10 +1,10 @@
-import { z } from "zod"
-import { distance } from "../units"
-import { expectTypesMatch } from "src/utils/expect-types-match"
-import { ninePointAnchor } from "src/common/NinePointAnchor"
-import type { NinePointAnchor } from "src/common/NinePointAnchor"
 import type { FivePointAnchor } from "src/common/FivePointAnchor"
 import { fivePointAnchor } from "src/common/FivePointAnchor"
+import { ninePointAnchor } from "src/common/NinePointAnchor"
+import type { NinePointAnchor } from "src/common/NinePointAnchor"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+import { z } from "zod"
+import { distance } from "../units"
 
 export interface SchematicText {
   type: "schematic_text"
@@ -20,10 +20,10 @@ export interface SchematicText {
    */
   source_trace_id?: string
   text: string
-  text_decoration_ranges?: Array<{
-    start: number
-    end: number
-    decoration: "overline" | "underline" | "line-through"
+  /** Ranges of Unicode characters in `text` that should have an overline. */
+  overline_ranges?: Array<{
+    start_index: number
+    end_index: number
   }>
   font_size: number
   position: {
@@ -38,43 +38,43 @@ export interface SchematicText {
 
 export const schematic_text = z
   .object({
-  type: z.literal("schematic_text"),
-  schematic_sheet_id: z.string().optional(),
-  schematic_component_id: z.string().optional(),
-  schematic_symbol_id: z.string().optional(),
-  schematic_text_id: z.string(),
-  source_trace_id: z.string().optional(),
-  text: z.string(),
-  text_decoration_ranges: z
-    .array(
-      z.object({
-        start: z.number().int().nonnegative(),
-        end: z.number().int().positive(),
-        decoration: z.enum(["overline", "underline", "line-through"]),
-      }),
-    )
-    .optional(),
-  font_size: z.number().default(0.18),
-  position: z.object({
-    x: distance,
-    y: distance,
-  }),
-  rotation: z.number().default(0),
-  anchor: z
-    .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
-    .default("center"),
-  color: z.string().default("#000000"),
+    type: z.literal("schematic_text"),
+    schematic_sheet_id: z.string().optional(),
+    schematic_component_id: z.string().optional(),
+    schematic_symbol_id: z.string().optional(),
+    schematic_text_id: z.string(),
+    source_trace_id: z.string().optional(),
+    text: z.string(),
+    overline_ranges: z
+      .array(
+        z.object({
+          start_index: z.number().int().nonnegative(),
+          end_index: z.number().int().positive(),
+        }),
+      )
+      .optional(),
+    font_size: z.number().default(0.18),
+    position: z.object({
+      x: distance,
+      y: distance,
+    }),
+    rotation: z.number().default(0),
+    anchor: z
+      .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
+      .default("center"),
+    color: z.string().default("#000000"),
     subcircuit_id: z.string().optional(),
   })
   .superRefine((value, context) => {
-    for (const [index, range] of (
-      value.text_decoration_ranges ?? []
-    ).entries()) {
-      if (range.end <= range.start || range.end > Array.from(value.text).length) {
+    for (const [index, range] of (value.overline_ranges ?? []).entries()) {
+      if (
+        range.end_index <= range.start_index ||
+        range.end_index > Array.from(value.text).length
+      ) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["text_decoration_ranges", index],
-          message: "Text decoration ranges must be non-empty and within the text",
+          path: ["overline_ranges", index],
+          message: "Overline ranges must be non-empty and within the text",
         })
       }
     }

--- a/src/schematic/schematic_text.ts
+++ b/src/schematic/schematic_text.ts
@@ -20,6 +20,11 @@ export interface SchematicText {
    */
   source_trace_id?: string
   text: string
+  text_decoration_ranges?: Array<{
+    start: number
+    end: number
+    decoration: "overline" | "underline" | "line-through"
+  }>
   font_size: number
   position: {
     x: number
@@ -31,7 +36,8 @@ export interface SchematicText {
   subcircuit_id?: string
 }
 
-export const schematic_text = z.object({
+export const schematic_text = z
+  .object({
   type: z.literal("schematic_text"),
   schematic_sheet_id: z.string().optional(),
   schematic_component_id: z.string().optional(),
@@ -39,6 +45,15 @@ export const schematic_text = z.object({
   schematic_text_id: z.string(),
   source_trace_id: z.string().optional(),
   text: z.string(),
+  text_decoration_ranges: z
+    .array(
+      z.object({
+        start: z.number().int().nonnegative(),
+        end: z.number().int().positive(),
+        decoration: z.enum(["overline", "underline", "line-through"]),
+      }),
+    )
+    .optional(),
   font_size: z.number().default(0.18),
   position: z.object({
     x: distance,
@@ -49,8 +64,21 @@ export const schematic_text = z.object({
     .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
     .default("center"),
   color: z.string().default("#000000"),
-  subcircuit_id: z.string().optional(),
-})
+    subcircuit_id: z.string().optional(),
+  })
+  .superRefine((value, context) => {
+    for (const [index, range] of (
+      value.text_decoration_ranges ?? []
+    ).entries()) {
+      if (range.end <= range.start || range.end > Array.from(value.text).length) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["text_decoration_ranges", index],
+          message: "Text decoration ranges must be non-empty and within the text",
+        })
+      }
+    }
+  })
 
 export type SchematicTextInput = z.input<typeof schematic_text>
 type InferredSchematicText = z.infer<typeof schematic_text>

--- a/tests/schematic_text.test.ts
+++ b/tests/schematic_text.test.ts
@@ -29,14 +29,12 @@ test("schematic_text allows source_trace_id", () => {
   expect(text.source_trace_id).toBe("source_trace_1")
 })
 
-test("schematic_text allows text decoration ranges", () => {
+test("schematic_text allows overline ranges", () => {
   const text = schematic_text.parse({
     type: "schematic_text",
     schematic_text_id: "schematic_text_decorated",
     text: "RESET/GPIO",
-    text_decoration_ranges: [
-      { start: 0, end: 5, decoration: "overline" },
-    ],
+    overline_ranges: [{ start_index: 0, end_index: 5 }],
     font_size: 0.18,
     position: { x: 0, y: 0 },
     rotation: 0,
@@ -44,9 +42,7 @@ test("schematic_text allows text decoration ranges", () => {
     color: "#000000",
   })
 
-  expect(text.text_decoration_ranges).toEqual([
-    { start: 0, end: 5, decoration: "overline" },
-  ])
+  expect(text.overline_ranges).toEqual([{ start_index: 0, end_index: 5 }])
 })
 
 test("any_circuit_element includes schematic_text with source_trace_id", () => {

--- a/tests/schematic_text.test.ts
+++ b/tests/schematic_text.test.ts
@@ -29,6 +29,26 @@ test("schematic_text allows source_trace_id", () => {
   expect(text.source_trace_id).toBe("source_trace_1")
 })
 
+test("schematic_text allows text decoration ranges", () => {
+  const text = schematic_text.parse({
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_decorated",
+    text: "RESET/GPIO",
+    text_decoration_ranges: [
+      { start: 0, end: 5, decoration: "overline" },
+    ],
+    font_size: 0.18,
+    position: { x: 0, y: 0 },
+    rotation: 0,
+    anchor: "center",
+    color: "#000000",
+  })
+
+  expect(text.text_decoration_ranges).toEqual([
+    { start: 0, end: 5, decoration: "overline" },
+  ])
+})
+
 test("any_circuit_element includes schematic_text with source_trace_id", () => {
   const text = any_circuit_element.parse({
     type: "schematic_text",


### PR DESCRIPTION
Adds `overline_ranges` to `schematic_text`; each range uses the explicit `start_index` and `end_index` fields to identify Unicode characters in `text` that need one continuous overline. The field is necessary because plain text loses KiCad's active-low span, combining Unicode marks draw separate bars per character, and separate line primitives require inaccurate font-positioning constants. This keeps Circuit JSON semantic while leaving exact glyph measurement and drawing to the renderer.

Motive: Preserve partial active-low signal notation without embedding renderer-specific glyphs or geometry in Circuit JSON.