### PR TITLE
feat: add styled schematic pin label runs

### DIFF
--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -53,6 +53,7 @@ export const schematic_port = z
           overline: z.boolean().optional(),
         }),
       )
+      .min(1)
       .optional(),
     display_pin_label_font_size: z.number().positive().finite().optional(),
     subcircuit_id: z.string().optional(),

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -2,12 +2,12 @@ import { z } from "zod"
 import { point, type Point } from "../common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
-/** A contiguous part of a schematic pin label that shares the same styling. */
-export interface SchematicTextRun {
+/** One part of a schematic pin label with its display options. */
+export interface SchematicTextPart {
   /** The literal text displayed for this part of the label. */
   text: string
   /** Draw a line above this text, typically indicating an active-low signal. */
-  overline?: boolean
+  is_overlined?: boolean
 }
 
 export interface SchematicPort {
@@ -28,7 +28,7 @@ export interface SchematicPort {
    * For example, `A~{BC}D` is represented as `A`, overlined `BC`, then `D`.
    * Consumers that do not support styled text can use `display_pin_label`.
    */
-  display_pin_label_text_runs?: SchematicTextRun[]
+  display_pin_label_text_parts?: SchematicTextPart[]
   display_pin_label_font_size?: number
   subcircuit_id?: string
   is_connected?: boolean
@@ -53,11 +53,11 @@ export const schematic_port = z
     true_ccw_index: z.number().optional(),
     pin_number: z.number().optional(),
     display_pin_label: z.string().optional(),
-    display_pin_label_text_runs: z
+    display_pin_label_text_parts: z
       .array(
         z.object({
           text: z.string(),
-          overline: z.boolean().optional(),
+          is_overlined: z.boolean().optional(),
         }),
       )
       .min(1)

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -2,8 +2,11 @@ import { z } from "zod"
 import { point, type Point } from "../common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
+/** A contiguous part of a schematic pin label that shares the same styling. */
 export interface SchematicTextRun {
+  /** The literal text displayed for this part of the label. */
   text: string
+  /** Draw a line above this text, typically indicating an active-low signal. */
   overline?: boolean
 }
 
@@ -20,7 +23,11 @@ export interface SchematicPort {
   true_ccw_index?: number
   pin_number?: number
   display_pin_label?: string
-  /** Ordered styled runs for the label. Plain-text consumers can fall back to display_pin_label. */
+  /**
+   * Ordered parts of the pin label with per-part styling.
+   * For example, `A~{BC}D` is represented as `A`, overlined `BC`, then `D`.
+   * Consumers that do not support styled text can use `display_pin_label`.
+   */
   display_pin_label_text_runs?: SchematicTextRun[]
   display_pin_label_font_size?: number
   subcircuit_id?: string

--- a/src/schematic/schematic_port.ts
+++ b/src/schematic/schematic_port.ts
@@ -2,6 +2,11 @@ import { z } from "zod"
 import { point, type Point } from "../common"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
+export interface SchematicTextRun {
+  text: string
+  overline?: boolean
+}
+
 export interface SchematicPort {
   type: "schematic_port"
   schematic_port_id: string
@@ -15,6 +20,8 @@ export interface SchematicPort {
   true_ccw_index?: number
   pin_number?: number
   display_pin_label?: string
+  /** Ordered styled runs for the label. Plain-text consumers can fall back to display_pin_label. */
+  display_pin_label_text_runs?: SchematicTextRun[]
   display_pin_label_font_size?: number
   subcircuit_id?: string
   is_connected?: boolean
@@ -39,6 +46,14 @@ export const schematic_port = z
     true_ccw_index: z.number().optional(),
     pin_number: z.number().optional(),
     display_pin_label: z.string().optional(),
+    display_pin_label_text_runs: z
+      .array(
+        z.object({
+          text: z.string(),
+          overline: z.boolean().optional(),
+        }),
+      )
+      .optional(),
     display_pin_label_font_size: z.number().positive().finite().optional(),
     subcircuit_id: z.string().optional(),
     is_connected: z.boolean().optional(),

--- a/tests/schematic-port.test.ts
+++ b/tests/schematic-port.test.ts
@@ -39,32 +39,32 @@ test("schematic ports accept an optional display pin-label font size", () => {
   expect(portWithoutOverride.display_pin_label_font_size).toBeUndefined()
 })
 
-test("schematic ports accept styled display pin-label runs", () => {
+test("schematic ports accept styled display pin-label parts", () => {
   const port = schematic_port.parse({
     ...baseSchematicPort,
     schematic_port_id: "schematic_port_with_text_runs",
     display_pin_label: "ABC",
-    display_pin_label_text_runs: [
+    display_pin_label_text_parts: [
       { text: "A" },
-      { text: "B", overline: true },
+      { text: "B", is_overlined: true },
       { text: "C" },
     ],
   })
 
-  expect(port.display_pin_label_text_runs).toEqual([
+  expect(port.display_pin_label_text_parts).toEqual([
     { text: "A" },
-    { text: "B", overline: true },
+    { text: "B", is_overlined: true },
     { text: "C" },
   ])
 })
 
-test("schematic ports reject empty styled display pin-label runs", () => {
+test("schematic ports reject empty styled display pin-label parts", () => {
   expect(
     schematic_port.safeParse({
       ...baseSchematicPort,
       schematic_port_id: "schematic_port_with_empty_text_runs",
       display_pin_label: "ABC",
-      display_pin_label_text_runs: [],
+      display_pin_label_text_parts: [],
     }).success,
   ).toBe(false)
 })

--- a/tests/schematic-port.test.ts
+++ b/tests/schematic-port.test.ts
@@ -39,6 +39,25 @@ test("schematic ports accept an optional display pin-label font size", () => {
   expect(portWithoutOverride.display_pin_label_font_size).toBeUndefined()
 })
 
+test("schematic ports accept styled display pin-label runs", () => {
+  const port = schematic_port.parse({
+    ...baseSchematicPort,
+    schematic_port_id: "schematic_port_with_text_runs",
+    display_pin_label: "ABC",
+    display_pin_label_text_runs: [
+      { text: "A" },
+      { text: "B", overline: true },
+      { text: "C" },
+    ],
+  })
+
+  expect(port.display_pin_label_text_runs).toEqual([
+    { text: "A" },
+    { text: "B", overline: true },
+    { text: "C" },
+  ])
+})
+
 test("schematic ports reject invalid display pin-label font sizes", () => {
   for (const display_pin_label_font_size of [
     0,

--- a/tests/schematic-port.test.ts
+++ b/tests/schematic-port.test.ts
@@ -58,6 +58,17 @@ test("schematic ports accept styled display pin-label runs", () => {
   ])
 })
 
+test("schematic ports reject empty styled display pin-label runs", () => {
+  expect(
+    schematic_port.safeParse({
+      ...baseSchematicPort,
+      schematic_port_id: "schematic_port_with_empty_text_runs",
+      display_pin_label: "ABC",
+      display_pin_label_text_runs: [],
+    }).success,
+  ).toBe(false)
+})
+
 test("schematic ports reject invalid display pin-label font sizes", () => {
   for (const display_pin_label_font_size of [
     0,


### PR DESCRIPTION
## Summary

- add optional ordered `display_pin_label_text_runs` to `schematic_port`
- model each run as `{ text, overline? }`
- retain `display_pin_label` as the backward-compatible plain-text fallback

This schema extension supports mixed negation such as plain `A`, overlined `B`, plain `C`, which cannot be represented by the existing whole-label `N_` convention.

## Motive : 
Adds structured text runs for schematic pin labels, allowing individual segments to be marked as overlined.

## Test

- `bun test tests/schematic-port.test.ts`

Used by tscircuit/kicad-to-circuit-json#183 and the companion circuit-to-svg renderer PR.