### PR TITLE
Round all SI unit schemas to the same precision as capacitance

### DIFF
--- a/src/units/index.ts
+++ b/src/units/index.ts
@@ -57,28 +57,36 @@ export {
 //   | `${number} ${SIPrefix}${UnitOrAbbreviation}`
 
 // TODO lots of validation to make sure the unit is valid etc.
+const SIGNIFICANT_DIGITS = 12
+
+const roundToSignificantDigits = (value: number) =>
+  Number.isFinite(value)
+    ? Number.parseFloat(value.toPrecision(SIGNIFICANT_DIGITS))
+    : value
+
 export const resistance = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v, "Ω").value!)
+  .transform(roundToSignificantDigits)
 
 export const capacitance = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v, "F").value!)
-  .transform((value) => {
-    return Number.parseFloat(value.toPrecision(12)) // Round to 12 significant digits
-  })
+  .transform(roundToSignificantDigits)
 
 export const inductance = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v, "H").value!)
+  .transform(roundToSignificantDigits)
 
 export const voltage = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v, "V").value!)
+  .transform(roundToSignificantDigits)
 
 export const length = z
   .string()
@@ -89,6 +97,7 @@ export const frequency = z
   .string()
   .or(z.number())
   .transform((v) => parseAndConvertSiUnit(v, "Hz").value!)
+  .transform(roundToSignificantDigits)
 
 /**
  * Length in meters

--- a/tests/unit-precision-parity.test.ts
+++ b/tests/unit-precision-parity.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import {
+  capacitance,
+  frequency,
+  inductance,
+  resistance,
+  voltage,
+} from "../src/units"
+
+test("SI unit schemas round to the same precision as capacitance", () => {
+  expect(inductance.parse("10uH")).toBe(0.00001)
+  expect(capacitance.parse("10uF")).toBe(0.00001)
+
+  expect(inductance.parse("100nH")).toBe(1e-7)
+  expect(capacitance.parse("100nF")).toBe(1e-7)
+
+  expect(voltage.parse("10uV")).toBe(0.00001)
+  expect(frequency.parse("10uHz")).toBe(0.00001)
+  expect(resistance.parse("10uΩ")).toBe(0.00001)
+})
+
+test("SI unit schemas keep ordinary values untouched", () => {
+  expect(resistance.parse("4.7k")).toBe(4700)
+  expect(resistance.parse(0.07)).toBe(0.07)
+  expect(inductance.parse("4.7mH")).toBe(0.0047)
+  expect(capacitance.parse("100nF")).toBe(1e-7)
+  expect(voltage.parse("3.3V")).toBe(3.3)
+  expect(frequency.parse("16MHz")).toBe(16000000)
+})
+
+test("unparseable values still come through as NaN rather than throwing", () => {
+  for (const schema of [resistance, inductance, capacitance, voltage, frequency]) {
+    expect(schema.parse("not-a-number")).toBeNaN()
+  }
+})


### PR DESCRIPTION
`capacitance` rounds its parsed value to 12 significant digits, but `resistance`, `inductance`, `voltage` and `frequency` do not, so equivalent inputs disagree. `capacitance.parse("10uF")` is `0.00001` while `inductance.parse("10uH")` is `0.000009999999999999999`, and `100nF` gives `1e-7` against `100nH` at `1.0000000000000001e-7`. This pulls the rounding capacitance already did into a shared helper and applies it to the other four.

`length` is deliberately left as it is. It feeds PCB coordinates rather than a component value, so rounding it would move snapshots across the org without buying correctness here.

Unparseable input still comes through as `NaN` rather than throwing, guarded by `Number.isFinite`, so this does not touch the separate validation gap reported in tscircuit/core#3110 and tscircuit/core#3114.

Validation: 327 tests pass, up from 324 on main, and no existing expectation changed. `tsc --noEmit`, `bun run check-snake-case`, `bun run lint:zod` and the ESM/declaration build all pass.
