### PR TITLE
Add display_superscript to schematic net labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -3320,6 +3320,8 @@ interface SchematicNetLabel {
   anchor_position?: Point | undefined
   anchor_side: "top" | "bottom" | "left" | "right"
   text: string
+  /** Display-only superscript suffix, e.g. "1" in GND¹. Does not change net identity. */
+  display_superscript?: string
   symbol_name?: string | undefined
   /** When true the net label can be repositioned. When false the label's
    * position is fixed by the element it is attached to. */

--- a/src/schematic/schematic_net_label.ts
+++ b/src/schematic/schematic_net_label.ts
@@ -14,6 +14,8 @@ export interface SchematicNetLabel {
   anchor_position?: Point | undefined
   anchor_side: "top" | "bottom" | "left" | "right"
   text: string
+  /** Display-only superscript suffix, e.g. "1" in GND¹. Does not change net identity. */
+  display_superscript?: string
   symbol_name?: string | undefined
   /**
    * When true the net label can be repositioned. When false the label's
@@ -34,6 +36,7 @@ export const schematic_net_label = z.object({
   anchor_position: point.optional(),
   anchor_side: z.enum(["top", "bottom", "left", "right"]),
   text: z.string(),
+  display_superscript: z.string().optional(),
   symbol_name: z.string().optional(),
   is_movable: z.boolean().optional(),
   subcircuit_id: z.string().optional(),

--- a/tests/schematic_net_label.test.ts
+++ b/tests/schematic_net_label.test.ts
@@ -37,7 +37,8 @@ test("display_superscript is an optional display-only string", () => {
       ...input,
       display_superscript: suffix,
     })
-    expect(label.display_superscript).toBe(suffix)
+    if (suffix === undefined) expect(label.display_superscript).toBeUndefined()
+    else expect(label.display_superscript).toBe(suffix)
     expect(label.text).toBe("GND")
     expect(label.source_net_id).toBe("net_gnd")
   }

--- a/tests/schematic_net_label.test.ts
+++ b/tests/schematic_net_label.test.ts
@@ -23,3 +23,25 @@ test("schematic_net_label.is_movable can be false", () => {
   })
   expect(label.is_movable).toBe(false)
 })
+
+test("display_superscript is an optional display-only string", () => {
+  const input = {
+    type: "schematic_net_label",
+    source_net_id: "net_gnd",
+    center: { x: 0, y: 0 },
+    anchor_side: "left",
+    text: "GND",
+  }
+  for (const suffix of [undefined, "", "1", "12", "A"]) {
+    const label = schematic_net_label.parse({
+      ...input,
+      display_superscript: suffix,
+    })
+    expect(label.display_superscript).toBe(suffix)
+    expect(label.text).toBe("GND")
+    expect(label.source_net_id).toBe("net_gnd")
+  }
+  expect(
+    schematic_net_label.safeParse({ ...input, display_superscript: 1 }).success,
+  ).toBe(false)
+})


### PR DESCRIPTION
Adds optional `display_superscript: string` to schematic net labels. For example, `text: "GND", display_superscript: "1"` can render as GND¹ while preserving the label text and source net identity.

This is presentation metadata; assigning suffixes is left to the producer. Existing labels remain valid. Strings support multi-digit or nonnumeric suffixes.

Validation: all 319 tests pass; ESM and declaration build pass. Tests cover omitted, empty, numeric-string, multi-digit and alphabetic suffixes, plus rejection of numeric values.

Full TypeScript check (`tsc --noEmit`) also passes.
