### PR TITLE
Add autorouting phase context to DRC diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4080,3 +4080,18 @@ interface SimulationAcVoltageSource {
 ```
 
 <!-- circuit-json-docs:end -->
+
+### Autorouting phase attribution
+
+DRC errors and `pcb_trace_too_long_warning` can carry optional `autorouting_phase` context:
+
+```ts
+{
+  subcircuit_id: "subcircuit_0",
+  routing_phase_index: 2,
+  name: "fanout",
+  stage_index: 0,
+}
+```
+
+`routing_phase_index` is the zero-based execution-stage index within a subcircuit (matching core autorouting events), not the user-supplied phase index. `stage_index` is the optional zero-based stage within a phase's autorouter pipeline. The context identifies where a diagnostic was observed; it does not imply that this stage introduced the violation. Existing records without context remain valid.

--- a/src/base_circuit_json_error.ts
+++ b/src/base_circuit_json_error.ts
@@ -1,10 +1,23 @@
 import { z } from "zod"
 import { expectTypesMatch } from "src/utils/expect-types-match"
 
+/** Identifies the completed local autorouting stage where a DRC was observed.
+ * This is observation context, not a claim that the stage introduced the error.
+ */
+export const autorouting_phase = z.object({
+  subcircuit_id: z.string(),
+  routing_phase_index: z.number().int().nonnegative(),
+  name: z.string().optional(),
+  stage_index: z.number().int().nonnegative().optional(),
+})
+
+export type AutoroutingPhase = z.infer<typeof autorouting_phase>
+
 export const base_circuit_json_error = z.object({
   error_type: z.string(),
   message: z.string(),
   is_fatal: z.boolean().optional(),
+  autorouting_phase: autorouting_phase.optional(),
 })
 
 export type BaseCircuitJsonErrorInput = z.input<typeof base_circuit_json_error>
@@ -14,6 +27,7 @@ export interface BaseCircuitJsonError {
   error_type: string
   message: string
   is_fatal?: boolean
+  autorouting_phase?: AutoroutingPhase
 }
 
 expectTypesMatch<BaseCircuitJsonError, InferredBaseCircuitJsonError>(true)

--- a/src/pcb/pcb_trace_too_long_warning.ts
+++ b/src/pcb/pcb_trace_too_long_warning.ts
@@ -1,4 +1,8 @@
 import { z } from "zod"
+import {
+  autorouting_phase,
+  type AutoroutingPhase,
+} from "src/base_circuit_json_error"
 import { getZodPrefixedIdWithDefault } from "src/common"
 import { distance, type Distance } from "src/units"
 import { expectTypesMatch } from "src/utils/expect-types-match"
@@ -13,6 +17,7 @@ export const pcb_trace_too_long_warning = z
       .literal("pcb_trace_too_long_warning")
       .default("pcb_trace_too_long_warning"),
     message: z.string(),
+    autorouting_phase: autorouting_phase.optional(),
     pcb_trace_id: z.string(),
     source_net_id: z.string().optional(),
     source_trace_id: z.string().optional(),
@@ -31,6 +36,7 @@ type InferredPcbTraceTooLongWarning = z.infer<typeof pcb_trace_too_long_warning>
 
 /** Warning emitted when a PCB trace is longer than its maximum allowed length */
 export interface PcbTraceTooLongWarning {
+  autorouting_phase?: AutoroutingPhase
   type: "pcb_trace_too_long_warning"
   pcb_trace_too_long_warning_id: string
   warning_type: "pcb_trace_too_long_warning"

--- a/tests/autorouting-phase.test.ts
+++ b/tests/autorouting-phase.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import {
+  pcb_trace_error,
+  pcb_trace_too_long_warning,
+  autorouting_phase,
+} from "../src"
+
+test("DRC phase attribution survives parsing and remains optional", () => {
+  const error = {
+    type: "pcb_trace_error",
+    message: "Trace crosses the board edge",
+    pcb_trace_id: "pcb_trace_1",
+    source_trace_id: "source_trace_1",
+    pcb_component_ids: [],
+    pcb_port_ids: [],
+  }
+  const phase = {
+    subcircuit_id: "subcircuit_1",
+    routing_phase_index: 2,
+    name: "fanout",
+    stage_index: 0,
+  }
+  expect(
+    pcb_trace_error.parse({ ...error, autorouting_phase: phase })
+      .autorouting_phase,
+  ).toEqual(phase)
+  expect(pcb_trace_error.parse(error).autorouting_phase).toBeUndefined()
+  expect(
+    pcb_trace_too_long_warning.parse({
+      type: "pcb_trace_too_long_warning",
+      message: "Too long",
+      pcb_trace_id: "pcb_trace_1",
+      actual_trace_length: 20,
+      maximum_trace_length: 10,
+      autorouting_phase: phase,
+    }).autorouting_phase,
+  ).toEqual(phase)
+  expect(
+    autorouting_phase.safeParse({ ...phase, routing_phase_index: -1 }).success,
+  ).toBe(false)
+  expect(
+    autorouting_phase.safeParse({ ...phase, stage_index: 0.5 }).success,
+  ).toBe(false)
+})


### PR DESCRIPTION
DRCs observed during autorouting can now retain the stage where they were detected. Add optional `autorouting_phase` context to the base error schema and routing length warning, with subcircuit ID, execution-stage index, optional phase name, and pipeline stage index. Existing records remain valid.

The context describes where a violation was observed, not necessarily where it was introduced. This supports per-stage checks in `@tscircuit/checks` and `@tscircuit/core` without persisting stale intermediate errors on the final board.

Validation: all 319 tests pass; package build, TypeScript check, Zod lint, and snake-case check pass. Added parsing coverage for error/warning attribution, omitted context, and invalid indexes.

Downstream PRs: https://github.com/tscircuit/checks/pull/265 and https://github.com/tscircuit/core/pull/3658.
