### PR TITLE
Add display_superscript to schematic text for inline net labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -3527,6 +3527,8 @@ interface SchematicText {
   schematic_symbol_id?: string
   schematic_text_id: string
   text: string
+  /** Display-only superscript suffix, e.g. "1" in GND¹ for an inline net label. */
+  display_superscript?: string
   font_size: number
   position: {
     x: number

--- a/src/schematic/schematic_text.ts
+++ b/src/schematic/schematic_text.ts
@@ -20,6 +20,8 @@ export interface SchematicText {
    */
   source_trace_id?: string
   text: string
+  /** Display-only superscript suffix, e.g. "1" in GND¹ for an inline net label. */
+  display_superscript?: string
   font_size: number
   position: {
     x: number
@@ -39,6 +41,7 @@ export const schematic_text = z.object({
   schematic_text_id: z.string(),
   source_trace_id: z.string().optional(),
   text: z.string(),
+  display_superscript: z.string().optional(),
   font_size: z.number().default(0.18),
   position: z.object({
     x: distance,

--- a/tests/schematic_text.test.ts
+++ b/tests/schematic_text.test.ts
@@ -40,3 +40,24 @@ test("any_circuit_element includes schematic_text with source_trace_id", () => {
 
   expect(text.source_trace_id).toBe("source_trace_2")
 })
+
+test("schematic_text supports optional display superscripts for inline net labels", () => {
+  const input = {
+    type: "schematic_text",
+    schematic_text_id: "schematic_text_inline_gnd",
+    source_trace_id: "source_trace_gnd",
+    text: "GND",
+    position: { x: 1, y: 2 },
+  }
+  for (const suffix of [undefined, "", "1", "12", "A"]) {
+    const text = schematic_text.parse({ ...input, display_superscript: suffix })
+    if (suffix === undefined) expect(text.display_superscript).toBeUndefined()
+    else expect(text.display_superscript).toBe(suffix)
+    expect(text.text).toBe("GND")
+    expect(text.source_trace_id).toBe("source_trace_gnd")
+    expect(any_circuit_element.parse(text)).toEqual(text)
+  }
+  expect(
+    schematic_text.safeParse({ ...input, display_superscript: 1 }).success,
+  ).toBe(false)
+})


### PR DESCRIPTION
Adds optional `display_superscript: string` to `schematic_text`, matching the field on `schematic_net_label` introduced in #750. Inline net labels can carry `text: "GND", display_superscript: "1"` while preserving the original text and `source_trace_id`.

Updates the Zod schema, TypeScript interface, and documentation. Tests cover omitted, empty, numeric-string, multi-digit, and alphabetic suffixes, reject numeric values, and verify that the field survives `any_circuit_element` parsing.

Validation: all 322 tests pass, `tsc --noEmit` passes, and the ESM/declaration build passes.
