### PR TITLE
Add display_tolerance to source_simple_resistor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,8 @@ interface SourceSimpleResistor extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
   display_resistance?: string
+  /** Display-only tolerance string, e.g. "5%" for a resistor declared as tolerance="5%". */
+  display_tolerance?: string
 }
 ```
 

--- a/src/source/source_simple_resistor.ts
+++ b/src/source/source_simple_resistor.ts
@@ -10,6 +10,7 @@ export const source_simple_resistor = source_component_base.extend({
   ftype: z.literal("simple_resistor"),
   resistance,
   display_resistance: z.string().optional(),
+  display_tolerance: z.string().optional(),
 })
 
 export type SourceSimpleResistorInput = z.input<typeof source_simple_resistor>
@@ -22,6 +23,8 @@ export interface SourceSimpleResistor extends SourceComponentBase {
   ftype: "simple_resistor"
   resistance: number
   display_resistance?: string
+  /** Display-only tolerance string, e.g. "5%" for a resistor declared as tolerance="5%". */
+  display_tolerance?: string
 }
 
 expectTypesMatch<SourceSimpleResistor, InferredSourceSimpleResistor>(true)

--- a/tests/source_simple_resistor.test.ts
+++ b/tests/source_simple_resistor.test.ts
@@ -23,8 +23,8 @@ test("source_simple_resistor parse preserves display_tolerance", () => {
   expect(resistor.display_tolerance).toBe("5%")
 })
 
-test("source_simple_resistor accepts the tolerance strings a resistor can produce", () => {
-  for (const tolerance of [undefined, "", "5%", "0.1%", "12.5%", "±5%"]) {
+test("source_simple_resistor accepts an optional display_tolerance string", () => {
+  for (const tolerance of [undefined, "5%", "0.1%", "12.5%", "100%"]) {
     const resistor = source_simple_resistor.parse({
       ...base,
       display_tolerance: tolerance,

--- a/tests/source_simple_resistor.test.ts
+++ b/tests/source_simple_resistor.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { source_simple_resistor } from "../src/source/source_simple_resistor"
+import { any_circuit_element } from "../src/any_circuit_element"
+
+const base = {
+  type: "source_component",
+  ftype: "simple_resistor",
+  source_component_id: "R1",
+  name: "R1",
+  resistance: 10000,
+  display_resistance: "10kΩ",
+}
+
+test("source_simple_resistor parse preserves display_tolerance", () => {
+  const resistor = source_simple_resistor.parse({
+    ...base,
+    display_tolerance: "5%",
+  })
+
+  expect(resistor.ftype).toBe("simple_resistor")
+  expect(resistor.resistance).toBe(10000)
+  expect(resistor.display_resistance).toBe("10kΩ")
+  expect(resistor.display_tolerance).toBe("5%")
+})
+
+test("source_simple_resistor accepts the tolerance strings a resistor can produce", () => {
+  for (const tolerance of [undefined, "", "5%", "0.1%", "12.5%", "±5%"]) {
+    const resistor = source_simple_resistor.parse({
+      ...base,
+      display_tolerance: tolerance,
+    })
+
+    if (tolerance === undefined) {
+      expect(resistor.display_tolerance).toBeUndefined()
+    } else {
+      expect(resistor.display_tolerance).toBe(tolerance)
+    }
+    expect(resistor.resistance).toBe(10000)
+    expect(any_circuit_element.parse(resistor)).toEqual(resistor)
+  }
+
+  expect(
+    source_simple_resistor.safeParse({ ...base, display_tolerance: 0.05 })
+      .success,
+  ).toBe(false)
+})
+
+test("any_circuit_element includes display_tolerance for simple resistors", () => {
+  const parsed = any_circuit_element.parse({
+    ...base,
+    display_tolerance: "1%",
+  })
+
+  expect(parsed).toMatchObject({
+    ftype: "simple_resistor",
+    display_tolerance: "1%",
+  })
+})


### PR DESCRIPTION
Adds optional `display_tolerance: string` to `source_simple_resistor`, matching `display_resistance` on the same element and `display_inductance` on `source_simple_inductor`. A resistor declared as `tolerance="5%"` can then carry `display_tolerance: "5%"` alongside its resistance.

This is the display-string alternative to the numeric field, which has now been pushed back on twice: #693 got "Not a valid unit of tolerance", and tscircuit/core#3097 got "tolerance may not be the source component property key, we will definitely support display_tolerance however so you could add that". #699 proposes the same numeric field and also adds `tests/source_simple_resistor.test.ts`, so if this lands both of those can be closed and whichever went second would have had to redo that file anyway. Keeping it a display string avoids committing to a units representation.

Updates the Zod schema, TypeScript interface, and documentation. Tests cover the omitted and present forms, reject a numeric value, and verify the field survives `any_circuit_element` parsing. The doc generator rewrites several unrelated sections that have drifted from `src`, so the README hunk here is only the resistor block, byte-identical to what the generator emits for it.

Validation: 327 tests pass, up from 324 on main. `tsc --noEmit`, `bun run check-snake-case`, `bun run lint:zod` and the ESM/declaration build all pass. The new tests fail against the unmodified schema, since Zod strips the unknown key.
