### PR TITLE
Add non-fatal PCB autorouter warning element

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ https://github.com/user-attachments/assets/2f28b7ba-689e-4d80-85b2-5bdef84b41f8
   - [CAD Components](#cad-components)
     - [CadComponent](#cadcomponent)
   - [PCB Elements](#pcb-elements)
+    - [PcbAutorouterWarning](#pcbautorouterwarning)
     - [PcbAutoroutingError](#pcbautoroutingerror)
     - [PcbBoard](#pcbboard)
     - [PcbBreakoutPoint](#pcbbreakoutpoint)
@@ -1340,6 +1341,28 @@ interface CadComponent {
 ```
 
 ## PCB Elements
+
+### PcbAutorouterWarning
+
+[Source](https://github.com/tscircuit/circuit-json/blob/main/src/pcb/pcb_autorouter_warning.ts)
+
+Non-fatal diagnostic emitted by an autorouter
+
+```typescript
+/** Non-fatal diagnostic emitted by an autorouter */
+interface PcbAutorouterWarning {
+  type: "pcb_autorouter_warning"
+  pcb_autorouter_warning_id: string
+  warning_type: "pcb_autorouter_warning"
+  message: string
+  /** The autorouter's connection name, when the diagnostic concerns one connection */
+  connection_name?: string
+  pcb_port_ids?: string[]
+  /** Board coordinates in millimeters, with positive X right and positive Y up */
+  center?: Point
+  subcircuit_id?: string
+}
+```
 
 ### PcbAutoroutingError
 

--- a/src/any_circuit_element.ts
+++ b/src/any_circuit_element.ts
@@ -114,6 +114,7 @@ export const any_circuit_element = z.union([
   pcb.pcb_note_line,
   pcb.pcb_note_dimension,
   pcb.pcb_autorouting_error,
+  pcb.pcb_autorouter_warning,
   pcb.pcb_footprint_overlap_error,
   pcb.pcb_courtyard_overlap_error,
   pcb.pcb_breakout_point,

--- a/src/pcb/index.ts
+++ b/src/pcb/index.ts
@@ -58,6 +58,7 @@ export * from "./external_footprint_load_error"
 export * from "./circuit_json_footprint_load_error"
 export * from "./pcb_group"
 export * from "./pcb_autorouting_error"
+export * from "./pcb_autorouter_warning"
 export * from "./pcb_manual_edit_conflict_warning"
 export * from "./pcb_connector_not_in_accessible_orientation_warning"
 export * from "./pcb_component_missing_courtyard_warning"
@@ -127,6 +128,7 @@ import type { PcbNotePath } from "./pcb_note_path"
 import type { PcbNoteLine } from "./pcb_note_line"
 import type { PcbNoteDimension } from "./pcb_note_dimension"
 import type { PcbAutoroutingError } from "./pcb_autorouting_error"
+import type { PcbAutorouterWarning } from "./pcb_autorouter_warning"
 import type { PcbFootprintOverlapError } from "./pcb_footprint_overlap_error"
 import type { PcbCutout } from "./pcb_cutout"
 import type { PcbBreakoutPoint } from "./pcb_breakout_point"
@@ -197,6 +199,7 @@ export type PcbCircuitElement =
   | PcbNoteLine
   | PcbNoteDimension
   | PcbAutoroutingError
+  | PcbAutorouterWarning
   | PcbFootprintOverlapError
   | PcbCutout
   | PcbBreakoutPoint

--- a/src/pcb/pcb_autorouter_warning.ts
+++ b/src/pcb/pcb_autorouter_warning.ts
@@ -1,0 +1,45 @@
+import { z } from "zod"
+import { getZodPrefixedIdWithDefault, point, type Point } from "src/common"
+import { expectTypesMatch } from "src/utils/expect-types-match"
+
+export const pcb_autorouter_warning = z
+  .object({
+    type: z.literal("pcb_autorouter_warning"),
+    pcb_autorouter_warning_id: getZodPrefixedIdWithDefault(
+      "pcb_autorouter_warning",
+    ),
+    warning_type: z
+      .literal("pcb_autorouter_warning")
+      .default("pcb_autorouter_warning"),
+    message: z.string(),
+    connection_name: z.string().optional(),
+    pcb_port_ids: z.array(z.string()).optional(),
+    center: point
+      .optional()
+      .describe(
+        "Board coordinates in millimeters, with positive X right and positive Y up",
+      ),
+    subcircuit_id: z.string().optional(),
+  })
+  .describe(
+    "Non-fatal diagnostic emitted by an autorouter; does not replace errors for unrouted connections",
+  )
+
+export type PcbAutorouterWarningInput = z.input<typeof pcb_autorouter_warning>
+type InferredPcbAutorouterWarning = z.infer<typeof pcb_autorouter_warning>
+
+/** Non-fatal diagnostic emitted by an autorouter */
+export interface PcbAutorouterWarning {
+  type: "pcb_autorouter_warning"
+  pcb_autorouter_warning_id: string
+  warning_type: "pcb_autorouter_warning"
+  message: string
+  /** The autorouter's connection name, when the diagnostic concerns one connection */
+  connection_name?: string
+  pcb_port_ids?: string[]
+  /** Board coordinates in millimeters, with positive X right and positive Y up */
+  center?: Point
+  subcircuit_id?: string
+}
+
+expectTypesMatch<PcbAutorouterWarning, InferredPcbAutorouterWarning>(true)

--- a/tests/pcb_autorouter_warning.test.ts
+++ b/tests/pcb_autorouter_warning.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import {
+  any_circuit_element,
+  pcb_autorouter_warning,
+  type AnyCircuitElement,
+  type PcbCircuitElement,
+  type PcbAutorouterWarning,
+  type PcbAutorouterWarningInput,
+} from "../src"
+
+const warningInput: PcbAutorouterWarningInput = {
+  type: "pcb_autorouter_warning",
+  message: "Via placement is blocked; deferring connection to direct routing",
+}
+
+test("autorouter warnings can describe a non-fatal condition without a trace", () => {
+  const warning: PcbAutorouterWarning =
+    pcb_autorouter_warning.parse(warningInput)
+
+  expect(warning.pcb_autorouter_warning_id).toStartWith(
+    "pcb_autorouter_warning",
+  )
+  expect(warning.warning_type).toBe("pcb_autorouter_warning")
+  expect(warning.message).toBe(warningInput.message)
+  expect(warning.connection_name).toBeUndefined()
+  expect(warning.pcb_port_ids).toBeUndefined()
+  expect(warning.center).toBeUndefined()
+  expect(warning.subcircuit_id).toBeUndefined()
+  expect(warning).not.toHaveProperty("error_type")
+})
+
+test("autorouter warnings preserve supplied identity and routing context", () => {
+  const contextualWarning = {
+    ...warningInput,
+    pcb_autorouter_warning_id: "pcb_autorouter_warning_4",
+    warning_type: "pcb_autorouter_warning" as const,
+    connection_name: "source_trace_2",
+    pcb_port_ids: ["pcb_port_1", "pcb_port_2"],
+    center: { x: 4.5, y: -2 },
+    subcircuit_id: "subcircuit_0",
+  }
+  const warning: PcbCircuitElement =
+    pcb_autorouter_warning.parse(contextualWarning)
+  const element: AnyCircuitElement =
+    any_circuit_element.parse(contextualWarning)
+
+  expect(warning).toEqual(contextualWarning)
+  expect(element).toEqual(contextualWarning)
+})
+
+test("autorouter warnings reject missing messages and malformed routing context", () => {
+  expect(
+    pcb_autorouter_warning.safeParse({ type: warningInput.type }).success,
+  ).toBe(false)
+  expect(
+    pcb_autorouter_warning.safeParse({ ...warningInput, pcb_port_ids: [1] })
+      .success,
+  ).toBe(false)
+  expect(
+    pcb_autorouter_warning.safeParse({ ...warningInput, center: { x: 0 } })
+      .success,
+  ).toBe(false)
+  expect(
+    pcb_autorouter_warning.safeParse({
+      ...warningInput,
+      warning_type: "pcb_autorouting_error",
+    }).success,
+  ).toBe(false)
+})


### PR DESCRIPTION
Autorouters can encounter a recoverable routing limitation and continue producing useful copper. Circuit JSON currently has an autorouting error element but no general diagnostic for an autorouter that continues.

Add `pcb_autorouter_warning` with a message and optional connection name, PCB port IDs, board-space location, and subcircuit ID. The warning uses the existing warning identity/severity conventions and is exported through the PCB and any-element unions. It does not replace missing-trace or connectivity errors for connections that remain unrouted.

Validation: 327 tests pass; typecheck, package build, Zod lint, and snake-case checks pass. New tests cover minimal diagnostics, preserved routing context and identity, public union parsing, and invalid input.

This schema supports a companion core change that records local autorouter `warning` events and a happy-autorouter change that attempts direct connections after blocked via placement.
